### PR TITLE
perf: tighten network timeouts for faster connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2481,8 +2481,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e33412e61b0cb630410981a629f967a858b1663be8f71b75eadb66c9588ef26"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#24bec697562a972bfac01a2b730a3694e5fc5fd7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ parking_lot = "0.12"
 once_cell = "1.21"
 
 # Networking
-saorsa-transport = "0.31.0"
+saorsa-transport = { git = "https://github.com/saorsa-labs/saorsa-transport.git", branch = "rc-2026.4.1" }
 
 # Core-specific dependencies
 dirs = "6.0"

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -2536,8 +2536,13 @@ impl DhtNetworkManager {
     }
 }
 
-/// Default request timeout for DHT operations (seconds)
-const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
+/// Default request timeout for outbound DHT operations (seconds).
+///
+/// Governs `wait_for_response` and the upper bound of `dial_candidate`'s
+/// dial timeout (`min(connection_timeout, request_timeout)`). Must stay
+/// above the relay stage (~10s) so it never truncates the NAT traversal
+/// cascade.
+const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 15;
 
 /// Default maximum concurrent DHT operations
 const DEFAULT_MAX_CONCURRENT_OPS: usize = 100;

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -51,10 +51,10 @@ const MAX_CANDIDATE_NODES: usize = 200;
 /// Messages larger than this are rejected before deserialization
 const MAX_MESSAGE_SIZE: usize = 64 * 1024;
 
-/// Request timeout for DHT message handlers (30 seconds)
+/// Request timeout for DHT message handlers (10 seconds)
 /// Prevents long-running handlers from starving the semaphore permit pool
 /// SEC-001: DoS mitigation via timeout enforcement on concurrent operations
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Reliability score assigned to the local node in K-closest results.
 /// The local node is always considered fully reliable for its own lookups.
@@ -62,7 +62,7 @@ const SELF_RELIABILITY_SCORE: f64 = 1.0;
 
 /// Maximum time to wait for the identity-exchange handshake after dialling
 /// a peer. The actual timeout is `min(request_timeout, this)`.
-const IDENTITY_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(10);
+const IDENTITY_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Maximum time to wait for a stale peer's ping response during admission contention.
 const STALE_REVALIDATION_TIMEOUT: Duration = Duration::from_secs(1);

--- a/src/network.rs
+++ b/src/network.rs
@@ -124,16 +124,16 @@ const DEFAULT_MAX_CONNECTIONS: usize = 10_000;
 
 /// Default connection timeout in seconds.
 ///
-/// Must accommodate the full NAT traversal flow: direct (5s) → hole-punch
-/// (15s) → relay (30s) = ~50s. With 90s we have headroom for retries and
-/// slow handshakes.
-const DEFAULT_CONNECTION_TIMEOUT_SECS: u64 = 90;
+/// Derived from the sum of connection strategy stages: direct (2s) +
+/// 2 × hole-punch rounds (3s + 1s retry each) + relay (10s) = ~20s.
+/// 25s provides margin for handshake jitter.
+const DEFAULT_CONNECTION_TIMEOUT_SECS: u64 = 25;
 
 /// Number of cached bootstrap peers to retrieve.
 const BOOTSTRAP_PEER_BATCH_SIZE: usize = 20;
 
 /// Timeout in seconds for waiting on a bootstrap peer's identity exchange.
