### PR TITLE
feat(dht): hand the full ranked referrer list to saorsa-transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#496721bee0e5b535d5aec07513ec3ced29d20644"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#244189606913b1706ce146b5d8b741d9a9b698ee"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/adaptive/dht.rs
+++ b/src/adaptive/dht.rs
@@ -81,7 +81,7 @@ impl AdaptiveDhtConfig {
 /// consumer's responsibility via [`ApplicationSuccess`](Self::ApplicationSuccess).
 ///
 /// Consumer-reported events carry a weight multiplier that controls the
-/// severity of the update (clamped to [`MAX_CONSUMER_WEIGHT`]).
+/// severity of the update (clamped to `MAX_CONSUMER_WEIGHT`).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TrustEvent {
     // === Negative signals (core) ===

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -99,7 +99,7 @@ const AUTO_REBOOTSTRAP_THRESHOLD: usize = 3;
 
 /// Maximum number of distinct referrers stored per discovered peer during an
 /// iterative DHT lookup. The list is ranked at dial-time to pick the best
-/// hole-punch coordinator candidate (see [`DhtNetworkManager::select_best_referrer`]).
+/// hole-punch coordinator candidate (see [`DhtNetworkManager::rank_referrers_for_target`]).
 ///
 /// Bound exists to cap per-lookup memory; in practice 4 is more than enough
 /// because Kademlia typically converges before any peer is referred more than
@@ -286,7 +286,7 @@ pub struct DhtNetworkManager {
 ///
 /// During a single iterative lookup we collect up to
 /// [`MAX_REFERRERS_PER_TARGET`] referrers per discovered peer and rank them
-/// at dial-time via [`DhtNetworkManager::select_best_referrer`].
+/// at dial-time via [`DhtNetworkManager::rank_referrers_for_target`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ReferrerInfo {
     /// Peer ID of the referring node (used for trust score lookup and tiebreak).
@@ -806,7 +806,7 @@ impl DhtNetworkManager {
     /// queried the same ones). The pinning is removed: subsequent
     /// iterative DHT lookups via `find_closest_nodes_network` collect
     /// referrers across multiple rounds and rank them via
-    /// [`Self::select_best_referrer`], naturally de-preferring round-0
+    /// [`Self::rank_referrers_for_target`], naturally de-preferring round-0
     /// bootstrap referrers as the routing table grows.
     ///
     /// **Iteration order**: bootstrap peers are visited in a per-call
@@ -1071,7 +1071,7 @@ impl DhtNetworkManager {
         // hole-punch coordinator for T.
         //
         // We collect up to MAX_REFERRERS_PER_TARGET observations and rank
-        // them at dial-time via `select_best_referrer`. The ranking prefers
+        // them at dial-time via `rank_referrers_for_target`. The ranking prefers
         // referrers seen in later iteration rounds (closer to the target in
         // XOR space) over earlier rounds, which naturally de-prefers the
         // round-0 bootstrap referrers without any explicit bootstrap

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -636,7 +636,7 @@ impl DhtNetworkManager {
                                 if dht_node.peer_id == this.config.peer_id {
                                     continue;
                                 }
-                                this.dial_addresses(&dht_node.peer_id, &dht_node.addresses, None)
+                                this.dial_addresses(&dht_node.peer_id, &dht_node.addresses, &[])
                                     .await;
                             }
                         }
@@ -672,7 +672,7 @@ impl DhtNetworkManager {
                     // Dial if not already connected — try every advertised
                     // address, not just the first, so a stale NAT binding on
                     // one entry doesn't kill the dial.
-                    self.dial_addresses(&dht_node.peer_id, &dht_node.addresses, None)
+                    self.dial_addresses(&dht_node.peer_id, &dht_node.addresses, &[])
                         .await;
                 }
                 Ok(())
@@ -837,12 +837,13 @@ impl DhtNetworkManager {
                             dialable.len()
                         );
                         if seen.insert(node.peer_id) && !dialable.is_empty() {
-                            // Pass `None` as referrer: the bootstrap peer is no
-                            // longer hard-pinned as the hole-punch coordinator
-                            // for these freshly-discovered peers. The next
-                            // iterative lookup will populate proper referrers
-                            // via the round-aware ranking.
-                            self.dial_addresses(&node.peer_id, &node.addresses, None)
+                            // Pass an empty referrer list: the bootstrap
+                            // peer is no longer hard-pinned as the
+                            // hole-punch coordinator for these freshly-
+                            // discovered peers. The next iterative lookup
+                            // will populate proper referrers via the
+                            // round-aware ranking.
+                            self.dial_addresses(&node.peer_id, &node.addresses, &[])
                                 .await;
                         }
                     }
@@ -1149,12 +1150,15 @@ impl DhtNetworkManager {
                 .map(|node| {
                     let peer_id = node.peer_id;
                     let addresses = node.addresses.clone();
-                    // Pick the best-ranked referrer for this target as the
-                    // hole-punch coordinator hint. PR #3 will plumb the full
-                    // ranked list down to saorsa-transport; for now we hand
-                    // over a single best choice.
-                    let referrer =
-                        self.select_best_referrer(referrers.get(&peer_id).map(Vec::as_slice));
+                    // Build the full ranked list of preferred coordinators
+                    // for this target. saorsa-transport rotates through
+                    // them in order with a short per-attempt timeout for
+                    // all but the final candidate, so handing over the
+                    // full list (instead of just the best) lets the
+                    // hole-punch loop fall through busy or unreachable
+                    // referrers without waiting on the strategy timeout.
+                    let referrer_list =
+                        self.rank_referrers_for_target(referrers.get(&peer_id).map(Vec::as_slice));
                     let op = DhtNetworkOperation::FindNode { key: *key };
                     async move {
                         // Try every dialable address, not just the first.
@@ -1162,7 +1166,8 @@ impl DhtNetworkManager {
                         // `send_dht_request` will reuse that channel; if all
                         // fail, `send_dht_request`'s own fallback will retry
                         // with the routing-table addresses.
-                        self.dial_addresses(&peer_id, &addresses, referrer).await;
+                        self.dial_addresses(&peer_id, &addresses, &referrer_list)
+                            .await;
                         let address_hint = Self::first_dialable_address(&addresses);
                         (
                             peer_id,
@@ -1462,13 +1467,17 @@ impl DhtNetworkManager {
         Self::dialable_addresses(addresses).into_iter().next()
     }
 
-    /// Pick the best hole-punch coordinator candidate from a slice of
-    /// referrer observations, using this manager's [`TrustEngine`] (or
-    /// default neutral trust when none is configured).
+    /// Rank a slice of referrer observations into an ordered list of
+    /// hole-punch coordinator addresses, best-first, using this manager's
+    /// [`TrustEngine`] (or default neutral trust when none is configured).
     ///
     /// Thin wrapper around the pure function [`Self::rank_referrers`] —
-    /// see that for the actual ranking logic.
-    fn select_best_referrer(&self, referrers: Option<&[ReferrerInfo]>) -> Option<SocketAddr> {
+    /// see that for the actual ranking logic. The returned `Vec` is what
+    /// gets handed to
+    /// [`crate::transport::saorsa_transport_adapter::SaorsaDualStackTransport::set_hole_punch_preferred_coordinators`]
+    /// so the transport's hole-punch loop can rotate through coordinators
+    /// in order.
+    fn rank_referrers_for_target(&self, referrers: Option<&[ReferrerInfo]>) -> Vec<SocketAddr> {
         let trust_for = |peer_id: &PeerId| -> f64 {
             self.trust_engine
                 .as_ref()
@@ -1478,7 +1487,8 @@ impl DhtNetworkManager {
         Self::rank_referrers(referrers, trust_for)
     }
 
-    /// Pure ranking function that picks the best referrer from a slice.
+    /// Pure ranking function that sorts a slice of referrer observations
+    /// into a best-first list of coordinator addresses.
     ///
     /// Ranking (highest priority first):
     /// 1. **`round_observed` DESC** — referrers seen in later iteration
@@ -1491,42 +1501,49 @@ impl DhtNetworkManager {
     ///    same round, prefer the one with the higher trust score returned
     ///    by `trust_for`.
     /// 3. **deterministic hash tiebreak** — when round and trust both tie,
-    ///    keep the referrer whose `peer_id` byte 0 is **larger**. Using a
-    ///    pure peer-id ordering instead of a random RNG keeps the choice
+    ///    prefer the referrer whose `peer_id` byte 0 is **larger**. Using
+    ///    a pure peer-id ordering instead of a random RNG keeps the choice
     ///    reproducible across runs (useful for tests) while still
     ///    spreading load across coordinators because different targets
     ///    see different referrer sets.
     ///
-    /// Returns `None` when the slice is empty or `None` itself, so the
-    /// caller can pass-through directly to APIs that take an
-    /// `Option<SocketAddr>` referrer hint.
+    /// Returns an empty `Vec` when the slice is empty or `None` itself,
+    /// so the caller can pass-through directly to
+    /// `set_hole_punch_preferred_coordinators` (which treats an empty
+    /// list as "remove the entry").
     ///
     /// Pure function (no `&self`) so it can be unit-tested without
     /// constructing a full [`DhtNetworkManager`].
     fn rank_referrers(
         referrers: Option<&[ReferrerInfo]>,
         trust_for: impl Fn(&PeerId) -> f64,
-    ) -> Option<SocketAddr> {
-        let list = referrers?;
+    ) -> Vec<SocketAddr> {
+        let Some(list) = referrers else {
+            return Vec::new();
+        };
         if list.is_empty() {
-            return None;
+            return Vec::new();
         }
 
-        list.iter()
-            .max_by(|a, b| {
-                // Primary: higher round wins.
-                a.round_observed
-                    .cmp(&b.round_observed)
-                    // Secondary: higher trust wins (total_cmp sidesteps NaN
-                    // issues — score is bounded but total_cmp is safe
-                    // regardless).
-                    .then_with(|| trust_for(&a.peer_id).total_cmp(&trust_for(&b.peer_id)))
-                    // Tertiary: deterministic tiebreak by peer_id byte 0.
-                    // `max_by` keeps the larger one — arbitrary but
-                    // reproducible.
-                    .then_with(|| a.peer_id.to_bytes()[0].cmp(&b.peer_id.to_bytes()[0]))
-            })
-            .map(|r| r.addr)
+        // Pre-compute trust scores once per referrer so the comparator
+        // doesn't re-invoke the closure repeatedly during sort.
+        let mut scored: Vec<(f64, &ReferrerInfo)> =
+            list.iter().map(|r| (trust_for(&r.peer_id), r)).collect();
+
+        scored.sort_by(|a, b| {
+            // Primary: higher round wins → reverse so DESC sort.
+            b.1.round_observed
+                .cmp(&a.1.round_observed)
+                // Secondary: higher trust wins (total_cmp sidesteps NaN
+                // issues — score is bounded but total_cmp is safe
+                // regardless). Reverse for DESC.
+                .then_with(|| b.0.total_cmp(&a.0))
+                // Tertiary: deterministic tiebreak — larger peer_id
+                // byte 0 wins. Reverse for DESC.
+                .then_with(|| b.1.peer_id.to_bytes()[0].cmp(&a.1.peer_id.to_bytes()[0]))
+        });
+
+        scored.into_iter().map(|(_, r)| r.addr).collect()
     }
 
     /// Merge a single referrer observation into the per-target slot table,
@@ -1603,7 +1620,7 @@ impl DhtNetworkManager {
         &self,
         peer_id: &PeerId,
         addresses: &[MultiAddr],
-        referrer: Option<SocketAddr>,
+        referrers: &[SocketAddr],
     ) -> Option<String> {
         let dialable = Self::dialable_addresses(addresses);
         if dialable.is_empty() {
@@ -1614,7 +1631,7 @@ impl DhtNetworkManager {
             return None;
         }
         for addr in &dialable {
-            if let Some(channel_id) = self.dial_candidate(peer_id, addr, referrer).await {
+            if let Some(channel_id) = self.dial_candidate(peer_id, addr, referrers).await {
                 return Some(channel_id);
             }
         }
@@ -1766,7 +1783,7 @@ impl DhtNetworkManager {
                 candidate_addresses.len()
             );
             if let Some(channel_id) = self
-                .dial_addresses(peer_id, &candidate_addresses, None)
+                .dial_addresses(peer_id, &candidate_addresses, &[])
                 .await
             {
                 let identity_timeout = self.config.request_timeout.min(IDENTITY_EXCHANGE_TIMEOUT);
@@ -1927,7 +1944,7 @@ impl DhtNetworkManager {
         &self,
         peer_id: &PeerId,
         address: &MultiAddr,
-        referrer: Option<std::net::SocketAddr>,
+        referrers: &[std::net::SocketAddr],
     ) -> Option<String> {
         let peer_hex = peer_id.to_hex();
 
@@ -1959,18 +1976,23 @@ impl DhtNetworkManager {
                 .await;
         }
 
-        // If we know which peer referred us to this target (from a DHT
-        // FindNode response), set it as the preferred coordinator for
-        // hole-punching. That peer has a connection to the target.
-        if let Some(coordinator_addr) = referrer
-            && let Some(socket_addr) = address.dialable_socket_addr()
-        {
+        // Hand the full ranked list of referrers to saorsa-transport so its
+        // hole-punch loop can rotate through them in order. The first
+        // `K - 1` get a short per-attempt timeout (~1.5s) so a busy or
+        // unreachable referrer is abandoned quickly; the final entry gets
+        // the strategy's full hole-punch timeout to give it time to
+        // actually complete the punch. An empty list removes any prior
+        // preference for this target — see
+        // [`Self::rank_referrers_for_target`].
+        if let Some(socket_addr) = address.dialable_socket_addr() {
             info!(
-                "dial_candidate: setting preferred coordinator for {} = {} (DHT referrer)",
-                socket_addr, coordinator_addr
+                "dial_candidate: setting {} preferred coordinator(s) for {} (DHT referrers): {:?}",
+                referrers.len(),
+                socket_addr,
+                referrers
             );
             self.transport
-                .set_hole_punch_preferred_coordinator(socket_addr, coordinator_addr)
+                .set_hole_punch_preferred_coordinators(socket_addr, referrers.to_vec())
                 .await;
         }
 
@@ -3212,57 +3234,51 @@ mod tests {
     }
 
     #[test]
-    fn rank_referrers_returns_none_for_empty_or_missing() {
-        assert_eq!(
-            DhtNetworkManager::rank_referrers(None, neutral_trust),
-            None,
-            "None input must yield None"
+    fn rank_referrers_returns_empty_for_empty_or_missing() {
+        assert!(
+            DhtNetworkManager::rank_referrers(None, neutral_trust).is_empty(),
+            "None input must yield an empty list"
         );
-        assert_eq!(
-            DhtNetworkManager::rank_referrers(Some(&[]), neutral_trust),
-            None,
-            "empty slice must yield None"
+        assert!(
+            DhtNetworkManager::rank_referrers(Some(&[]), neutral_trust).is_empty(),
+            "empty slice must yield an empty list"
         );
     }
 
     #[test]
     fn rank_referrers_single_referrer_returned() {
         let only = make_referrer(0x01, 1, 0);
-        let chosen = DhtNetworkManager::rank_referrers(Some(&[only]), neutral_trust);
-        assert_eq!(
-            chosen,
-            Some(only.addr),
-            "single-referrer slice must return that referrer's addr"
-        );
+        let ranked = DhtNetworkManager::rank_referrers(Some(&[only]), neutral_trust);
+        assert_eq!(ranked, vec![only.addr]);
     }
 
     #[test]
     fn rank_referrers_prefers_later_round_over_earlier() {
         // Round 0 (bootstrap-equivalent) vs round 3 (deep iteration).
-        // Round 3 must win regardless of order or trust.
+        // Round 3 must come first regardless of input order or trust.
         let round_zero = make_referrer(0xFF, 1, 0);
         let round_three = make_referrer(0x01, 2, 3);
 
-        let chosen_a =
+        let ranked_a =
             DhtNetworkManager::rank_referrers(Some(&[round_zero, round_three]), neutral_trust);
-        let chosen_b =
+        let ranked_b =
             DhtNetworkManager::rank_referrers(Some(&[round_three, round_zero]), neutral_trust);
 
         assert_eq!(
-            chosen_a,
-            Some(round_three.addr),
-            "later round must win regardless of slice order"
+            ranked_a,
+            vec![round_three.addr, round_zero.addr],
+            "later round must come first regardless of input order"
         );
         assert_eq!(
-            chosen_b,
-            Some(round_three.addr),
-            "later round must win regardless of slice order (reversed)"
+            ranked_b,
+            vec![round_three.addr, round_zero.addr],
+            "later round must come first regardless of input order (reversed)"
         );
     }
 
     #[test]
     fn rank_referrers_tiebreaks_round_with_trust() {
-        // Same round, different trust. Higher trust must win.
+        // Same round, different trust. Higher-trust comes first.
         let low_trust = make_referrer(0x55, 1, 2);
         let high_trust = make_referrer(0xAA, 2, 2);
         let trust_for = |peer_id: &PeerId| -> f64 {
@@ -3273,33 +3289,56 @@ mod tests {
             }
         };
 
-        let chosen = DhtNetworkManager::rank_referrers(Some(&[low_trust, high_trust]), trust_for);
+        let ranked = DhtNetworkManager::rank_referrers(Some(&[low_trust, high_trust]), trust_for);
         assert_eq!(
-            chosen,
-            Some(high_trust.addr),
-            "higher trust must win when rounds tie"
+            ranked,
+            vec![high_trust.addr, low_trust.addr],
+            "higher trust must come first when rounds tie"
         );
     }
 
     #[test]
     fn rank_referrers_tiebreaks_round_and_trust_with_peer_id_byte_zero() {
         // Same round, same (neutral) trust. The referrer with the larger
-        // byte-0 must win deterministically.
+        // byte-0 comes first deterministically.
         let small = make_referrer(0x01, 1, 1);
         let large = make_referrer(0xF0, 2, 1);
 
-        let chosen_a = DhtNetworkManager::rank_referrers(Some(&[small, large]), neutral_trust);
-        let chosen_b = DhtNetworkManager::rank_referrers(Some(&[large, small]), neutral_trust);
+        let ranked_a = DhtNetworkManager::rank_referrers(Some(&[small, large]), neutral_trust);
+        let ranked_b = DhtNetworkManager::rank_referrers(Some(&[large, small]), neutral_trust);
 
         assert_eq!(
-            chosen_a,
-            Some(large.addr),
-            "larger peer_id byte 0 must win the tertiary tiebreak"
+            ranked_a,
+            vec![large.addr, small.addr],
+            "larger peer_id byte 0 must come first via tertiary tiebreak"
         );
         assert_eq!(
-            chosen_b,
-            Some(large.addr),
+            ranked_b,
+            vec![large.addr, small.addr],
             "tiebreak must be order-independent"
+        );
+    }
+
+    #[test]
+    fn rank_referrers_full_list_is_sorted_best_first() {
+        // Mixed rounds and trust scores: verify the entire list is sorted
+        // correctly, not just the head.
+        let r0 = make_referrer(0x01, 1, 0); // round 0
+        let r1 = make_referrer(0x02, 2, 1); // round 1
+        let r2_low = make_referrer(0x03, 3, 2); // round 2, low trust
+        let r2_high = make_referrer(0x04, 4, 2); // round 2, high trust
+        let trust_for = |peer_id: &PeerId| -> f64 {
+            if peer_id.to_bytes()[0] == 0x04 {
+                0.9
+            } else {
+                0.5
+            }
+        };
+        let ranked = DhtNetworkManager::rank_referrers(Some(&[r0, r1, r2_low, r2_high]), trust_for);
+        assert_eq!(
+            ranked,
+            vec![r2_high.addr, r2_low.addr, r1.addr, r0.addr],
+            "full list must be sorted (round DESC, trust DESC) end-to-end"
         );
     }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -235,7 +235,7 @@ pub struct NodeConfig {
     ///
     /// Controls whether peers with low trust scores are eligible for
     /// swap-out from the routing table when better candidates arrive. Use
-    /// [`NodeConfigBuilder::trust_enforcement`] for a simple on/off toggle.
+    /// `NodeConfigBuilder::trust_enforcement` for a simple on/off toggle.
     ///
     /// Default: enabled with a swap threshold of 0.35.
     #[serde(default)]
@@ -741,7 +741,7 @@ const QUIC_TEARDOWN_GRACE: Duration = Duration::from_millis(100);
 /// - Handle network events and peer lifecycle
 ///
 /// Transport concerns (connections, messaging, events) are delegated to
-/// [`TransportHandle`](crate::transport_handle::TransportHandle).
+/// `TransportHandle`.
 pub struct P2PNode {
     /// Node configuration
     config: NodeConfig,
@@ -978,7 +978,7 @@ impl P2PNode {
     ///
     /// # Returns
     ///
-    /// A [`PeerResponse`] on success, or an error on timeout / connection failure.
+    /// A `PeerResponse` on success, or an error on timeout / connection failure.
     ///
     /// # Example
     ///

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -856,18 +856,30 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         }
     }
 
-    /// Set a preferred coordinator for hole-punching to a specific target.
-    /// The preferred coordinator is a peer that referred us to the target
-    /// during a DHT lookup, so it has a connection to the target.
-    pub async fn set_hole_punch_preferred_coordinator(
+    /// Set an ordered list of preferred coordinators for hole-punching to a
+    /// specific target.
+    ///
+    /// The list is iterated front to back at hole-punch time: every
+    /// coordinator except the last gets a short per-attempt timeout
+    /// (~1.5s) so a busy or unreachable referrer is abandoned quickly,
+    /// and the final coordinator gets the strategy's full hole-punch
+    /// timeout to give it time to actually complete the punch.
+    ///
+    /// The caller (`DhtNetworkManager::dial_candidate`) is expected to
+    /// rank the list best-first using DHT signals — round observed,
+    /// trust score, etc. — via [`DhtNetworkManager::rank_referrers`].
+    ///
+    /// Empty `coordinators` removes any preferred coordinators for
+    /// `target`.
+    pub async fn set_hole_punch_preferred_coordinators(
         &self,
         target: SocketAddr,
-        coordinator: SocketAddr,
+        coordinators: Vec<SocketAddr>,
     ) {
         for node in [&self.v6, &self.v4].into_iter().flatten() {
             node.transport
                 .endpoint()
-                .set_hole_punch_preferred_coordinator(target, coordinator)
+                .set_hole_punch_preferred_coordinators(target, coordinators.clone())
                 .await;
         }
     }

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -721,16 +721,18 @@ impl TransportHandle {
             .await;
     }
 
-    /// Set a preferred coordinator for hole-punching to a specific target.
-    /// The preferred coordinator is a peer that referred us to the target
-    /// during a DHT lookup, so it has a connection to the target.
-    pub async fn set_hole_punch_preferred_coordinator(
+    /// Set an ordered list of preferred coordinators for hole-punching to a
+    /// specific target.
+    ///
+    /// See [`crate::transport::saorsa_transport_adapter::SaorsaDualStackTransport::set_hole_punch_preferred_coordinators`]
+    /// for the rotation semantics.
+    pub async fn set_hole_punch_preferred_coordinators(
         &self,
         target: SocketAddr,
-        coordinator: SocketAddr,
+        coordinators: Vec<SocketAddr>,
     ) {
         self.dual_node
-            .set_hole_punch_preferred_coordinator(target, coordinator)
+            .set_hole_punch_preferred_coordinators(target, coordinators)
             .await;
     }
 


### PR DESCRIPTION
## Summary
- Wires saorsa-core's DHT layer to the new \`set_hole_punch_preferred_coordinators(Vec<SocketAddr>)\` API landed in saorsa-labs/saorsa-transport#43. \`dial_candidate\` now hands over the **full ranked referrer list** instead of picking a single best coordinator.
- The transport's hole-punch loop rotates through the list in order with a short per-attempt timeout (~1.5s) for all but the final candidate, so a busy or unreachable referrer is abandoned quickly. Worst-case dial time drops from \`K * 8s\` to \`(K-1) * 1.5s + 8s\`.
- The old single-coordinator wrappers \`set_hole_punch_preferred_coordinator\` are **removed** from \`TransportHandle\` and the \`saorsa_transport_adapter\` (no backward-compat shims, per repo policy).

## Why
This is the third PR in the smarter-coordinator series. The first (saorsa-labs/saorsa-core#73) added round-aware referrer ranking inside the DHT layer. The second (saorsa-labs/saorsa-transport#43) gave the transport a list-form coordinator API and node-wide back-pressure. This PR is the bridge: round-aware ranking on the saorsa-core side, list-rotation on the saorsa-transport side, end-to-end.

## Changes

### \`transport_handle.rs\` / \`saorsa_transport_adapter.rs\`
- \`set_hole_punch_preferred_coordinator(target, SocketAddr)\` → \`set_hole_punch_preferred_coordinators(target, Vec<SocketAddr>)\`. Old wrappers removed entirely.

### \`dht_network_manager.rs\`
- \`dial_candidate\` and \`dial_addresses\` now take \`referrers: &[SocketAddr]\` instead of \`Option<SocketAddr>\`. The five non-DHT call sites (bucket refresh, self-lookup, send_dht_request fallback, bootstrap_from_peers, periodic re-bootstrap) pass \`&[]\` because they have no DHT-derived ranking signal at the call site.
- \`select_best_referrer(&self) -> Option<SocketAddr>\` is replaced with \`rank_referrers_for_target(&self) -> Vec<SocketAddr>\`.
- Pure helper \`rank_referrers\` now sorts the **entire** slice instead of returning a single max, with one trust-score evaluation per referrer (cached in a \`(score, &referrer)\` tuple) so the comparator doesn't re-invoke the closure during sort.
- \`dial_candidate\` no longer guards on \`referrer.is_some()\` — it always calls \`set_hole_punch_preferred_coordinators\` so the transport's preference state stays in sync with the latest ranking. An empty slice removes any prior preference for that target.

## Subtle behavior change worth flagging
\`dial_candidate\` now ALWAYS pushes the referrer list down, even when empty. Previously the call was conditional. Within a single iterative lookup the referrer map is monotonically growing so re-dials produce equal-or-better preferences. Cross-call: \`bootstrap_from_peers\` (empty) only runs during boot, before iterative lookups, so the ordering is fine. The "always sync" behavior is arguably more correct than the old "set once and forget" because it keeps the transport state aligned with our latest understanding.

## Test plan
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings -D clippy::unwrap_used -D clippy::expect_used\` clean
- [x] \`cargo test --lib\` passes (295 tests, +1 net new)
- [x] 5 existing \`rank_referrers\` tests updated for the new \`Vec\` return type
- [x] 1 new test \`rank_referrers_full_list_is_sorted_best_first\` covering end-to-end sort order across mixed rounds and trust scores — not just the head, so future regressions where the head is correct but the tail is wrong will be caught
- [x] No panic paths added; the per-call \`Vec\` clone in \`dial_candidate\` and per-node clone in the adapter are necessary because the transport API takes ownership (clones occur once per dial)

## Dependencies
- saorsa-labs/saorsa-transport#43 — **merged**, this PR pulls the new API via \`cargo update -p saorsa-transport\` (Cargo.lock bump included)
- saorsa-labs/saorsa-core#73 — **merged**, this PR builds on the round-aware ranking it added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bridges saorsa-core's DHT layer to the new `set_hole_punch_preferred_coordinators(Vec<SocketAddr>)` transport API, passing the full ranked referrer list (sorted by round then trust score) instead of a single coordinator. Old single-coordinator wrappers are removed at every layer and non-DHT call sites correctly pass `&[]`.

The only finding is four stale references to the removed `select_best_referrer` in `src/dht_network_manager.rs` (lines 102, 289, 809, 1074) that will produce broken rustdoc link warnings.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 doc cleanup with no runtime impact.

Logic is correct and well-tested (295+1 tests passing). The behavioral change is clearly motivated and correctly implemented. The only remaining issue is stale documentation references to a removed function, which do not affect runtime behavior.

src/dht_network_manager.rs — four stale select_best_referrer doc references at lines 102, 289, 809, and 1074 should be updated before the next cargo doc run.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.lock | Bumps saorsa-transport to 0.31.0 to pull in the new list-form coordinator API; no other notable dependency changes. |
| src/dht_network_manager.rs | Core change: rank_referrers now sorts the full slice and dial_candidate passes the ranked Vec<SocketAddr> to the transport; four stale rustdoc/comment references to the removed select_best_referrer remain. |
| src/transport/saorsa_transport_adapter.rs | Adds set_hole_punch_preferred_coordinators forwarding to both v4/v6 endpoints; old single-coordinator wrapper cleanly removed. |
| src/transport_handle.rs | Thin public wrapper updated to expose set_hole_punch_preferred_coordinators; documentation is accurate. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant DNM as DhtNetworkManager
    participant TH as TransportHandle
    participant ST as SaorsaDualStackTransport

    DNM->>DNM: iterative lookup collects ReferrerInfo[]
    DNM->>DNM: rank_referrers_for_target() → Vec<SocketAddr>
    Note over DNM: sorted by round DESC, trust DESC
    DNM->>TH: set_hole_punch_preferred_coordinators(socket_addr, ranked_list)
    TH->>ST: set_hole_punch_preferred_coordinators(socket_addr, ranked_list)
    ST->>ST: clone list for v4 and v6 endpoints
    ST-->>DNM: ()
    DNM->>TH: connect_peer(address)
    TH->>ST: hole-punch rotates through coordinators in rank order
    Note over ST: First K-1 get ~1.5s timeout, last gets full strategy timeout
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/dht_network_manager.rs`, line 102 ([link](https://github.com/saorsa-labs/saorsa-core/blob/c15cecf85621afaf7215bbf50afffbd5b7b8afa5/src/dht_network_manager.rs#L102)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale doc-links to removed `select_best_referrer`**

   Three intra-doc links and one inline comment still reference the removed `select_best_referrer` function. The rustdoc links at lines 102, 289, and 809 will produce broken-link warnings and fail any `cargo doc --deny warnings` run; line 1074's inline comment misleads future readers.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/dht_network_manager.rs
   Line: 102

   Comment:
   **Stale doc-links to removed `select_best_referrer`**

   Three intra-doc links and one inline comment still reference the removed `select_best_referrer` function. The rustdoc links at lines 102, 289, and 809 will produce broken-link warnings and fail any `cargo doc --deny warnings` run; line 1074's inline comment misleads future readers.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/dht_network_manager.rs
Line: 102

Comment:
**Stale doc-links to removed `select_best_referrer`**

Three intra-doc links and one inline comment still reference the removed `select_best_referrer` function. The rustdoc links at lines 102, 289, and 809 will produce broken-link warnings and fail any `cargo doc --deny warnings` run; line 1074's inline comment misleads future readers.

```suggestion
/// Maximum number of distinct referrers stored per discovered peer during an
/// iterative DHT lookup. The list is ranked at dial-time and passed in full to
/// `set_hole_punch_preferred_coordinators` (see [`DhtNetworkManager::rank_referrers_for_target`]).
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dht): hand the full ranked referrer..."](https://github.com/saorsa-labs/saorsa-core/commit/c15cecf85621afaf7215bbf50afffbd5b7b8afa5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27523547)</sub>

<!-- /greptile_comment -->