-const BOOTSTRAP_IDENTITY_TIMEOUT_SECS: u64 = 10;
+const BOOTSTRAP_IDENTITY_TIMEOUT_SECS: u64 = 5;
 
 /// Serde helper — returns `true`.
 const fn default_true() -> bool {

--- a/src/network.rs
+++ b/src/network.rs
@@ -2271,7 +2271,7 @@ mod tests {
 
         assert_eq!(config.listen_addrs().len(), 2); // IPv4 + IPv6
         assert_eq!(config.max_connections, 10000);
-        assert_eq!(config.connection_timeout, Duration::from_secs(90));
+        assert_eq!(config.connection_timeout, Duration::from_secs(25));
     }
 
     #[tokio::test]

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -437,11 +437,10 @@ impl<T: LinkTransport + Send + Sync + 'static> P2PNetworkNode<T> {
 
     /// Connect to a peer by address
     pub async fn connect_to_peer(&self, peer_addr: SocketAddr) -> Result<SocketAddr> {
-        // The full NAT traversal flow is: direct (5s) → hole-punch (15s) →
-        // relay (30s). The outer timeout must accommodate the entire flow,
-        // otherwise the connection attempt is killed mid-hole-punch and the
-        // NAT'd peer is never reached.
-        const DIAL_TIMEOUT: Duration = Duration::from_secs(90);
+        // The full NAT traversal flow is: direct (2s) + 2 × hole-punch
+        // rounds (3s + 1s retry each) + relay (10s) = ~20s. 25s provides
+        // margin for handshake jitter.
+        const DIAL_TIMEOUT: Duration = Duration::from_secs(25);
 
         let conn = tokio::time::timeout(
             DIAL_TIMEOUT,
@@ -519,14 +518,14 @@ impl<T: LinkTransport + Send + Sync + 'static> P2PNetworkNode<T> {
     /// Dials the peer by address, opens a typed unidirectional stream,
     /// writes the data, and finishes the stream.
     pub async fn send_to_peer_raw(&self, addr: &SocketAddr, data: &[u8]) -> Result<()> {
-        // Wrap the entire send path in a 15-second timeout.
+        // Wrap the entire send path in a 10-second timeout.
         //
         // For chunk storage, the client should already have the correct
-        // address (relay or direct) from the DHT. Direct connections
-        // complete in <5s, so 15s is generous. A longer timeout (e.g. 60s)
-        // causes ~60s delays per unreachable peer when the DHT has stale
-        // NATted addresses, dominating upload time.
-        const SEND_TIMEOUT: Duration = Duration::from_secs(15);
+        // address (relay or direct) from the DHT. A 4MB chunk at 10 Mbps
+        // takes ~3.2s; 10s provides 3x margin for slow-start and jitter.
+        // Longer timeouts cause excessive delays per unreachable peer when
+        // the DHT has stale NATted addresses, dominating upload time.
+        const SEND_TIMEOUT: Duration = Duration::from_secs(10);
 
         tokio::time::timeout(SEND_TIMEOUT, async {
             let conn = self

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -518,14 +518,9 @@ impl<T: LinkTransport + Send + Sync + 'static> P2PNetworkNode<T> {
     /// Dials the peer by address, opens a typed unidirectional stream,
     /// writes the data, and finishes the stream.
     pub async fn send_to_peer_raw(&self, addr: &SocketAddr, data: &[u8]) -> Result<()> {
-        // Wrap the entire send path in a 10-second timeout.
-        //
-        // For chunk storage, the client should already have the correct
-        // address (relay or direct) from the DHT. A 4MB chunk at 10 Mbps
-        // takes ~3.2s; 10s provides 3x margin for slow-start and jitter.
-        // Longer timeouts cause excessive delays per unreachable peer when
-        // the DHT has stale NATted addresses, dominating upload time.
-        const SEND_TIMEOUT: Duration = Duration::from_secs(10);
+        // Budget must cover dial (up to ~20s for full NAT traversal cascade)
+        // plus the data transfer. Matches DIAL_TIMEOUT in connect_to_peer.
+        const SEND_TIMEOUT: Duration = Duration::from_secs(25);
 
         tokio::time::timeout(SEND_TIMEOUT, async {
             let conn = self


### PR DESCRIPTION
## Summary
- Reduce dial, send, DHT, and identity exchange timeouts based on 300ms worst-case RTT analysis
- `DIAL_TIMEOUT` and `DEFAULT_CONNECTION_TIMEOUT_SECS` reduced from 90s→25s (derived from sum of connection strategy stages)
- **Companion PR**: saorsa-labs/saorsa-transport#37 (transport-layer timeout changes)

## Timeout changes

| Timeout | Old | New | Rationale |
|---------|-----|-----|-----------|
| `DIAL_TIMEOUT` | 90s | 25s | Sum of stages: direct (2s) + 2×holepunch (3s+1s) + relay (10s) + margin |
| `DEFAULT_CONNECTION_TIMEOUT_SECS` | 90s | 25s | Matches DIAL_TIMEOUT |
| `SEND_TIMEOUT` | 15s | 10s | 3x margin over 4MB at 10Mbps |
| `REQUEST_TIMEOUT` | 30s | 10s | Aligned with libp2p/BEP 5 practice |
| `IDENTITY_EXCHANGE_TIMEOUT` | 10s | 5s | 1-2 RTTs + margin |
| `BOOTSTRAP_IDENTITY_TIMEOUT_SECS` | 10s | 5s | Matches identity exchange |

## Test plan
- [x] `cargo check` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --lib --all-features -- -D warnings` — clean
- [ ] E2E testnet validation with mixed NAT nodes across regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces six network timeouts across the transport adapter, DHT network manager, and node configuration — cutting dial/connection timeouts from 90s→25s, send timeout from 15s→10s, and request/identity timeouts from 30s→10s and 10s→5s. The rationale (sum-of-stages analysis: direct 2s + hole-punch 3+1s + relay 10s = ~20s, 25s with margin) is well-documented and the approach is sound for the majority of changes. However, `SEND_TIMEOUT` in `send_to_peer_raw` presents a concrete issue: it wraps both `dial_addr` and the data transfer in the same 10s budget, while the companion `DIAL_TIMEOUT` analysis documents that relay connections alone take ~10s, leaving no time for data writes in relay-only NAT scenarios.

- **`DIAL_TIMEOUT` 90s→25s**: Well-justified from stage analysis; consistent with `DEFAULT_CONNECTION_TIMEOUT_SECS`.
- **`SEND_TIMEOUT` 15s→10s**: ⚠️ The 10s budget covers both the `dial_addr` call (up to ~20s for relay) and the actual transfer — relay-only peers will almost certainly time out before any data is sent.
- **`REQUEST_TIMEOUT` 30s→10s**: Reasonable tightening for DoS-protection on message handlers.
- **`IDENTITY_EXCHANGE_TIMEOUT` 10s→5s**: Safe; the `min(config.request_timeout, IDENTITY_EXCHANGE_TIMEOUT)` guard still correctly applies the 5s cap.
- **`DEFAULT_CONNECTION_TIMEOUT_SECS` 90s→25s** and **`BOOTSTRAP_IDENTITY_TIMEOUT_SECS` 10s→5s**: Well-reasoned, no concerns.
- E2E testnet validation with mixed NAT nodes is still pending in the PR checklist."

<h3>Confidence Score: 3/5</h3>

Mostly safe to merge, but SEND_TIMEOUT in send_to_peer_raw is too tight for relay paths and will cause silent send failures to NAT'd peers requiring relay connections

Five of six timeout changes are well-reasoned and consistent with the documented stage-sum analysis. The SEND_TIMEOUT change introduces a concrete regression: by wrapping dial_addr (which can take ~20s in relay scenarios) inside a 10s budget, sends to relay-only peers will reliably time out. The E2E testnet validation across mixed NAT nodes is also still pending. These two factors lower confidence from what would otherwise be a 4-5.

src/transport/saorsa_transport_adapter.rs — specifically the SEND_TIMEOUT constant and send_to_peer_raw function; verify whether saorsa-transport's dial_addr reuses existing connections before applying the new timeout

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/transport/saorsa_transport_adapter.rs | DIAL_TIMEOUT 90s→25s is correct; SEND_TIMEOUT 15s→10s is too aggressive — the 10s budget encompasses the full dial_addr call which can itself take ~20s for relay paths, causing systematic timeouts for relay-only peers |
| src/dht_network_manager.rs | REQUEST_TIMEOUT 30s→10s and IDENTITY_EXCHANGE_TIMEOUT 10s→5s are safe; min() guard logic is preserved; DEFAULT_REQUEST_TIMEOUT_SECS (30s) is unchanged and may warrant review for consistency |
| src/network.rs | DEFAULT_CONNECTION_TIMEOUT_SECS 90s→25s and BOOTSTRAP_IDENTITY_TIMEOUT_SECS 10s→5s are well-justified, consistent with DIAL_TIMEOUT rationale, and correctly wired into NodeConfig defaults |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant send_to_peer_raw
    participant dial_addr
    participant Transport

    Caller->>send_to_peer_raw: send(addr, data)
    Note over send_to_peer_raw: SEND_TIMEOUT = 10s (entire block)
    send_to_peer_raw->>dial_addr: dial_addr(addr)
    dial_addr->>Transport: direct attempt (~2s)
    alt direct succeeds
        Transport-->>dial_addr: conn ✓
    else hole-punch
        dial_addr->>Transport: hole-punch rounds (~3s + 1s)
        alt hole-punch succeeds
            Transport-->>dial_addr: conn ✓
        else relay fallback
            dial_addr->>Transport: relay connection (~10s)
            Note over dial_addr,Transport: Relay alone ≈ 10s = SEND_TIMEOUT ⚠️
            Transport-->>dial_addr: conn (or timeout ❌)
        end
    end
    dial_addr-->>send_to_peer_raw: conn
    send_to_peer_raw->>Transport: open_uni_typed + write_all + finish
    Transport-->>send_to_peer_raw: Ok(())
    send_to_peer_raw-->>Caller: Ok(()) or Elapsed timeout error
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/transport/saorsa_transport_adapter.rs`, line 520-558 ([link](https://github.com/saorsa-labs/saorsa-core/blob/d1c24bb50e397622706a85855aebae908e54d2fb/src/transport/saorsa_transport_adapter.rs#L520-L558)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`SEND_TIMEOUT` too tight to cover relay dial + data transfer**

   `send_to_peer_raw` wraps both `dial_addr` *and* the subsequent stream write inside the same 10-second budget. According to the updated comment on `DIAL_TIMEOUT` in `connect_to_peer` (lines 440–443), the full NAT-traversal flow is:

   > direct (2s) + 2 × hole-punch rounds (3s + 1s retry each) + relay (10s) ≈ 20s

   The relay fallback alone is documented as **10s**, which exactly equals the new `SEND_TIMEOUT`. For a fresh relay connection to a NAT'd peer, `dial_addr` can consume the entire 10-second window before a single byte of data is written — meaning `send_to_peer_raw` will reliably time out in the worst-case relay scenario.

   `connect_to_peer` correctly budgets 25s for the same dial path via `DIAL_TIMEOUT`. `send_to_peer_raw` invokes the same transport but has only 10s total for dial + transfer. Consider splitting the timeout budget:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/transport/saorsa_transport_adapter.rs
   Line: 520-558

   Comment:
   **`SEND_TIMEOUT` too tight to cover relay dial + data transfer**

   `send_to_peer_raw` wraps both `dial_addr` *and* the subsequent stream write inside the same 10-second budget. According to the updated comment on `DIAL_TIMEOUT` in `connect_to_peer` (lines 440–443), the full NAT-traversal flow is:

   > direct (2s) + 2 × hole-punch rounds (3s + 1s retry each) + relay (10s) ≈ 20s

   The relay fallback alone is documented as **10s**, which exactly equals the new `SEND_TIMEOUT`. For a fresh relay connection to a NAT'd peer, `dial_addr` can consume the entire 10-second window before a single byte of data is written — meaning `send_to_peer_raw` will reliably time out in the worst-case relay scenario.

   `connect_to_peer` correctly budgets 25s for the same dial path via `DIAL_TIMEOUT`. `send_to_peer_raw` invokes the same transport but has only 10s total for dial + transfer. Consider splitting the timeout budget:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/dht_network_manager.rs`, line 2539-2541 ([link](https://github.com/saorsa-labs/saorsa-core/blob/d1c24bb50e397622706a85855aebae908e54d2fb/src/dht_network_manager.rs#L2539-L2541)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`DEFAULT_REQUEST_TIMEOUT_SECS` not updated alongside `REQUEST_TIMEOUT`**

   The module-level `REQUEST_TIMEOUT` (DoS-protection timeout on DHT message handlers) was reduced from 30s → 10s. However, `DEFAULT_REQUEST_TIMEOUT_SECS` still defaults to **30s** and feeds `DhtNetworkConfig::default().request_timeout`, which drives:
   - `response_timeout` in `wait_for_dht_response` (30s)
   - The upper bound of `dial_timeout = transport.connection_timeout().min(config.request_timeout)`

   These two constants serve different roles so diverging values may be intentional, but given the PR's stated goal of a 10s request budget it is worth confirming `DEFAULT_REQUEST_TIMEOUT_SECS` should remain at 30s.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/dht_network_manager.rs
   Line: 2539-2541

   Comment:
   **`DEFAULT_REQUEST_TIMEOUT_SECS` not updated alongside `REQUEST_TIMEOUT`**

   The module-level `REQUEST_TIMEOUT` (DoS-protection timeout on DHT message handlers) was reduced from 30s → 10s. However, `DEFAULT_REQUEST_TIMEOUT_SECS` still defaults to **30s** and feeds `DhtNetworkConfig::default().request_timeout`, which drives:
   - `response_timeout` in `wait_for_dht_response` (30s)
   - The upper bound of `dial_timeout = transport.connection_timeout().min(config.request_timeout)`

   These two constants serve different roles so diverging values may be intentional, but given the PR's stated goal of a 10s request budget it is worth confirming `DEFAULT_REQUEST_TIMEOUT_SECS` should remain at 30s.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/transport/saorsa_transport_adapter.rs
Line: 520-558

Comment:
**`SEND_TIMEOUT` too tight to cover relay dial + data transfer**

`send_to_peer_raw` wraps both `dial_addr` *and* the subsequent stream write inside the same 10-second budget. According to the updated comment on `DIAL_TIMEOUT` in `connect_to_peer` (lines 440–443), the full NAT-traversal flow is:

> direct (2s) + 2 × hole-punch rounds (3s + 1s retry each) + relay (10s) ≈ 20s

The relay fallback alone is documented as **10s**, which exactly equals the new `SEND_TIMEOUT`. For a fresh relay connection to a NAT'd peer, `dial_addr` can consume the entire 10-second window before a single byte of data is written — meaning `send_to_peer_raw` will reliably time out in the worst-case relay scenario.

`connect_to_peer` correctly budgets 25s for the same dial path via `DIAL_TIMEOUT`. `send_to_peer_raw` invokes the same transport but has only 10s total for dial + transfer. Consider splitting the timeout budget:

```suggestion
        const DIAL_PHASE_TIMEOUT: Duration = Duration::from_secs(25);
        const SEND_TIMEOUT: Duration = Duration::from_secs(30);

        tokio::time::timeout(SEND_TIMEOUT, async {
            let conn = tokio::time::timeout(
                DIAL_PHASE_TIMEOUT,
                self.transport.dial_addr(*addr, SAORSA_DHT_PROTOCOL),
            )
            .await
            .map_err(|_| anyhow::anyhow!("Dial timed out after {DIAL_PHASE_TIMEOUT:?} to {addr}"))?
            .map_err(|e| anyhow::anyhow!("Dial by address failed: {}", e))?;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/dht_network_manager.rs
Line: 2539-2541

Comment:
**`DEFAULT_REQUEST_TIMEOUT_SECS` not updated alongside `REQUEST_TIMEOUT`**

The module-level `REQUEST_TIMEOUT` (DoS-protection timeout on DHT message handlers) was reduced from 30s → 10s. However, `DEFAULT_REQUEST_TIMEOUT_SECS` still defaults to **30s** and feeds `DhtNetworkConfig::default().request_timeout`, which drives:
- `response_timeout` in `wait_for_dht_response` (30s)
- The upper bound of `dial_timeout = transport.connection_timeout().min(config.request_timeout)`

These two constants serve different roles so diverging values may be intentional, but given the PR's stated goal of a 10s request budget it is worth confirming `DEFAULT_REQUEST_TIMEOUT_SECS` should remain at 30s.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: tighten network timeouts for faste..."](https://github.com/saorsa-labs/saorsa-core/commit/d1c24bb50e397622706a85855aebae908e54d2fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27358336)</sub>

<!-- /greptile_comment -->