### PR TITLE
feat!(transport): use TLS-derived peer ID and retire identity-announce protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,6 +2461,7 @@ dependencies = [
  "async-trait",
  "blake3",
  "bytes",
+ "dashmap",
  "dirs 6.0.0",
  "futures",
  "hex",
@@ -2568,7 +2569,6 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#52ef49364ea71520787fb9edb2a2df476bc3c281"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#28264672995950e5094f6d1f5cfea588c018c2b7"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#c86a37fba6bffb0b45266ba8270e5202098252ed"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#244189606913b1706ce146b5d8b741d9a9b698ee"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#28264672995950e5094f6d1f5cfea588c018c2b7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#496721bee0e5b535d5aec07513ec3ced29d20644"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#244189606913b1706ce146b5d8b741d9a9b698ee"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.31.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#c86a37fba6bffb0b45266ba8270e5202098252ed"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.1#52ef49364ea71520787fb9edb2a2df476bc3c281"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,10 @@ blake3 = "1.6"
 # Performance optimization
 parking_lot = "0.12"
 once_cell = "1.21"
+dashmap = "6"
 
 # Networking
-saorsa-transport = { git = "https://github.com/saorsa-labs/saorsa-transport.git", branch = "rc-2026.4.1" }
+saorsa-transport = { path = "../saorsa-transport" }
 
 # Core-specific dependencies
 dirs = "6.0"

--- a/src/adaptive/dht.rs
+++ b/src/adaptive/dht.rs
@@ -81,7 +81,7 @@ impl AdaptiveDhtConfig {
 /// consumer's responsibility via [`ApplicationSuccess`](Self::ApplicationSuccess).
 ///
 /// Consumer-reported events carry a weight multiplier that controls the
-/// severity of the update (clamped to [`MAX_CONSUMER_WEIGHT`]).
+/// severity of the update (clamped to `MAX_CONSUMER_WEIGHT`).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TrustEvent {
     // === Negative signals (core) ===

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -287,7 +287,7 @@ pub struct DhtNetworkManager {
 /// During a single iterative lookup we collect up to
 /// [`MAX_REFERRERS_PER_TARGET`] referrers per discovered peer and rank them
 /// at dial-time via [`DhtNetworkManager::select_best_referrer`].
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ReferrerInfo {
     /// Peer ID of the referring node (used for trust score lookup and tiebreak).
     peer_id: PeerId,
@@ -1208,23 +1208,27 @@ impl DhtNetworkManager {
                             // MAX_REFERRERS_PER_TARGET observations and rank
                             // them at dial-time, so we no longer pin the
                             // first-seen referrer.
+                            //
+                            // When the slot table is full, we still want to
+                            // accept a *strictly later round* observation by
+                            // evicting the lowest-round entry. Otherwise a
+                            // burst of round-0 referrers (e.g. several
+                            // bootstraps all returning the same hot peer)
+                            // would lock out the higher-round referrers we
+                            // actually prefer at dial-time, defeating the
+                            // round-aware ranking in exactly the case we
+                            // care about.
                             if let Some(ref_addr) = referrer_addr {
                                 let entry = referrers.entry(node.peer_id).or_default();
-                                let already_present = entry.iter().any(|r| r.peer_id == peer_id);
-                                if !already_present && entry.len() < MAX_REFERRERS_PER_TARGET {
-                                    info!(
-                                        "find_closest_nodes_network: peer {} referred by {} ({}) round {}",
-                                        hex::encode(&node.peer_id.to_bytes()[..8]),
-                                        hex::encode(&peer_id.to_bytes()[..8]),
-                                        ref_addr,
-                                        iteration,
-                                    );
-                                    entry.push(ReferrerInfo {
+                                Self::merge_referrer_observation(
+                                    entry,
+                                    ReferrerInfo {
                                         peer_id,
                                         addr: ref_addr,
                                         round_observed: iteration as u32,
-                                    });
-                                }
+                                    },
+                                    &node.peer_id,
+                                );
                             }
                             let dist = node.peer_id.distance(&target_key);
                             let cand_key = (dist, node.peer_id);
@@ -1523,6 +1527,66 @@ impl DhtNetworkManager {
                     .then_with(|| a.peer_id.to_bytes()[0].cmp(&b.peer_id.to_bytes()[0]))
             })
             .map(|r| r.addr)
+    }
+
+    /// Merge a single referrer observation into the per-target slot table,
+    /// preserving the round-aware ranking invariant.
+    ///
+    /// Behaviour:
+    /// - Duplicate referrer (same `peer_id` already present): no-op.
+    /// - Slot table not yet full: append.
+    /// - Slot table full AND `new.round_observed` is strictly greater than
+    ///   the current minimum round in the table: evict the lowest-round
+    ///   entry and replace it with `new`.
+    /// - Slot table full AND `new.round_observed <= min(table.rounds)`:
+    ///   drop `new` (it would lose the dial-time ranking against every
+    ///   existing entry anyway).
+    ///
+    /// The eviction path exists so that a burst of round-0 referrers (e.g.
+    /// every bootstrap returning the same hot peer in the first DHT round)
+    /// cannot lock out the higher-round referrers we actually prefer at
+    /// dial-time. Without this, the slot cap silently degrades the
+    /// round-aware ranking in exactly the case the PR is targeting.
+    ///
+    /// Pure function (no `&self`) so it can be unit-tested directly.
+    fn merge_referrer_observation(
+        entry: &mut Vec<ReferrerInfo>,
+        new: ReferrerInfo,
+        target_peer_id: &PeerId,
+    ) {
+        if entry.iter().any(|r| r.peer_id == new.peer_id) {
+            return;
+        }
+        if entry.len() < MAX_REFERRERS_PER_TARGET {
+            info!(
+                "find_closest_nodes_network: peer {} referred by {} ({}) round {}",
+                hex::encode(&target_peer_id.to_bytes()[..8]),
+                hex::encode(&new.peer_id.to_bytes()[..8]),
+                new.addr,
+                new.round_observed,
+            );
+            entry.push(new);
+            return;
+        }
+        // Slot full — evict the lowest-round entry only if `new` is
+        // strictly later.
+        if let Some((min_idx, min_referrer)) = entry
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, r)| r.round_observed)
+            && min_referrer.round_observed < new.round_observed
+        {
+            info!(
+                "find_closest_nodes_network: peer {} referrer slot full — evicting round {} entry ({}) for round {} entry from {} ({})",
+                hex::encode(&target_peer_id.to_bytes()[..8]),
+                min_referrer.round_observed,
+                min_referrer.addr,
+                new.round_observed,
+                hex::encode(&new.peer_id.to_bytes()[..8]),
+                new.addr,
+            );
+            entry[min_idx] = new;
+        }
     }
 
     /// Try dialing each dialable address in `addresses` in order until one
@@ -3236,6 +3300,140 @@ mod tests {
             chosen_b,
             Some(large.addr),
             "tiebreak must be order-independent"
+        );
+    }
+
+    // ---- merge_referrer_observation ----
+
+    fn dummy_target() -> PeerId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0xCC;
+        PeerId::from_bytes(bytes)
+    }
+
+    #[test]
+    fn merge_referrer_observation_appends_until_full() {
+        let mut entry: Vec<ReferrerInfo> = Vec::new();
+        let target = dummy_target();
+        for i in 0..MAX_REFERRERS_PER_TARGET as u8 {
+            DhtNetworkManager::merge_referrer_observation(
+                &mut entry,
+                make_referrer(0x10 + i, i + 1, 0),
+                &target,
+            );
+        }
+        assert_eq!(
+            entry.len(),
+            MAX_REFERRERS_PER_TARGET,
+            "first MAX_REFERRERS_PER_TARGET observations must all land in the slot table"
+        );
+    }
+
+    #[test]
+    fn merge_referrer_observation_drops_duplicate_peer() {
+        let mut entry: Vec<ReferrerInfo> = Vec::new();
+        let target = dummy_target();
+        let original = make_referrer(0x42, 1, 0);
+        DhtNetworkManager::merge_referrer_observation(&mut entry, original, &target);
+        // True duplicate: identical peer_id, different addr and round.
+        // (`make_referrer` randomises bytes 1..32 per call, so we cannot
+        // produce a duplicate by re-tagging — we have to reuse the
+        // original peer_id directly.)
+        let duplicate = ReferrerInfo {
+            peer_id: original.peer_id,
+            addr: SocketAddr::from(([10, 0, 0, 99], 9000)),
+            round_observed: 5,
+        };
+        DhtNetworkManager::merge_referrer_observation(&mut entry, duplicate, &target);
+        assert_eq!(
+            entry.len(),
+            1,
+            "duplicate referrer (same peer_id) must not consume an additional slot"
+        );
+        assert_eq!(
+            entry[0].addr, original.addr,
+            "duplicate must NOT overwrite — first observation wins for the same peer"
+        );
+    }
+
+    #[test]
+    fn merge_referrer_observation_evicts_lowest_round_when_full_and_new_is_later() {
+        // Fill all 4 slots with round-0 referrers — the worst case the
+        // reviewer flagged: 4+ bootstraps all returning the same hot peer
+        // in round 0 would otherwise lock out later-round referrers.
+        let mut entry: Vec<ReferrerInfo> = Vec::new();
+        let target = dummy_target();
+        for i in 0..MAX_REFERRERS_PER_TARGET as u8 {
+            DhtNetworkManager::merge_referrer_observation(
+                &mut entry,
+                make_referrer(0x10 + i, i + 1, 0),
+                &target,
+            );
+        }
+        assert_eq!(entry.len(), MAX_REFERRERS_PER_TARGET);
+        assert!(
+            entry.iter().all(|r| r.round_observed == 0),
+            "all 4 slots should hold round-0 referrers"
+        );
+
+        // A round-3 referrer arrives — must evict one round-0 entry.
+        let later = make_referrer(0xAA, 99, 3);
+        DhtNetworkManager::merge_referrer_observation(&mut entry, later, &target);
+
+        assert_eq!(
+            entry.len(),
+            MAX_REFERRERS_PER_TARGET,
+            "table size must remain at the cap after eviction"
+        );
+        assert!(
+            entry.iter().any(|r| r.peer_id == later.peer_id),
+            "the new round-3 referrer must be present in the slot table"
+        );
+        // Exactly one round-0 entry was evicted, three remain.
+        let round_zero_count = entry.iter().filter(|r| r.round_observed == 0).count();
+        assert_eq!(
+            round_zero_count,
+            MAX_REFERRERS_PER_TARGET - 1,
+            "exactly one round-0 entry must have been evicted"
+        );
+    }
+
+    #[test]
+    fn merge_referrer_observation_does_not_evict_when_new_is_same_or_lower_round() {
+        // Fill all 4 slots with round-2 referrers, then submit a round-2
+        // and a round-0 referrer. Neither should evict — both would tie
+        // or lose against the existing entries at dial-time anyway.
+        let mut entry: Vec<ReferrerInfo> = Vec::new();
+        let target = dummy_target();
+        for i in 0..MAX_REFERRERS_PER_TARGET as u8 {
+            DhtNetworkManager::merge_referrer_observation(
+                &mut entry,
+                make_referrer(0x10 + i, i + 1, 2),
+                &target,
+            );
+        }
+        let snapshot: Vec<ReferrerInfo> = entry.clone();
+
+        // Same-round arrival: must NOT evict (strictly-greater check).
+        DhtNetworkManager::merge_referrer_observation(
+            &mut entry,
+            make_referrer(0x80, 50, 2),
+            &target,
+        );
+        assert_eq!(
+            entry, snapshot,
+            "same-round referrer must not evict the existing slot table"
+        );
+
+        // Earlier-round arrival: must NOT evict.
+        DhtNetworkManager::merge_referrer_observation(
+            &mut entry,
+            make_referrer(0x90, 60, 0),
+            &target,
+        );
+        assert_eq!(
+            entry, snapshot,
+            "lower-round referrer must not evict the existing slot table"
         );
     }
 

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -99,7 +99,7 @@ const AUTO_REBOOTSTRAP_THRESHOLD: usize = 3;
 
 /// Maximum number of distinct referrers stored per discovered peer during an
 /// iterative DHT lookup. The list is ranked at dial-time to pick the best
-/// hole-punch coordinator candidate (see [`DhtNetworkManager::select_best_referrer`]).
+/// hole-punch coordinator candidate (see [`DhtNetworkManager::rank_referrers_for_target`]).
 ///
 /// Bound exists to cap per-lookup memory; in practice 4 is more than enough
 /// because Kademlia typically converges before any peer is referred more than
@@ -286,7 +286,7 @@ pub struct DhtNetworkManager {
 ///
 /// During a single iterative lookup we collect up to
 /// [`MAX_REFERRERS_PER_TARGET`] referrers per discovered peer and rank them
-/// at dial-time via [`DhtNetworkManager::select_best_referrer`].
+/// at dial-time via [`DhtNetworkManager::rank_referrers_for_target`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ReferrerInfo {
     /// Peer ID of the referring node (used for trust score lookup and tiebreak).
@@ -806,7 +806,7 @@ impl DhtNetworkManager {
     /// queried the same ones). The pinning is removed: subsequent
     /// iterative DHT lookups via `find_closest_nodes_network` collect
     /// referrers across multiple rounds and rank them via
-    /// [`Self::select_best_referrer`], naturally de-preferring round-0
+    /// [`Self::rank_referrers_for_target`], naturally de-preferring round-0
     /// bootstrap referrers as the routing table grows.
     ///
     /// **Iteration order**: bootstrap peers are visited in a per-call
@@ -1071,7 +1071,7 @@ impl DhtNetworkManager {
         // hole-punch coordinator for T.
         //
         // We collect up to MAX_REFERRERS_PER_TARGET observations and rank
-        // them at dial-time via `select_best_referrer`. The ranking prefers
+        // them at dial-time via `rank_referrers_for_target`. The ranking prefers
         // referrers seen in later iteration rounds (closer to the target in
         // XOR space) over earlier rounds, which naturally de-prefers the
         // round-0 bootstrap referrers without any explicit bootstrap

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -29,12 +29,13 @@ use crate::{
     network::NodeConfig,
 };
 use anyhow::Context as _;
+use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime};
-use tokio::sync::{RwLock, Semaphore, broadcast, oneshot};
+use tokio::sync::{Notify, RwLock, Semaphore, broadcast, oneshot};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace, warn};
 use uuid::Uuid;
@@ -60,18 +61,16 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 /// The local node is always considered fully reliable for its own lookups.
 const SELF_RELIABILITY_SCORE: f64 = 1.0;
 
-/// Maximum time to wait for the identity-exchange handshake after dialling
-/// a peer. The actual timeout is `min(request_timeout, this)`.
+/// Defensive upper bound on the wait for a freshly-dialled peer's
+/// TLS-authenticated identity to be registered.
 ///
-/// Identity exchange is two RTTs over a freshly-handshaken QUIC connection
-/// plus an ML-DSA-65 signature verification. On a LAN this completes in
-/// well under a second; on congested cellular or cross-region links it can
-/// blow past 5s with retransmits. Kept in lockstep with
-/// `BOOTSTRAP_IDENTITY_TIMEOUT_SECS` in `network.rs` — both budgets exist
-/// to absorb the same slow-link failure mode (the bootstrap variant covers
-/// the initial join, this one covers every subsequent peer dial via
-/// `send_dht_request`).
-const IDENTITY_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(15);
+/// Since identity is now derived synchronously from the TLS-handshake
+/// SPKI by the connection lifecycle monitor, this wait completes within
+/// a scheduler tick of `connect_peer` returning. The 2 s budget exists
+/// only as a safety net for the lifecycle monitor being wedged or the
+/// peer presenting an unparseable SPKI. The effective wait remains
+/// `min(request_timeout, this)`.
+const IDENTITY_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Maximum time to wait for a stale peer's ping response during admission contention.
 const STALE_REVALIDATION_TIMEOUT: Duration = Duration::from_secs(1);
@@ -275,6 +274,21 @@ pub struct DhtNetworkManager {
     /// Timestamp of the last automatic re-bootstrap attempt, guarded by a
     /// cooldown to avoid hammering bootstrap peers during transient churn.
     last_rebootstrap: tokio::sync::Mutex<Option<Instant>>,
+    /// Per-peer dial coalescing.
+    ///
+    /// When [`Self::send_dht_request`] needs to dial a peer that no other
+    /// task is already dialling, it inserts a fresh `Notify` here and runs
+    /// the dial inline. Concurrent callers targeting the same peer find an
+    /// existing entry, await `notified()`, and then re-check whether the
+    /// peer is now connected. This prevents N parallel iterative lookups
+    /// from each kicking off their own coordinator-rotation cascade against
+    /// the same peer — under symmetric NAT that cascade is what produced
+    /// the "duplicate" connection-close storm during identity exchange.
+    ///
+    /// Entries are removed by the dialing task as soon as the dial returns
+    /// (success or failure), so the map only ever holds peers that have a
+    /// dial actively in progress.
+    inflight_dials: Arc<DashMap<PeerId, Arc<Notify>>>,
 }
 
 /// One observation of a peer being referred during an iterative DHT lookup.
@@ -409,6 +423,29 @@ impl Drop for BucketRevalidationGuard {
     }
 }
 
+/// RAII guard for the dial-coalescing slot owned by a single
+/// [`DhtNetworkManager::dial_or_await_inflight`] caller.
+///
+/// On drop the inflight entry is removed and `notify_waiters()` is called,
+/// so any concurrent callers awaiting on `notified()` are unblocked even if
+/// the owning caller's dial future panicked or was cancelled. Without this
+/// guard, a panic inside `dial_addresses` would leave waiters blocked
+/// indefinitely, because they have no timeout of their own.
+struct InflightDialGuard {
+    inflight: Arc<DashMap<PeerId, Arc<Notify>>>,
+    peer_id: PeerId,
+    notify: Arc<Notify>,
+}
+
+impl Drop for InflightDialGuard {
+    fn drop(&mut self) {
+        // Remove the inflight entry first so any waiter that re-enters
+        // `dial_or_await_inflight` after waking sees a clean state.
+        self.inflight.remove(&self.peer_id);
+        self.notify.notify_waiters();
+    }
+}
+
 impl DhtNetworkManager {
     fn new_from_components(
         transport: Arc<crate::transport_handle::TransportHandle>,
@@ -455,6 +492,7 @@ impl DhtNetworkManager {
             self_lookup_handle: Arc::new(RwLock::new(None)),
             bucket_refresh_handle: Arc::new(RwLock::new(None)),
             last_rebootstrap: tokio::sync::Mutex::new(None),
+            inflight_dials: Arc::new(DashMap::new()),
         })
     }
 
@@ -671,8 +709,10 @@ impl DhtNetworkManager {
                     }
                     // Dial if not already connected — try every advertised
                     // address, not just the first, so a stale NAT binding on
-                    // one entry doesn't kill the dial.
-                    self.dial_addresses(&dht_node.peer_id, &dht_node.addresses, &[])
+                    // one entry doesn't kill the dial. Routed through the
+                    // coalescing helper so a concurrent self-lookup and
+                    // send_dht_request to the same peer share one dial.
+                    self.dial_or_await_inflight(&dht_node.peer_id, &dht_node.addresses, &[])
                         .await;
                 }
                 Ok(())
@@ -843,7 +883,7 @@ impl DhtNetworkManager {
                             // discovered peers. The next iterative lookup
                             // will populate proper referrers via the
                             // round-aware ranking.
-                            self.dial_addresses(&node.peer_id, &node.addresses, &[])
+                            self.dial_or_await_inflight(&node.peer_id, &node.addresses, &[])
                                 .await;
                         }
                     }
@@ -1165,8 +1205,10 @@ impl DhtNetworkManager {
                         // If at least one succeeds the peer is connected and
                         // `send_dht_request` will reuse that channel; if all
                         // fail, `send_dht_request`'s own fallback will retry
-                        // with the routing-table addresses.
-                        self.dial_addresses(&peer_id, &addresses, &referrer_list)
+                        // with the routing-table addresses. The coalescing
+                        // helper ensures the parallel iterative-lookup batch
+                        // shares one dial per peer rather than racing.
+                        self.dial_or_await_inflight(&peer_id, &addresses, &referrer_list)
                             .await;
                         let address_hint = Self::first_dialable_address(&addresses);
                         (
@@ -1652,6 +1694,112 @@ impl DhtNetworkManager {
         }
     }
 
+    /// Dial coalescing: ensure at most one in-flight `dial_addresses` per
+    /// `peer_id` across all concurrent `send_dht_request` calls.
+    ///
+    /// # Outcome shape
+    ///
+    /// Returns `Ok(Some(channel_id))` when this call (or a coalesced
+    /// predecessor) successfully established a channel to `peer_id`.
+    /// Returns `Ok(None)` when the dial attempt completed without yielding
+    /// a usable channel (the peer is unreachable on every candidate
+    /// address). Returns `Err` only if the underlying transport call panics
+    /// out of the dial future — the dial path itself swallows individual
+    /// connect errors and surfaces them as `Ok(None)`.
+    ///
+    /// # Coalescing semantics
+    ///
+    /// 1. The first caller to a peer inserts a fresh `Notify` into
+    ///    `inflight_dials`, runs the dial inline, removes the entry, and
+    ///    finally calls `notify_waiters()` to wake every secondary caller
+    ///    blocked on the same peer.
+    /// 2. Secondary callers find an existing entry, await `notified()`
+    ///    *before* re-checking, and then ask the transport whether the
+    ///    peer is now connected. They do **not** receive the channel_id
+    ///    from the first caller — saorsa-transport's connection map is the
+    ///    canonical source, and querying it after the wake handles every
+    ///    success path uniformly (direct connect, hole-punch, relay).
+    /// 3. If the first caller fails, secondary callers see no live
+    ///    connection after their re-check and propagate the same `None`
+    ///    result rather than starting their own racing dial. They will
+    ///    retry on the *next* `send_dht_request` call, which is the right
+    ///    granularity for backoff.
+    ///
+    /// This eliminates the racing-dial cascade that previously caused N
+    /// concurrent DHT lookups against the same peer to each issue their
+    /// own coordinator-rotation pass, producing the "duplicate connection"
+    /// close storm under symmetric NAT.
+    async fn dial_or_await_inflight(
+        &self,
+        peer_id: &PeerId,
+        addresses: &[MultiAddr],
+        referrers: &[SocketAddr],
+    ) -> Option<String> {
+        // Fast path: peer is already connected — no dial needed.
+        if self.transport.is_peer_connected(peer_id).await {
+            return self
+                .transport
+                .channels_for_peer(peer_id)
+                .await
+                .into_iter()
+                .next();
+        }
+
+        // Try to claim the dial slot for this peer. The DashMap entry API
+        // is the single point of mutual exclusion: exactly one caller
+        // observes `Vacant` and proceeds to dial; everyone else observes
+        // `Occupied` and falls into the wait branch below.
+        enum Slot {
+            Owner(Arc<Notify>),
+            Waiter(Arc<Notify>),
+        }
+        let slot = match self.inflight_dials.entry(*peer_id) {
+            dashmap::mapref::entry::Entry::Vacant(v) => {
+                let notify = Arc::new(Notify::new());
+                v.insert(Arc::clone(&notify));
+                Slot::Owner(notify)
+            }
+            dashmap::mapref::entry::Entry::Occupied(o) => Slot::Waiter(Arc::clone(o.get())),
+        };
+
+        match slot {
+            Slot::Owner(notify) => {
+                // RAII guard ensures the inflight entry is removed and
+                // waiters are notified even if `dial_addresses` panics or
+                // the future is cancelled. Without this, a panic in the
+                // dial path would leave waiters blocked on `notified()`
+                // forever, since they have no timeout of their own.
+                let _guard = InflightDialGuard {
+                    inflight: Arc::clone(&self.inflight_dials),
+                    peer_id: *peer_id,
+                    notify: Arc::clone(&notify),
+                };
+                self.dial_addresses(peer_id, addresses, referrers).await
+            }
+            Slot::Waiter(notify) => {
+                debug!(
+                    peer = %peer_id.to_hex(),
+                    "Dial coalescing: awaiting in-flight dial",
+                );
+                notify.notified().await;
+                // The owning caller's dial has finished. If it succeeded,
+                // the peer is now connected and we can pick up its channel
+                // from the transport. If it failed, we return None and let
+                // the caller surface the failure exactly as it would have
+                // for a direct dial.
+                if self.transport.is_peer_connected(peer_id).await {
+                    self.transport
+                        .channels_for_peer(peer_id)
+                        .await
+                        .into_iter()
+                        .next()
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
     /// Remove expired operations from `active_operations`.
     ///
     /// Uses a 2x timeout multiplier as safety margin. Called at the start of
@@ -1783,7 +1931,7 @@ impl DhtNetworkManager {
                 candidate_addresses.len()
             );
             if let Some(channel_id) = self
-                .dial_addresses(peer_id, &candidate_addresses, &[])
+                .dial_or_await_inflight(peer_id, &candidate_addresses, &[])
                 .await
             {
                 let identity_timeout = self.config.request_timeout.min(IDENTITY_EXCHANGE_TIMEOUT);
@@ -3169,6 +3317,55 @@ mod tests {
             }
             _ => panic!("expected KClosestPeersChanged"),
         }
+    }
+
+    #[tokio::test]
+    async fn inflight_dial_guard_releases_slot_and_wakes_waiters_on_drop() {
+        // Verify the InflightDialGuard's RAII semantics: dropping the
+        // guard (which happens whether the owning future returns
+        // normally, panics, or is cancelled) must remove the inflight
+        // entry AND wake every blocked waiter. Without this, a panic in
+        // the dial path would leave secondary callers blocked on
+        // `notified()` forever.
+        let inflight: Arc<DashMap<PeerId, Arc<Notify>>> = Arc::new(DashMap::new());
+        let peer = PeerId::random();
+        let notify = Arc::new(Notify::new());
+        inflight.insert(peer, Arc::clone(&notify));
+
+        let waiter_inflight = Arc::clone(&inflight);
+        let waiter_notify = Arc::clone(&notify);
+        let waiter = tokio::spawn(async move {
+            waiter_notify.notified().await;
+            // After the wake, the entry must be gone so the waiter that
+            // re-enters the dial path sees a clean state.
+            assert!(
+                !waiter_inflight.contains_key(&peer),
+                "inflight entry should be removed before notify_waiters fires",
+            );
+        });
+
+        // Give the waiter task a chance to register with the Notify.
+        tokio::task::yield_now().await;
+
+        // Drop the guard — this is what `dial_or_await_inflight`'s Owner
+        // branch does on every exit path (success, error, panic, cancel).
+        let guard = InflightDialGuard {
+            inflight: Arc::clone(&inflight),
+            peer_id: peer,
+            notify: Arc::clone(&notify),
+        };
+        drop(guard);
+
+        // The waiter should wake immediately and complete its assertion.
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter must wake within 1s of guard drop")
+            .expect("waiter task should not panic");
+
+        assert!(
+            !inflight.contains_key(&peer),
+            "guard drop must remove the inflight entry",
+        );
     }
 
     #[test]

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -769,18 +769,24 @@ impl DhtNetworkManager {
             return indices;
         }
         // Build a 32-byte entropy buffer per call. PeerId::random() gives us
-        // 32 bytes, which is enough for ~32 swap decisions — well above the
-        // bootstrap-list sizes we expect (typically 2-5).
+        // 32 bytes, which covers ~16 two-byte swap decisions — well above
+        // the bootstrap-list sizes we expect (typically 2-5).
         let entropy_owner = PeerId::random();
         let entropy = entropy_owner.to_bytes();
         let entropy_len = entropy.len();
         // Fisher-Yates: for i from len-1 down to 1, swap indices[i] with
         // indices[j] where j is uniform in [0, i].
         for i in (1..len).rev() {
-            // Use a single byte from the entropy buffer as the random source
-            // for this swap. Indexing wraps if `len` exceeds the entropy
-            // buffer size, which is fine for the small lists we shuffle.
-            let byte = entropy[(len - 1 - i) % entropy_len] as usize;
+            // Draw a 16-bit window (two bytes) instead of one byte. With a
+            // single byte the modulo bias `byte % (i + 1)` slightly
+            // over-represents low values whenever `(i + 1)` does not
+            // divide 256 — at i = 4 the bias on slot 0 is ~0.4%, which is
+            // exactly the opposite of the load-spreading goal. A 16-bit
+            // window cuts the bias to ~1/65536 for any realistic list
+            // size at zero added complexity.
+            let idx = (len - 1 - i) * 2;
+            let byte = ((entropy[idx % entropy_len] as usize) << 8)
+                | (entropy[(idx + 1) % entropy_len] as usize);
             let j = byte % (i + 1);
             indices.swap(i, j);
         }

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -2604,6 +2604,23 @@ impl DhtNetworkManager {
     async fn handle_peer_connected(&self, node_id: PeerId, user_agent: &str) {
         let app_peer_id_hex = node_id.to_hex();
 
+        // The first `PeerConnected` event for a peer is emitted by the
+        // lifecycle monitor at TLS-handshake time, when the peer's identity
+        // is known but no signed application message has arrived yet — so
+        // its user-agent string is empty. Routing-table classification
+        // requires `is_dht_participant(user_agent)`, which would
+        // misclassify every peer as ephemeral on this first call. Defer
+        // until the shard consumer re-emits `PeerConnected` with the
+        // user-agent extracted from the first signed message (typically a
+        // DHT ping or find_node within one round trip of the handshake).
+        if user_agent.is_empty() {
+            debug!(
+                "DHT peer connected (TLS handshake): app_id={} — deferring routing classification until user_agent learned",
+                app_peer_id_hex
+            );
+            return;
+        }
+
         info!(
             "DHT peer connected: app_id={}, user_agent={}",
             app_peer_id_hex, user_agent

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -636,7 +636,7 @@ impl DhtNetworkManager {
                                 if dht_node.peer_id == this.config.peer_id {
                                     continue;
                                 }
-                                this.dial_addresses(&dht_node.peer_id, &dht_node.addresses, None)
+                                this.dial_addresses(&dht_node.peer_id, &dht_node.addresses, &[])
                                     .await;
                             }
                         }
@@ -672,7 +672,7 @@ impl DhtNetworkManager {
                     // Dial if not already connected — try every advertised
                     // address, not just the first, so a stale NAT binding on
                     // one entry doesn't kill the dial.
-                    self.dial_addresses(&dht_node.peer_id, &dht_node.addresses, None)
+                    self.dial_addresses(&dht_node.peer_id, &dht_node.addresses, &[])
                         .await;
                 }
                 Ok(())
@@ -837,12 +837,13 @@ impl DhtNetworkManager {
                             dialable.len()
                         );
                         if seen.insert(node.peer_id) && !dialable.is_empty() {
-                            // Pass `None` as referrer: the bootstrap peer is no
-                            // longer hard-pinned as the hole-punch coordinator
-                            // for these freshly-discovered peers. The next
-                            // iterative lookup will populate proper referrers
-                            // via the round-aware ranking.
-                            self.dial_addresses(&node.peer_id, &node.addresses, None)
+                            // Pass an empty referrer list: the bootstrap
+                            // peer is no longer hard-pinned as the
+                            // hole-punch coordinator for these freshly-
+                            // discovered peers. The next iterative lookup
+                            // will populate proper referrers via the
+                            // round-aware ranking.
+                            self.dial_addresses(&node.peer_id, &node.addresses, &[])
                                 .await;
                         }
                     }
@@ -1149,12 +1150,15 @@ impl DhtNetworkManager {
                 .map(|node| {
                     let peer_id = node.peer_id;
                     let addresses = node.addresses.clone();
-                    // Pick the best-ranked referrer for this target as the
-                    // hole-punch coordinator hint. PR #3 will plumb the full
-                    // ranked list down to saorsa-transport; for now we hand
-                    // over a single best choice.
-                    let referrer =
-                        self.select_best_referrer(referrers.get(&peer_id).map(Vec::as_slice));
+                    // Build the full ranked list of preferred coordinators
+                    // for this target. saorsa-transport rotates through
+                    // them in order with a short per-attempt timeout for
+                    // all but the final candidate, so handing over the
+                    // full list (instead of just the best) lets the
+                    // hole-punch loop fall through busy or unreachable
+                    // referrers without waiting on the strategy timeout.
+                    let referrer_list =
+                        self.rank_referrers_for_target(referrers.get(&peer_id).map(Vec::as_slice));
                     let op = DhtNetworkOperation::FindNode { key: *key };
                     async move {
                         // Try every dialable address, not just the first.
@@ -1162,7 +1166,8 @@ impl DhtNetworkManager {
                         // `send_dht_request` will reuse that channel; if all
                         // fail, `send_dht_request`'s own fallback will retry
                         // with the routing-table addresses.
-                        self.dial_addresses(&peer_id, &addresses, referrer).await;
+                        self.dial_addresses(&peer_id, &addresses, &referrer_list)
+                            .await;
                         let address_hint = Self::first_dialable_address(&addresses);
                         (
                             peer_id,
@@ -1462,13 +1467,17 @@ impl DhtNetworkManager {
         Self::dialable_addresses(addresses).into_iter().next()
     }
 
-    /// Pick the best hole-punch coordinator candidate from a slice of
-    /// referrer observations, using this manager's [`TrustEngine`] (or
-    /// default neutral trust when none is configured).
+    /// Rank a slice of referrer observations into an ordered list of
+    /// hole-punch coordinator addresses, best-first, using this manager's
+    /// [`TrustEngine`] (or default neutral trust when none is configured).
     ///
     /// Thin wrapper around the pure function [`Self::rank_referrers`] —
-    /// see that for the actual ranking logic.
-    fn select_best_referrer(&self, referrers: Option<&[ReferrerInfo]>) -> Option<SocketAddr> {
+    /// see that for the actual ranking logic. The returned `Vec` is what
+    /// gets handed to
+    /// [`crate::transport::saorsa_transport_adapter::SaorsaDualStackTransport::set_hole_punch_preferred_coordinators`]
+    /// so the transport's hole-punch loop can rotate through coordinators
+    /// in order.
+    fn rank_referrers_for_target(&self, referrers: Option<&[ReferrerInfo]>) -> Vec<SocketAddr> {
         let trust_for = |peer_id: &PeerId| -> f64 {
             self.trust_engine
                 .as_ref()
@@ -1478,7 +1487,8 @@ impl DhtNetworkManager {
         Self::rank_referrers(referrers, trust_for)
     }
 
-    /// Pure ranking function that picks the best referrer from a slice.
+    /// Pure ranking function that sorts a slice of referrer observations
+    /// into a best-first list of coordinator addresses.
     ///
     /// Ranking (highest priority first):
     /// 1. **`round_observed` DESC** — referrers seen in later iteration
@@ -1491,42 +1501,49 @@ impl DhtNetworkManager {
     ///    same round, prefer the one with the higher trust score returned
     ///    by `trust_for`.
     /// 3. **deterministic hash tiebreak** — when round and trust both tie,
-    ///    keep the referrer whose `peer_id` byte 0 is **larger**. Using a
-    ///    pure peer-id ordering instead of a random RNG keeps the choice
+    ///    prefer the referrer whose `peer_id` byte 0 is **larger**. Using
+    ///    a pure peer-id ordering instead of a random RNG keeps the choice
     ///    reproducible across runs (useful for tests) while still
     ///    spreading load across coordinators because different targets
     ///    see different referrer sets.
     ///
-    /// Returns `None` when the slice is empty or `None` itself, so the
-    /// caller can pass-through directly to APIs that take an
-    /// `Option<SocketAddr>` referrer hint.
+    /// Returns an empty `Vec` when the slice is empty or `None` itself,
+    /// so the caller can pass-through directly to
+    /// `set_hole_punch_preferred_coordinators` (which treats an empty
+    /// list as "remove the entry").
     ///
     /// Pure function (no `&self`) so it can be unit-tested without
     /// constructing a full [`DhtNetworkManager`].
     fn rank_referrers(
         referrers: Option<&[ReferrerInfo]>,
         trust_for: impl Fn(&PeerId) -> f64,
-    ) -> Option<SocketAddr> {
-        let list = referrers?;
+    ) -> Vec<SocketAddr> {
+        let Some(list) = referrers else {
+            return Vec::new();
+        };
         if list.is_empty() {
-            return None;
+            return Vec::new();
         }
 
-        list.iter()
-            .max_by(|a, b| {
-                // Primary: higher round wins.
-                a.round_observed
-                    .cmp(&b.round_observed)
-                    // Secondary: higher trust wins (total_cmp sidesteps NaN
-                    // issues — score is bounded but total_cmp is safe
-                    // regardless).
-                    .then_with(|| trust_for(&a.peer_id).total_cmp(&trust_for(&b.peer_id)))
-                    // Tertiary: deterministic tiebreak by peer_id byte 0.
-                    // `max_by` keeps the larger one — arbitrary but
-                    // reproducible.
-                    .then_with(|| a.peer_id.to_bytes()[0].cmp(&b.peer_id.to_bytes()[0]))
-            })
-            .map(|r| r.addr)
+        // Pre-compute trust scores once per referrer so the comparator
+        // doesn't re-invoke the closure repeatedly during sort.
+        let mut scored: Vec<(f64, &ReferrerInfo)> =
+            list.iter().map(|r| (trust_for(&r.peer_id), r)).collect();
+
+        scored.sort_by(|a, b| {
+            // Primary: higher round wins → reverse so DESC sort.
+            b.1.round_observed
+                .cmp(&a.1.round_observed)
+                // Secondary: higher trust wins (total_cmp sidesteps NaN
+                // issues — score is bounded but total_cmp is safe
+                // regardless). Reverse for DESC.
+                .then_with(|| b.0.total_cmp(&a.0))
+                // Tertiary: deterministic tiebreak — larger peer_id
+                // byte 0 wins. Reverse for DESC.
+                .then_with(|| b.1.peer_id.to_bytes()[0].cmp(&a.1.peer_id.to_bytes()[0]))
+        });
+
+        scored.into_iter().map(|(_, r)| r.addr).collect()
     }
 
     /// Merge a single referrer observation into the per-target slot table,
@@ -1603,7 +1620,7 @@ impl DhtNetworkManager {
         &self,
         peer_id: &PeerId,
         addresses: &[MultiAddr],
-        referrer: Option<SocketAddr>,
+        referrers: &[SocketAddr],
     ) -> Option<String> {
         let dialable = Self::dialable_addresses(addresses);
         if dialable.is_empty() {
@@ -1614,7 +1631,7 @@ impl DhtNetworkManager {
             return None;
         }
         for addr in &dialable {
-            if let Some(channel_id) = self.dial_candidate(peer_id, addr, referrer).await {
+            if let Some(channel_id) = self.dial_candidate(peer_id, addr, referrers).await {
                 return Some(channel_id);
             }
         }
@@ -1766,7 +1783,7 @@ impl DhtNetworkManager {
                 candidate_addresses.len()
             );
             if let Some(channel_id) = self
-                .dial_addresses(peer_id, &candidate_addresses, None)
+                .dial_addresses(peer_id, &candidate_addresses, &[])
                 .await
             {
                 let identity_timeout = self.config.request_timeout.min(IDENTITY_EXCHANGE_TIMEOUT);
@@ -1927,7 +1944,7 @@ impl DhtNetworkManager {
         &self,
         peer_id: &PeerId,
         address: &MultiAddr,
-        referrer: Option<std::net::SocketAddr>,
+        referrers: &[std::net::SocketAddr],
     ) -> Option<String> {
         let peer_hex = peer_id.to_hex();
 
@@ -1959,18 +1976,23 @@ impl DhtNetworkManager {
                 .await;
         }
 
-        // If we know which peer referred us to this target (from a DHT
-        // FindNode response), set it as the preferred coordinator for
-        // hole-punching. That peer has a connection to the target.
-        if let Some(coordinator_addr) = referrer
-            && let Some(socket_addr) = address.dialable_socket_addr()
-        {
+        // Hand the full ranked list of referrers to saorsa-transport so its
+        // hole-punch loop can rotate through them in order. The first
+        // `K - 1` get a short per-attempt timeout (~1.5s) so a busy or
+        // unreachable referrer is abandoned quickly; the final entry gets
+        // the strategy's full hole-punch timeout to give it time to
+        // actually complete the punch. An empty list removes any prior
+        // preference for this target — see
+        // [`Self::rank_referrers_for_target`].
+        if let Some(socket_addr) = address.dialable_socket_addr() {
             info!(
-                "dial_candidate: setting preferred coordinator for {} = {} (DHT referrer)",
-                socket_addr, coordinator_addr
+                "dial_candidate: setting {} preferred coordinator(s) for {} (DHT referrers): {:?}",
+                referrers.len(),
+                socket_addr,
+                referrers
             );
             self.transport
-                .set_hole_punch_preferred_coordinator(socket_addr, coordinator_addr)
+                .set_hole_punch_preferred_coordinators(socket_addr, referrers.to_vec())
                 .await;
         }
 
@@ -3212,57 +3234,51 @@ mod tests {
     }
 
     #[test]
-    fn rank_referrers_returns_none_for_empty_or_missing() {
-        assert_eq!(
-            DhtNetworkManager::rank_referrers(None, neutral_trust),
-            None,
-            "None input must yield None"
+    fn rank_referrers_returns_empty_for_empty_or_missing() {
+        assert!(
+            DhtNetworkManager::rank_referrers(None, neutral_trust).is_empty(),
+            "None input must yield an empty list"
         );
-        assert_eq!(
-            DhtNetworkManager::rank_referrers(Some(&[]), neutral_trust),
-            None,
-            "empty slice must yield None"
+        assert!(
+            DhtNetworkManager::rank_referrers(Some(&[]), neutral_trust).is_empty(),
+            "empty slice must yield an empty list"
         );
     }
 
     #[test]
     fn rank_referrers_single_referrer_returned() {
         let only = make_referrer(0x01, 1, 0);
-        let chosen = DhtNetworkManager::rank_referrers(Some(&[only]), neutral_trust);
-        assert_eq!(
-            chosen,
-            Some(only.addr),
-            "single-referrer slice must return that referrer's addr"
-        );
+        let ranked = DhtNetworkManager::rank_referrers(Some(&[only]), neutral_trust);
+        assert_eq!(ranked, vec![only.addr]);
     }
 
     #[test]
     fn rank_referrers_prefers_later_round_over_earlier() {
         // Round 0 (bootstrap-equivalent) vs round 3 (deep iteration).
-        // Round 3 must win regardless of order or trust.
+        // Round 3 must come first regardless of input order or trust.
         let round_zero = make_referrer(0xFF, 1, 0);
         let round_three = make_referrer(0x01, 2, 3);
 
-        let chosen_a =
+        let ranked_a =
             DhtNetworkManager::rank_referrers(Some(&[round_zero, round_three]), neutral_trust);
-        let chosen_b =
+        let ranked_b =
             DhtNetworkManager::rank_referrers(Some(&[round_three, round_zero]), neutral_trust);
 
         assert_eq!(
-            chosen_a,
-            Some(round_three.addr),
-            "later round must win regardless of slice order"
+            ranked_a,
+            vec![round_three.addr, round_zero.addr],
+            "later round must come first regardless of input order"
         );
         assert_eq!(
-            chosen_b,
-            Some(round_three.addr),
-            "later round must win regardless of slice order (reversed)"
+            ranked_b,
+            vec![round_three.addr, round_zero.addr],
+            "later round must come first regardless of input order (reversed)"
         );
     }
 
     #[test]
     fn rank_referrers_tiebreaks_round_with_trust() {
-        // Same round, different trust. Higher trust must win.
+        // Same round, different trust. Higher-trust comes first.
         let low_trust = make_referrer(0x55, 1, 2);
         let high_trust = make_referrer(0xAA, 2, 2);
         let trust_for = |peer_id: &PeerId| -> f64 {
@@ -3273,33 +3289,56 @@ mod tests {
             }
         };
 
-        let chosen = DhtNetworkManager::rank_referrers(Some(&[low_trust, high_trust]), trust_for);
+        let ranked = DhtNetworkManager::rank_referrers(Some(&[low_trust, high_trust]), trust_for);
         assert_eq!(
-            chosen,
-            Some(high_trust.addr),
-            "higher trust must win when rounds tie"
+            ranked,
+            vec![high_trust.addr, low_trust.addr],
+            "higher trust must come first when rounds tie"
         );
     }
 
     #[test]
     fn rank_referrers_tiebreaks_round_and_trust_with_peer_id_byte_zero() {
         // Same round, same (neutral) trust. The referrer with the larger
-        // byte-0 must win deterministically.
+        // byte-0 comes first deterministically.
         let small = make_referrer(0x01, 1, 1);
         let large = make_referrer(0xF0, 2, 1);
 
-        let chosen_a = DhtNetworkManager::rank_referrers(Some(&[small, large]), neutral_trust);
-        let chosen_b = DhtNetworkManager::rank_referrers(Some(&[large, small]), neutral_trust);
+        let ranked_a = DhtNetworkManager::rank_referrers(Some(&[small, large]), neutral_trust);
+        let ranked_b = DhtNetworkManager::rank_referrers(Some(&[large, small]), neutral_trust);
 
         assert_eq!(
-            chosen_a,
-            Some(large.addr),
-            "larger peer_id byte 0 must win the tertiary tiebreak"
+            ranked_a,
+            vec![large.addr, small.addr],
+            "larger peer_id byte 0 must come first via tertiary tiebreak"
         );
         assert_eq!(
-            chosen_b,
-            Some(large.addr),
+            ranked_b,
+            vec![large.addr, small.addr],
             "tiebreak must be order-independent"
+        );
+    }
+
+    #[test]
+    fn rank_referrers_full_list_is_sorted_best_first() {
+        // Mixed rounds and trust scores: verify the entire list is sorted
+        // correctly, not just the head.
+        let r0 = make_referrer(0x01, 1, 0); // round 0
+        let r1 = make_referrer(0x02, 2, 1); // round 1
+        let r2_low = make_referrer(0x03, 3, 2); // round 2, low trust
+        let r2_high = make_referrer(0x04, 4, 2); // round 2, high trust
+        let trust_for = |peer_id: &PeerId| -> f64 {
+            if peer_id.to_bytes()[0] == 0x04 {
+                0.9
+            } else {
+                0.5
+            }
+        };
+        let ranked = DhtNetworkManager::rank_referrers(Some(&[r0, r1, r2_low, r2_high]), trust_for);
+        assert_eq!(
+            ranked,
+            vec![r2_high.addr, r2_low.addr, r1.addr, r0.addr],
+            "full list must be sorted (round DESC, trust DESC) end-to-end"
         );
     }
 

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -97,6 +97,20 @@ const BUCKET_REFRESH_INTERVAL: Duration = Duration::from_secs(600); // 10 minute
 /// Routing table size below which automatic re-bootstrap is triggered.
 const AUTO_REBOOTSTRAP_THRESHOLD: usize = 3;
 
+/// Maximum number of distinct referrers stored per discovered peer during an
+/// iterative DHT lookup. The list is ranked at dial-time to pick the best
+/// hole-punch coordinator candidate (see [`DhtNetworkManager::select_best_referrer`]).
+///
+/// Bound exists to cap per-lookup memory; in practice 4 is more than enough
+/// because Kademlia typically converges before any peer is referred more than
+/// 2-3 times within a single lookup. Compile-time asserted >= 2 because
+/// collecting only one referrer would defeat the purpose of ranking.
+const MAX_REFERRERS_PER_TARGET: usize = 4;
+const _: () = assert!(
+    MAX_REFERRERS_PER_TARGET >= 2,
+    "MAX_REFERRERS_PER_TARGET must be >= 2 for ranking to matter"
+);
+
 /// Minimum time between consecutive auto re-bootstrap attempts.
 const REBOOTSTRAP_COOLDOWN: Duration = Duration::from_secs(300); // 5 minutes
 
@@ -261,6 +275,29 @@ pub struct DhtNetworkManager {
     /// Timestamp of the last automatic re-bootstrap attempt, guarded by a
     /// cooldown to avoid hammering bootstrap peers during transient churn.
     last_rebootstrap: tokio::sync::Mutex<Option<Instant>>,
+}
+
+/// One observation of a peer being referred during an iterative DHT lookup.
+///
+/// When peer R answers a `FindNode` query and returns peer T, R becomes a
+/// referrer for T: R has T in its routing table and presumably has (or
+/// recently had) a connection to T, making R a good candidate to coordinate
+/// hole-punching to T.
+///
+/// During a single iterative lookup we collect up to
+/// [`MAX_REFERRERS_PER_TARGET`] referrers per discovered peer and rank them
+/// at dial-time via [`DhtNetworkManager::select_best_referrer`].
+#[derive(Clone, Copy, Debug)]
+struct ReferrerInfo {
+    /// Peer ID of the referring node (used for trust score lookup and tiebreak).
+    peer_id: PeerId,
+    /// Dialable socket address of the referring node — what we hand to
+    /// saorsa-transport as the preferred coordinator.
+    addr: SocketAddr,
+    /// 0-based iteration round in which this referral was observed.
+    /// Higher round = closer to the lookup target in XOR space = more likely
+    /// to actually have a live connection to the target.
+    round_observed: u32,
 }
 
 /// DHT operation context
@@ -714,29 +751,74 @@ impl DhtNetworkManager {
         min + jitter
     }
 
+    /// Return `[0, len)` in a per-call shuffled order using a Fisher-Yates
+    /// pass driven by [`PeerId::random()`] entropy.
+    ///
+    /// Used to randomise the order in which we visit a fixed input slice
+    /// (e.g. the bootstrap peer list in [`Self::bootstrap_from_peers`]) so
+    /// that across a fleet of nodes the load on any individual element of
+    /// the input is statistically uniform rather than concentrated on
+    /// `input[0]`.
+    ///
+    /// For `len <= 1` this returns a trivial unshuffled vector — there is
+    /// nothing to randomise. The entropy source is not cryptographically
+    /// secure but is more than sufficient for load distribution.
+    fn shuffled_indices(len: usize) -> Vec<usize> {
+        let mut indices: Vec<usize> = (0..len).collect();
+        if len <= 1 {
+            return indices;
+        }
+        // Build a 32-byte entropy buffer per call. PeerId::random() gives us
+        // 32 bytes, which is enough for ~32 swap decisions — well above the
+        // bootstrap-list sizes we expect (typically 2-5).
+        let entropy_owner = PeerId::random();
+        let entropy = entropy_owner.to_bytes();
+        let entropy_len = entropy.len();
+        // Fisher-Yates: for i from len-1 down to 1, swap indices[i] with
+        // indices[j] where j is uniform in [0, i].
+        for i in (1..len).rev() {
+            // Use a single byte from the entropy buffer as the random source
+            // for this swap. Indexing wraps if `len` exceeds the entropy
+            // buffer size, which is fine for the small lists we shuffle.
+            let byte = entropy[(len - 1 - i) % entropy_len] as usize;
+            let j = byte % (i + 1);
+            indices.swap(i, j);
+        }
+        indices
+    }
+
     /// Perform DHT peer discovery from already-connected bootstrap peers.
     ///
     /// Sends FIND_NODE(self) to each peer using the DHT postcard protocol,
     /// then dials any newly-discovered candidates. Returns the total number
     /// of new peers discovered.
+    ///
+    /// **Coordinator selection note**: previously this function pinned the
+    /// bootstrap peer's socket address as the preferred hole-punch
+    /// coordinator for every peer it returned. That concentrated load on
+    /// the small handful of bootstrap nodes (since every cold-starting node
+    /// queried the same ones). The pinning is removed: subsequent
+    /// iterative DHT lookups via `find_closest_nodes_network` collect
+    /// referrers across multiple rounds and rank them via
+    /// [`Self::select_best_referrer`], naturally de-preferring round-0
+    /// bootstrap referrers as the routing table grows.
+    ///
+    /// **Iteration order**: bootstrap peers are visited in a per-call
+    /// shuffled order (PeerId-derived entropy) so that in a fleet of N
+    /// nodes with M bootstrap peers, each bootstrap is the "first asked"
+    /// by ~N/M peers rather than all N hitting `peers[0]`.
     pub async fn bootstrap_from_peers(&self, peers: &[PeerId]) -> Result<usize> {
         let key = *self.config.peer_id.as_bytes();
         let mut seen = HashSet::new();
-        for peer_id in peers {
-            // Resolve the bootstrap peer's socket address so we can set it as
-            // the preferred coordinator for any peers it returns. The bootstrap
-            // peer has connections to those peers, making it a good relay.
-            let bootstrap_addr = self
-                .peer_addresses_for_dial(peer_id)
-                .await
-                .first()
-                .and_then(|a| a.dialable_socket_addr());
-
-            // The bootstrap peer is the natural NAT-traversal referrer for
-            // every node it returns: it has a live connection to us (we just
-            // queried it) and presumably also to the nodes it tells us about.
-            // Passing its socket address as the preferred coordinator lets
-            // hole-punch PUNCH_ME_NOW be relayed through it.
+        let visit_order = Self::shuffled_indices(peers.len());
+        for &idx in &visit_order {
+            // `shuffled_indices(peers.len())` is guaranteed to return values
+            // in `[0, peers.len())`, so this `.get()` always succeeds. We
+            // use `.get()` rather than direct indexing to keep this code
+            // panic-free even if the contract changes in future.
+            let Some(peer_id) = peers.get(idx) else {
+                continue;
+            };
             let op = DhtNetworkOperation::FindNode { key };
             match self.send_dht_request(peer_id, op, None).await {
                 Ok(DhtNetworkResult::NodesFound { nodes, .. }) => {
@@ -749,7 +831,12 @@ impl DhtNetworkManager {
                             dialable.len()
                         );
                         if seen.insert(node.peer_id) && !dialable.is_empty() {
-                            self.dial_addresses(&node.peer_id, &node.addresses, bootstrap_addr)
+                            // Pass `None` as referrer: the bootstrap peer is no
+                            // longer hard-pinned as the hole-punch coordinator
+                            // for these freshly-discovered peers. The next
+                            // iterative lookup will populate proper referrers
+                            // via the round-aware ranking.
+                            self.dial_addresses(&node.peer_id, &node.addresses, None)
                                 .await;
                         }
                     }
@@ -971,12 +1058,18 @@ impl DhtNetworkManager {
         let target_key = DhtKey::from_bytes(*key);
         let mut queried_nodes: HashSet<PeerId> = HashSet::new();
         let mut best_nodes: Vec<DHTNode> = Vec::new();
-        // Track which peer referred us to each discovered peer. When node A
-        // responds to FindNode with node B, node A has B in its routing table
-        // and has a connection to B. We use A as the preferred coordinator
-        // when hole-punching to B.
-        let mut referrers: std::collections::HashMap<PeerId, std::net::SocketAddr> =
-            std::collections::HashMap::new();
+        // Track every peer that referred us to each discovered peer. When
+        // node R responds to FindNode with node T, R has T in its routing
+        // table and presumably has a connection to T — making R a candidate
+        // hole-punch coordinator for T.
+        //
+        // We collect up to MAX_REFERRERS_PER_TARGET observations and rank
+        // them at dial-time via `select_best_referrer`. The ranking prefers
+        // referrers seen in later iteration rounds (closer to the target in
+        // XOR space) over earlier rounds, which naturally de-prefers the
+        // round-0 bootstrap referrers without any explicit bootstrap
+        // tagging.
+        let mut referrers: HashMap<PeerId, Vec<ReferrerInfo>> = HashMap::new();
 
         // Kademlia correctness: the local node must compete on distance in the
         // final K-closest result, but we must never send an RPC to ourselves.
@@ -1050,7 +1143,12 @@ impl DhtNetworkManager {
                 .map(|node| {
                     let peer_id = node.peer_id;
                     let addresses = node.addresses.clone();
-                    let referrer = referrers.get(&peer_id).copied();
+                    // Pick the best-ranked referrer for this target as the
+                    // hole-punch coordinator hint. PR #3 will plumb the full
+                    // ranked list down to saorsa-transport; for now we hand
+                    // over a single best choice.
+                    let referrer =
+                        self.select_best_referrer(referrers.get(&peer_id).map(Vec::as_slice));
                     let op = DhtNetworkOperation::FindNode { key: *key };
                     async move {
                         // Try every dialable address, not just the first.
@@ -1081,7 +1179,7 @@ impl DhtNetworkManager {
                             best_nodes.push(queried_node.clone());
                         }
 
-                        // Track this peer as the referrer for all nodes it returned.
+                        // Track this peer as a referrer for all nodes it returned.
                         let referrer_addr = batch
                             .iter()
                             .find(|n| n.peer_id == peer_id)
@@ -1099,18 +1197,28 @@ impl DhtNetworkManager {
                             {
                                 continue;
                             }
-                            // Record the referrer (first referrer wins)
-                            if let Some(ref_addr) = referrer_addr
-                                && let std::collections::hash_map::Entry::Vacant(e) =
-                                    referrers.entry(node.peer_id)
-                            {
-                                info!(
-                                    "find_closest_nodes_network: peer {} referred by {} ({})",
-                                    hex::encode(&node.peer_id.to_bytes()[..8]),
-                                    hex::encode(&peer_id.to_bytes()[..8]),
-                                    ref_addr
-                                );
-                                e.insert(ref_addr);
+                            // Append this referrer to the candidate list for
+                            // the discovered peer. We keep up to
+                            // MAX_REFERRERS_PER_TARGET observations and rank
+                            // them at dial-time, so we no longer pin the
+                            // first-seen referrer.
+                            if let Some(ref_addr) = referrer_addr {
+                                let entry = referrers.entry(node.peer_id).or_default();
+                                let already_present = entry.iter().any(|r| r.peer_id == peer_id);
+                                if !already_present && entry.len() < MAX_REFERRERS_PER_TARGET {
+                                    info!(
+                                        "find_closest_nodes_network: peer {} referred by {} ({}) round {}",
+                                        hex::encode(&node.peer_id.to_bytes()[..8]),
+                                        hex::encode(&peer_id.to_bytes()[..8]),
+                                        ref_addr,
+                                        iteration,
+                                    );
+                                    entry.push(ReferrerInfo {
+                                        peer_id,
+                                        addr: ref_addr,
+                                        round_observed: iteration as u32,
+                                    });
+                                }
                             }
                             let dist = node.peer_id.distance(&target_key);
                             let cand_key = (dist, node.peer_id);
@@ -1342,6 +1450,73 @@ impl DhtNetworkManager {
     /// Return the first dialable address from a list of [`MultiAddr`] values.
     fn first_dialable_address(addresses: &[MultiAddr]) -> Option<MultiAddr> {
         Self::dialable_addresses(addresses).into_iter().next()
+    }
+
+    /// Pick the best hole-punch coordinator candidate from a slice of
+    /// referrer observations, using this manager's [`TrustEngine`] (or
+    /// default neutral trust when none is configured).
+    ///
+    /// Thin wrapper around the pure function [`Self::rank_referrers`] —
+    /// see that for the actual ranking logic.
+    fn select_best_referrer(&self, referrers: Option<&[ReferrerInfo]>) -> Option<SocketAddr> {
+        let trust_for = |peer_id: &PeerId| -> f64 {
+            self.trust_engine
+                .as_ref()
+                .map(|engine| engine.score(peer_id))
+                .unwrap_or(DEFAULT_NEUTRAL_TRUST)
+        };
+        Self::rank_referrers(referrers, trust_for)
+    }
+
+    /// Pure ranking function that picks the best referrer from a slice.
+    ///
+    /// Ranking (highest priority first):
+    /// 1. **`round_observed` DESC** — referrers seen in later iteration
+    ///    rounds are by XOR-distance closer to the lookup target and so
+    ///    much more likely to actually have a live connection to it. This
+    ///    naturally de-prefers round-0 bootstrap referrers without any
+    ///    explicit bootstrap tagging, which is exactly the load-shedding
+    ///    behaviour we want.
+    /// 2. **trust score DESC** — when two referrers were observed in the
+    ///    same round, prefer the one with the higher trust score returned
+    ///    by `trust_for`.
+    /// 3. **deterministic hash tiebreak** — when round and trust both tie,
+    ///    keep the referrer whose `peer_id` byte 0 is **larger**. Using a
+    ///    pure peer-id ordering instead of a random RNG keeps the choice
+    ///    reproducible across runs (useful for tests) while still
+    ///    spreading load across coordinators because different targets
+    ///    see different referrer sets.
+    ///
+    /// Returns `None` when the slice is empty or `None` itself, so the
+    /// caller can pass-through directly to APIs that take an
+    /// `Option<SocketAddr>` referrer hint.
+    ///
+    /// Pure function (no `&self`) so it can be unit-tested without
+    /// constructing a full [`DhtNetworkManager`].
+    fn rank_referrers(
+        referrers: Option<&[ReferrerInfo]>,
+        trust_for: impl Fn(&PeerId) -> f64,
+    ) -> Option<SocketAddr> {
+        let list = referrers?;
+        if list.is_empty() {
+            return None;
+        }
+
+        list.iter()
+            .max_by(|a, b| {
+                // Primary: higher round wins.
+                a.round_observed
+                    .cmp(&b.round_observed)
+                    // Secondary: higher trust wins (total_cmp sidesteps NaN
+                    // issues — score is bounded but total_cmp is safe
+                    // regardless).
+                    .then_with(|| trust_for(&a.peer_id).total_cmp(&trust_for(&b.peer_id)))
+                    // Tertiary: deterministic tiebreak by peer_id byte 0.
+                    // `max_by` keeps the larger one — arbitrary but
+                    // reproducible.
+                    .then_with(|| a.peer_id.to_bytes()[0].cmp(&b.peer_id.to_bytes()[0]))
+            })
+            .map(|r| r.addr)
     }
 
     /// Try dialing each dialable address in `addresses` in order until one
@@ -2943,6 +3118,170 @@ mod tests {
         assert!(
             matches!(decoded.payload, DhtNetworkOperation::Ping),
             "response should echo the request's Ping payload"
+        );
+    }
+
+    // ---- Tier 1.2 + 1.4: hole-punch coordinator selection ----
+
+    /// Helper: build a [`ReferrerInfo`] with a deterministic peer_id whose
+    /// byte 0 is set to `tag`. The remaining bytes come from
+    /// [`PeerId::random()`] so the IDs collide on byte 0 but stay
+    /// otherwise unique.
+    fn make_referrer(tag: u8, addr_octet: u8, round: u32) -> ReferrerInfo {
+        let mut bytes = *PeerId::random().to_bytes();
+        bytes[0] = tag;
+        ReferrerInfo {
+            peer_id: PeerId::from_bytes(bytes),
+            addr: SocketAddr::from(([10, 0, 0, addr_octet], 9000)),
+            round_observed: round,
+        }
+    }
+
+    fn neutral_trust(_: &PeerId) -> f64 {
+        DEFAULT_NEUTRAL_TRUST
+    }
+
+    #[test]
+    fn rank_referrers_returns_none_for_empty_or_missing() {
+        assert_eq!(
+            DhtNetworkManager::rank_referrers(None, neutral_trust),
+            None,
+            "None input must yield None"
+        );
+        assert_eq!(
+            DhtNetworkManager::rank_referrers(Some(&[]), neutral_trust),
+            None,
+            "empty slice must yield None"
+        );
+    }
+
+    #[test]
+    fn rank_referrers_single_referrer_returned() {
+        let only = make_referrer(0x01, 1, 0);
+        let chosen = DhtNetworkManager::rank_referrers(Some(&[only]), neutral_trust);
+        assert_eq!(
+            chosen,
+            Some(only.addr),
+            "single-referrer slice must return that referrer's addr"
+        );
+    }
+
+    #[test]
+    fn rank_referrers_prefers_later_round_over_earlier() {
+        // Round 0 (bootstrap-equivalent) vs round 3 (deep iteration).
+        // Round 3 must win regardless of order or trust.
+        let round_zero = make_referrer(0xFF, 1, 0);
+        let round_three = make_referrer(0x01, 2, 3);
+
+        let chosen_a =
+            DhtNetworkManager::rank_referrers(Some(&[round_zero, round_three]), neutral_trust);
+        let chosen_b =
+            DhtNetworkManager::rank_referrers(Some(&[round_three, round_zero]), neutral_trust);
+
+        assert_eq!(
+            chosen_a,
+            Some(round_three.addr),
+            "later round must win regardless of slice order"
+        );
+        assert_eq!(
+            chosen_b,
+            Some(round_three.addr),
+            "later round must win regardless of slice order (reversed)"
+        );
+    }
+
+    #[test]
+    fn rank_referrers_tiebreaks_round_with_trust() {
+        // Same round, different trust. Higher trust must win.
+        let low_trust = make_referrer(0x55, 1, 2);
+        let high_trust = make_referrer(0xAA, 2, 2);
+        let trust_for = |peer_id: &PeerId| -> f64 {
+            if peer_id.to_bytes()[0] == 0xAA {
+                0.95
+            } else {
+                0.10
+            }
+        };
+
+        let chosen = DhtNetworkManager::rank_referrers(Some(&[low_trust, high_trust]), trust_for);
+        assert_eq!(
+            chosen,
+            Some(high_trust.addr),
+            "higher trust must win when rounds tie"
+        );
+    }
+
+    #[test]
+    fn rank_referrers_tiebreaks_round_and_trust_with_peer_id_byte_zero() {
+        // Same round, same (neutral) trust. The referrer with the larger
+        // byte-0 must win deterministically.
+        let small = make_referrer(0x01, 1, 1);
+        let large = make_referrer(0xF0, 2, 1);
+
+        let chosen_a = DhtNetworkManager::rank_referrers(Some(&[small, large]), neutral_trust);
+        let chosen_b = DhtNetworkManager::rank_referrers(Some(&[large, small]), neutral_trust);
+
+        assert_eq!(
+            chosen_a,
+            Some(large.addr),
+            "larger peer_id byte 0 must win the tertiary tiebreak"
+        );
+        assert_eq!(
+            chosen_b,
+            Some(large.addr),
+            "tiebreak must be order-independent"
+        );
+    }
+
+    #[test]
+    fn shuffled_indices_empty_and_singleton_are_identity() {
+        assert_eq!(
+            DhtNetworkManager::shuffled_indices(0),
+            Vec::<usize>::new(),
+            "len 0 must yield an empty vec"
+        );
+        assert_eq!(
+            DhtNetworkManager::shuffled_indices(1),
+            vec![0],
+            "len 1 must yield [0] unchanged"
+        );
+    }
+
+    #[test]
+    fn shuffled_indices_returns_valid_permutation() {
+        // For a wider input, every call must produce a permutation of
+        // [0, len) — same set, possibly different order.
+        const LEN: usize = 10;
+        let result = DhtNetworkManager::shuffled_indices(LEN);
+        assert_eq!(result.len(), LEN, "permutation must have the right length");
+        let mut sorted = result.clone();
+        sorted.sort_unstable();
+        let expected: Vec<usize> = (0..LEN).collect();
+        assert_eq!(
+            sorted, expected,
+            "shuffled output must be a permutation of [0, len)"
+        );
+    }
+
+    #[test]
+    fn shuffled_indices_distributes_across_calls() {
+        // Run many shuffles and assert the position-0 element is not
+        // always the same. With true randomisation across calls, the
+        // probability that 100 calls all return position-0 == 0 for a
+        // 5-element shuffle is negligible.
+        const TRIALS: usize = 100;
+        const LEN: usize = 5;
+        let mut first_positions = std::collections::HashSet::new();
+        for _ in 0..TRIALS {
+            let result = DhtNetworkManager::shuffled_indices(LEN);
+            first_positions.insert(result[0]);
+            if first_positions.len() >= 2 {
+                return; // pass — we observed at least two distinct positions
+            }
+        }
+        panic!(
+            "shuffled_indices(5) returned the same first element across {TRIALS} \
+             calls — entropy source is broken"
         );
     }
 }

--- a/src/identity/node_identity.rs
+++ b/src/identity/node_identity.rs
@@ -185,6 +185,17 @@ impl NodeIdentity {
         self.secret_key.as_bytes()
     }
 
+    /// Clone the underlying ML-DSA-65 keypair.
+    ///
+    /// Used to install the node's identity as the transport's TLS keypair so
+    /// that the SPKI carried in the QUIC handshake authenticates the same
+    /// peer ID that signs application messages. Without this, the
+    /// transport-level and application-level identities are distinct and
+    /// must be reconciled by a wire-level handshake.
+    pub fn clone_keypair(&self) -> (MlDsaPublicKey, MlDsaSecretKey) {
+        (self.public_key.clone(), self.secret_key.clone())
+    }
+
     /// Sign a message
     pub fn sign(&self, message: &[u8]) -> Result<MlDsaSignature> {
         crate::quantum_crypto::ml_dsa_sign(&self.secret_key, message).map_err(|e| {

--- a/src/network.rs
+++ b/src/network.rs
@@ -132,17 +132,17 @@ const DEFAULT_CONNECTION_TIMEOUT_SECS: u64 = 25;
 /// Number of cached bootstrap peers to retrieve.
 const BOOTSTRAP_PEER_BATCH_SIZE: usize = 20;
 
-/// Timeout in seconds for waiting on a bootstrap peer's identity exchange.
+/// Defensive upper bound on the wait for a bootstrap peer's
+/// TLS-authenticated identity to be registered after `connect_peer`.
 ///
-/// Identity exchange is two RTTs over a freshly-handshaken QUIC connection
-/// plus an ML-DSA-65 signature verification. On a LAN this completes in
-/// well under a second; on congested cellular or cross-region links it can
-/// blow past 5s with retransmits. The previous 5s default fired
-/// spuriously on slow networks during testnet validation, forcing
-/// reconnect loops that masqueraded as NAT traversal failures, so we
-/// budget enough headroom for two QUIC handshake retries on a high-latency
-/// link.
-const BOOTSTRAP_IDENTITY_TIMEOUT_SECS: u64 = 15;
+/// Since identity is now derived synchronously from the TLS-handshake
+/// SPKI inside the connection lifecycle monitor, the typical wait is a
+/// scheduler tick. This timeout only fires if the lifecycle monitor is
+/// wedged (e.g. broadcast lag) or the peer presented an SPKI that fails
+/// the saorsa-pqc parse — both cases that should be loud test failures
+/// rather than silent stalls. 2 s is generous and still well below any
+/// outer caller timeout, so this constant exists purely as a safety net.
+const BOOTSTRAP_IDENTITY_TIMEOUT_SECS: u64 = 2;
 
 /// Serde helper — returns `true`.
 const fn default_true() -> bool {

--- a/src/network.rs
+++ b/src/network.rs
@@ -235,7 +235,7 @@ pub struct NodeConfig {
     ///
     /// Controls whether peers with low trust scores are eligible for
     /// swap-out from the routing table when better candidates arrive. Use
-    /// [`NodeConfigBuilder::trust_enforcement`] for a simple on/off toggle.
+    /// `NodeConfigBuilder::trust_enforcement` for a simple on/off toggle.
     ///
     /// Default: enabled with a swap threshold of 0.35.
     #[serde(default)]
@@ -741,7 +741,7 @@ const QUIC_TEARDOWN_GRACE: Duration = Duration::from_millis(100);
 /// - Handle network events and peer lifecycle
 ///
 /// Transport concerns (connections, messaging, events) are delegated to
-/// [`TransportHandle`](crate::transport_handle::TransportHandle).
+/// `TransportHandle`.
 pub struct P2PNode {
     /// Node configuration
     config: NodeConfig,
@@ -978,7 +978,7 @@ impl P2PNode {
     ///
     /// # Returns
     ///
-    /// A [`PeerResponse`] on success, or an error on timeout / connection failure.
+    /// A `PeerResponse` on success, or an error on timeout / connection failure.
     ///
     /// # Example
     ///

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -39,6 +39,7 @@
 //! automatically enables saorsa-transport's prometheus metrics collection.
 
 use crate::error::{GeoRejectionError, GeographicConfig};
+use crate::quantum_crypto::saorsa_transport_integration::{MlDsaPublicKey, MlDsaSecretKey};
 use crate::transport::observed_address_cache::ObservedAddressCache;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
@@ -188,16 +189,30 @@ impl P2PNetworkNode<P2pLinkTransport> {
         max_connections: usize,
         max_msg_size: Option<usize>,
     ) -> Result<Self> {
-        Self::new_with_options(bind_addr, max_connections, max_msg_size, false).await
+        Self::new_with_options(bind_addr, max_connections, max_msg_size, false, None).await
     }
 
     /// Create a new P2P network node with full control over connection
-    /// limits, message size, and loopback address acceptance.
+    /// limits, message size, loopback acceptance, and TLS keypair injection.
+    ///
+    /// When `keypair` is `Some`, the supplied ML-DSA-65 keypair is installed
+    /// as the transport's TLS identity, so the SPKI carried in every QUIC
+    /// handshake authenticates the same peer ID that signs application
+    /// messages. saorsa-core threads its `NodeIdentity` keys through here so
+    /// the lifecycle monitor can derive the app-level peer ID directly from
+    /// the TLS-handshake bytes — no separate identity-announce protocol is
+    /// required.
+    ///
+    /// When `keypair` is `None`, saorsa-transport generates a fresh keypair
+    /// internally; the resulting peer ID will not match anything stored in
+    /// saorsa-core, so this branch is only suitable for tests that don't
+    /// cross the identity boundary.
     pub async fn new_with_options(
         bind_addr: SocketAddr,
         max_connections: usize,
         max_msg_size: Option<usize>,
         allow_loopback: bool,
+        keypair: Option<(MlDsaPublicKey, MlDsaSecretKey)>,
     ) -> Result<Self> {
         let mut builder = P2pConfig::builder()
             .bind_addr(bind_addr)
@@ -212,6 +227,9 @@ impl P2PNetworkNode<P2pLinkTransport> {
                 allow_loopback: true,
                 ..NatConfig::default()
             });
+        }
+        if let Some((public_key, secret_key)) = keypair {
+            builder = builder.keypair(public_key, secret_key);
         }
         let config = builder
             .build()
@@ -1075,17 +1093,22 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         max_connections: usize,
         max_msg_size: Option<usize>,
     ) -> Result<Self> {
-        Self::new_with_options(v6_addr, v4_addr, max_connections, max_msg_size, false).await
+        Self::new_with_options(v6_addr, v4_addr, max_connections, max_msg_size, false, None).await
     }
 
     /// Create dual nodes with full control over connection limits, message
-    /// size, and loopback address acceptance.
+    /// size, loopback acceptance, and TLS keypair injection.
+    ///
+    /// When `keypair` is `Some`, both stacks share the same ML-DSA-65
+    /// identity, so the SPKI carried in every QUIC handshake authenticates
+    /// the same peer ID regardless of which stack the connection arrived on.
     pub async fn new_with_options(
         v6_addr: Option<SocketAddr>,
         v4_addr: Option<SocketAddr>,
         max_connections: usize,
         max_msg_size: Option<usize>,
         allow_loopback: bool,
+        keypair: Option<(MlDsaPublicKey, MlDsaSecretKey)>,
     ) -> Result<Self> {
         let v6 = if let Some(addr) = v6_addr {
             Some(
@@ -1094,6 +1117,7 @@ impl DualStackNetworkNode<P2pLinkTransport> {
                     max_connections,
                     max_msg_size,
                     allow_loopback,
+                    keypair.clone(),
                 )
                 .await?,
             )
@@ -1106,6 +1130,7 @@ impl DualStackNetworkNode<P2pLinkTransport> {
                 max_connections,
                 max_msg_size,
                 allow_loopback,
+                keypair.clone(),
             )
             .await
             {

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -856,18 +856,30 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         }
     }
 
-    /// Set a preferred coordinator for hole-punching to a specific target.
-    /// The preferred coordinator is a peer that referred us to the target
-    /// during a DHT lookup, so it has a connection to the target.
-    pub async fn set_hole_punch_preferred_coordinator(
+    /// Set an ordered list of preferred coordinators for hole-punching to a
+    /// specific target.
+    ///
+    /// The list is iterated front to back at hole-punch time: every
+    /// coordinator except the last gets a short per-attempt timeout
+    /// (~1.5s) so a busy or unreachable referrer is abandoned quickly,
+    /// and the final coordinator gets the strategy's full hole-punch
+    /// timeout to give it time to actually complete the punch.
+    ///
+    /// The caller (`DhtNetworkManager::dial_candidate`) is expected to
+    /// rank the list best-first using DHT signals — round observed,
+    /// trust score, etc. — via [`DhtNetworkManager::rank_referrers`].
+    ///
+    /// Empty `coordinators` removes any preferred coordinators for
+    /// `target`.
+    pub async fn set_hole_punch_preferred_coordinators(
         &self,
         target: SocketAddr,
-        coordinator: SocketAddr,
+        coordinators: Vec<SocketAddr>,
     ) {
         for node in [&self.v6, &self.v4].into_iter().flatten() {
             node.transport
                 .endpoint()
-                .set_hole_punch_preferred_coordinator(target, coordinator)
+                .set_hole_punch_preferred_coordinators(target, coordinators.clone())
                 .await;
         }
     }

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -1696,16 +1696,34 @@ impl TransportHandle {
                     // populated by the lifecycle monitor at TLS-handshake
                     // time, so we don't touch it here. Skip echoes of our
                     // own identity.
+                    //
+                    // When the user-agent is learned for the first time (or
+                    // changes), re-emit `PeerConnected` so subscribers that
+                    // branch on the user-agent — notably the DHT bridge,
+                    // which uses `is_dht_participant` to gate routing-table
+                    // admission — can re-classify. The original handshake-
+                    // time `PeerConnected` is emitted with an empty
+                    // user-agent because TLS doesn't carry one; this is the
+                    // follow-up that delivers the application-level
+                    // capability bits within one signed-message round trip.
                     if let Some(ref app_id) = authenticated_node_id
                         && *app_id != self_peer_id
                         && !peer_user_agent.is_empty()
                     {
                         let mut uas = peer_user_agents.write().await;
-                        match uas.get(app_id) {
-                            Some(existing) if existing == &peer_user_agent => {}
-                            _ => {
-                                uas.insert(*app_id, peer_user_agent);
-                            }
+                        let changed = match uas.get(app_id) {
+                            Some(existing) => existing != &peer_user_agent,
+                            None => true,
+                        };
+                        if changed {
+                            uas.insert(*app_id, peer_user_agent.clone());
+                            // Drop the lock before emitting so subscribers
+                            // re-entering the registry don't deadlock.
+                            drop(uas);
+                            broadcast_event(
+                                &event_tx,
+                                P2PEvent::PeerConnected(*app_id, peer_user_agent),
+                            );
                         }
                     }
 

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -21,17 +21,19 @@ use crate::MultiAddr;
 use crate::PeerId;
 use crate::bgp_geo_provider::BgpGeoProvider;
 use crate::error::{NetworkError, P2PError, P2pResult as Result};
-use crate::identity::node_identity::NodeIdentity;
+use crate::identity::node_identity::{NodeIdentity, peer_id_from_public_key};
 use crate::network::{
     ConnectionStatus, MAX_ACTIVE_REQUESTS, MAX_REQUEST_TIMEOUT, MESSAGE_RECV_CHANNEL_CAPACITY,
     NetworkSender, P2PEvent, ParsedMessage, PeerInfo, PeerResponse, PendingRequest,
     RequestResponseEnvelope, WireMessage, broadcast_event, normalize_wildcard_to_loopback,
     parse_protocol_message, register_new_channel,
 };
+use crate::quantum_crypto::saorsa_transport_integration::MlDsaPublicKey;
 use crate::transport::observed_address_cache::ObservedAddressCache;
 use crate::transport::saorsa_transport_adapter::{ConnectionEvent, DualStackNetworkNode};
 use crate::validation::{RateLimitConfig, RateLimiter};
 
+use saorsa_transport::crypto::raw_public_keys::extract_public_key_from_spki;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
@@ -39,7 +41,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
-use tokio::sync::{RwLock, broadcast};
+use tokio::sync::{Notify, RwLock, broadcast};
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -51,10 +53,6 @@ const TEST_MAX_REQUESTS: u32 = 100;
 const TEST_BURST_SIZE: u32 = 100;
 const TEST_RATE_LIMIT_WINDOW_SECS: u64 = 1;
 const TEST_CONNECTION_TIMEOUT_SECS: u64 = 30;
-
-/// Internal protocol for automatic identity announcement on connect.
-/// Filtered from P2PEvent::Message emission — not visible to applications.
-const IDENTITY_ANNOUNCE_PROTOCOL: &str = "/saorsa/identity/1.0";
 
 /// Configuration for transport initialization, derived from [`NodeConfig`](crate::network::NodeConfig).
 pub struct TransportConfig {
@@ -150,14 +148,31 @@ pub struct TransportHandle {
     /// Maps app-level [`PeerId`] → set of channel IDs (QUIC, Bluetooth, …).
     ///
     /// A single peer may communicate over multiple channels simultaneously.
+    /// Populated synchronously when a `ConnectionEvent::Established` arrives —
+    /// the peer's identity is derived from the TLS-authenticated SPKI carried
+    /// in the event, so the entry is ready before any application bytes flow.
     peer_to_channel: Arc<RwLock<HashMap<PeerId, HashSet<String>>>>,
-    /// Reverse index: channel ID → set of app-level [`PeerId`]s on that channel.
-    channel_to_peers: Arc<RwLock<HashMap<String, HashSet<PeerId>>>>,
-    /// Maps app-level [`PeerId`] → user agent string received during authentication.
+    /// Reverse index: channel ID → authenticated app-level [`PeerId`].
     ///
-    /// Stored so that late subscribers (e.g. DHT manager reconciliation) can look
-    /// up a peer's mode without re-receiving the `PeerConnected` event.
+    /// One channel maps to exactly one peer because TLS authenticates a single
+    /// identity per QUIC connection. The previous `HashSet<PeerId>` shape was
+    /// a vestige of the now-retired identity-announce protocol.
+    channel_to_peer: Arc<RwLock<HashMap<String, PeerId>>>,
+    /// Maps app-level [`PeerId`] → user agent string received from a signed
+    /// application message.
+    ///
+    /// Lazy: TLS doesn't carry a user-agent string, so this map stays empty
+    /// until the first signed wire message from the peer is parsed. Late
+    /// subscribers fall back to "node/unknown" until then.
     peer_user_agents: Arc<RwLock<HashMap<PeerId, String>>>,
+    /// Wakes [`Self::wait_for_peer_identity`] callers whenever a new
+    /// `channel_to_peer` entry is inserted.
+    ///
+    /// `notify_waiters` is broadcast on every insert; callers re-check the map
+    /// after each wake. Inserts happen at the moment a TLS-authenticated
+    /// connection is established, so a waiter typically returns within a few
+    /// scheduler ticks of the underlying QUIC handshake completing.
+    identity_notify: Arc<Notify>,
 }
 
 // ============================================================================
@@ -188,6 +203,12 @@ impl TransportHandle {
             }
         }
 
+        // Install the node's NodeIdentity as the transport's TLS keypair so
+        // the SPKI carried in every QUIC handshake authenticates the same
+        // peer ID that signs application messages. The lifecycle monitor
+        // depends on this equality to register peers synchronously without a
+        // separate identity-announce round trip.
+        let tls_keypair = config.node_identity.clone_keypair();
         let dual_node = Arc::new(
             DualStackNetworkNode::new_with_options(
                 v6_opt,
@@ -195,6 +216,7 @@ impl TransportHandle {
                 config.max_connections,
                 config.max_message_size,
                 config.allow_loopback,
+                Some(tls_keypair),
             )
             .await
             .map_err(|e| {
@@ -230,9 +252,10 @@ impl TransportHandle {
         let connection_event_rx = dual_node.subscribe_connection_events();
 
         let peer_to_channel = Arc::new(RwLock::new(HashMap::new()));
-        let channel_to_peers = Arc::new(RwLock::new(HashMap::new()));
+        let channel_to_peer = Arc::new(RwLock::new(HashMap::new()));
         let peer_user_agents: Arc<RwLock<HashMap<PeerId, String>>> =
             Arc::new(RwLock::new(HashMap::new()));
+        let identity_notify = Arc::new(Notify::new());
         // (peer_addr_update_tx removed — dedicated forwarder creates its own)
 
         let connection_monitor_handle = {
@@ -243,10 +266,10 @@ impl TransportHandle {
             let geo_provider_clone = Arc::clone(&geo_provider);
             let shutdown_token = shutdown.clone();
             let p2c = Arc::clone(&peer_to_channel);
-            let c2p = Arc::clone(&channel_to_peers);
+            let c2p = Arc::clone(&channel_to_peer);
             let pua = Arc::clone(&peer_user_agents);
-            let identity_clone = config.node_identity.clone();
-            let user_agent_clone = config.user_agent.clone();
+            let notify = Arc::clone(&identity_notify);
+            let self_peer_id = *config.node_identity.peer_id();
 
             let handle = tokio::spawn(async move {
                 Self::connection_lifecycle_monitor_with_rx(
@@ -260,8 +283,8 @@ impl TransportHandle {
                     p2c,
                     c2p,
                     pua,
-                    identity_clone,
-                    user_agent_clone,
+                    notify,
+                    self_peer_id,
                 )
                 .await;
             });
@@ -288,8 +311,9 @@ impl TransportHandle {
             node_identity: config.node_identity,
             user_agent: config.user_agent,
             peer_to_channel,
-            channel_to_peers,
+            channel_to_peer,
             peer_user_agents,
+            identity_notify,
         })
     }
 
@@ -362,8 +386,9 @@ impl TransportHandle {
             node_identity: identity,
             user_agent: crate::network::user_agent_for_mode(crate::network::NodeMode::Node),
             peer_to_channel: Arc::new(RwLock::new(HashMap::new())),
-            channel_to_peers: Arc::new(RwLock::new(HashMap::new())),
+            channel_to_peer: Arc::new(RwLock::new(HashMap::new())),
             peer_user_agents: Arc::new(RwLock::new(HashMap::new())),
+            identity_notify: Arc::new(Notify::new()),
         })
     }
 }
@@ -593,11 +618,11 @@ impl TransportHandle {
 
     /// Look up the peer ID for a given connection address.
     pub async fn peer_id_for_addr(&self, addr: &SocketAddr) -> Option<PeerId> {
-        let c2p = self.channel_to_peers.read().await;
+        let c2p = self.channel_to_peer.read().await;
 
         // Try the exact stringified address first.
         let channel_id = addr.to_string();
-        if let Some(peer_id) = c2p.get(&channel_id).and_then(|p| p.iter().next().copied()) {
+        if let Some(peer_id) = c2p.get(&channel_id).copied() {
             return Some(peer_id);
         }
 
@@ -605,8 +630,7 @@ impl TransportHandle {
         // while the lookup address was normalized to IPv4 ("1.2.3.4:PORT"), or vice versa.
         let alt_addr = saorsa_transport::shared::dual_stack_alternate(addr)?;
         let alt_channel_id = alt_addr.to_string();
-        c2p.get(&alt_channel_id)
-            .and_then(|p| p.iter().next().copied())
+        c2p.get(&alt_channel_id).copied()
     }
 
     /// Drain pending peer address updates from ADD_ADDRESS frames.
@@ -668,14 +692,14 @@ impl TransportHandle {
 
     /// Remove channel mappings for a disconnected channel.
     ///
-    /// Removes the channel from `channel_to_peers` and scrubs it from every
-    /// affected peer's channel set in `peer_to_channel`. When a peer's last
-    /// channel is removed, emits `PeerDisconnected`.
+    /// Removes the channel from `channel_to_peer` and scrubs it from the
+    /// peer's channel set in `peer_to_channel`. When the peer's last channel
+    /// is removed, emits `PeerDisconnected`.
     async fn remove_channel_mappings(&self, channel_id: &str) {
         Self::remove_channel_mappings_static(
             channel_id,
             &self.peer_to_channel,
-            &self.channel_to_peers,
+            &self.channel_to_peer,
             &self.peer_user_agents,
             &self.event_tx,
         )
@@ -687,22 +711,20 @@ impl TransportHandle {
     async fn remove_channel_mappings_static(
         channel_id: &str,
         peer_to_channel: &RwLock<HashMap<PeerId, HashSet<String>>>,
-        channel_to_peers: &RwLock<HashMap<String, HashSet<PeerId>>>,
+        channel_to_peer: &RwLock<HashMap<String, PeerId>>,
         peer_user_agents: &RwLock<HashMap<PeerId, String>>,
         event_tx: &broadcast::Sender<P2PEvent>,
     ) {
         let mut p2c = peer_to_channel.write().await;
-        let mut c2p = channel_to_peers.write().await;
-        if let Some(app_peers) = c2p.remove(channel_id) {
-            for app_peer in &app_peers {
-                if let Some(channels) = p2c.get_mut(app_peer) {
-                    channels.remove(channel_id);
-                    if channels.is_empty() {
-                        p2c.remove(app_peer);
-                        peer_user_agents.write().await.remove(app_peer);
-                        let _ = event_tx.send(P2PEvent::PeerDisconnected(*app_peer));
-                    }
-                }
+        let mut c2p = channel_to_peer.write().await;
+        if let Some(app_peer) = c2p.remove(channel_id)
+            && let Some(channels) = p2c.get_mut(&app_peer)
+        {
+            channels.remove(channel_id);
+            if channels.is_empty() {
+                p2c.remove(&app_peer);
+                peer_user_agents.write().await.remove(&app_peer);
+                let _ = event_tx.send(P2PEvent::PeerDisconnected(app_peer));
             }
         }
     }
@@ -833,11 +855,12 @@ impl TransportHandle {
     pub async fn disconnect_peer(&self, peer_id: &PeerId) -> Result<()> {
         info!("Disconnecting from peer: {}", peer_id);
 
-        // Remove this peer from the bidirectional maps, collecting channels
-        // that have no remaining peers and should be closed at QUIC level.
+        // Remove this peer from the bidirectional maps. Each channel maps to
+        // exactly one peer, so removing a peer always orphans all of its
+        // channels — they need to be torn down at the QUIC level too.
         let orphaned_channels = {
             let mut p2c = self.peer_to_channel.write().await;
-            let mut c2p = self.channel_to_peers.write().await;
+            let mut c2p = self.channel_to_peer.write().await;
 
             let channel_ids = match p2c.remove(peer_id) {
                 Some(chs) => chs,
@@ -850,18 +873,10 @@ impl TransportHandle {
                 }
             };
 
-            let mut orphaned = Vec::new();
             for channel_id in &channel_ids {
-                if let Some(peers) = c2p.get_mut(channel_id) {
-                    peers.remove(peer_id);
-                    if peers.is_empty() {
-                        c2p.remove(channel_id);
-                        orphaned.push(channel_id.clone());
-                    }
-                }
+                c2p.remove(channel_id);
             }
-
-            orphaned
+            channel_ids.into_iter().collect::<Vec<_>>()
         };
 
         self.peer_user_agents.write().await.remove(peer_id);
@@ -1085,14 +1100,9 @@ impl TransportHandle {
             .unwrap_or_default()
     }
 
-    /// Get all authenticated app-level peer IDs communicating over a channel.
-    pub(crate) async fn peers_on_channel(&self, channel_id: &str) -> Vec<PeerId> {
-        self.channel_to_peers
-            .read()
-            .await
-            .get(channel_id)
-            .map(|set| set.iter().cloned().collect())
-            .unwrap_or_default()
+    /// Get the authenticated app-level peer ID for a channel, if any.
+    pub(crate) async fn peer_on_channel(&self, channel_id: &str) -> Option<PeerId> {
+        self.channel_to_peer.read().await.get(channel_id).copied()
     }
 
     /// Return true if `peer_id` is a known authenticated app-level peer ID.
@@ -1100,32 +1110,55 @@ impl TransportHandle {
         self.peer_to_channel.read().await.contains_key(peer_id)
     }
 
-    /// Wait for the identity exchange to complete on `channel_id` and return
-    /// the authenticated app-level [`PeerId`].
+    /// Wait for the channel's TLS-authenticated [`PeerId`] to be available.
     ///
     /// After [`connect_peer`](Self::connect_peer) returns a channel ID, the
-    /// remote's identity is not yet known — it arrives asynchronously via a
-    /// signed identity-announce message. This helper polls the
-    /// `channel_to_peers` index until the channel has an associated peer,
-    /// or the timeout expires.
+    /// `ConnectionEvent::Established` may not yet have been processed by the
+    /// background lifecycle monitor — at which point the `channel_to_peer`
+    /// map has not yet been populated. This helper does a fast initial
+    /// lookup, then `await`s on `identity_notify` for the next insert and
+    /// re-checks. The whole flow is event-driven (no polling), so a typical
+    /// caller resolves within a few scheduler ticks of the QUIC handshake
+    /// completing — far below the supplied `timeout`.
+    ///
+    /// `timeout` is a defence-in-depth bound for cases where the lifecycle
+    /// monitor is slow or the SPKI parse fails (e.g. a non-PQC peer slipped
+    /// past the TLS verifier). In normal operation it never fires.
     pub async fn wait_for_peer_identity(
         &self,
         channel_id: &str,
         timeout: Duration,
     ) -> Result<PeerId> {
         let deadline = Instant::now() + timeout;
-        let poll_interval = Duration::from_millis(50);
-
         loop {
-            // Check if any app-level peer has been authenticated on this channel.
-            let peers = self.peers_on_channel(channel_id).await;
-            if let Some(peer_id) = peers.into_iter().next() {
+            // Subscribe to the next notification BEFORE the map check.
+            //
+            // `Notify::notified()` only registers with the underlying
+            // `Notify` on first poll, *not* on creation. Without an
+            // explicit `enable()` call there is a race window: if the
+            // lifecycle monitor inserts the mapping and calls
+            // `notify_waiters()` between our `peer_on_channel` read and
+            // the subsequent `await`, the wake is missed and we sleep
+            // until the timeout.
+            //
+            // `enable()` synchronously registers the future with the
+            // `Notify`, so any `notify_waiters()` after this point reaches
+            // us even before the future is polled.
+            let notified = self.identity_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            if let Some(peer_id) = self.peer_on_channel(channel_id).await {
                 return Ok(peer_id);
             }
-            if Instant::now() >= deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
                 return Err(P2PError::Timeout(timeout));
             }
-            tokio::time::sleep(poll_interval).await;
+            match tokio::time::timeout(remaining, notified.as_mut()).await {
+                Ok(()) => continue,
+                Err(_) => return Err(P2PError::Timeout(timeout)),
+            }
         }
     }
 
@@ -1266,29 +1299,6 @@ impl TransportHandle {
 
         Self::sign_wire_message(&mut message, &self.node_identity)?;
 
-        Self::serialize_wire_message(&message)
-    }
-
-    /// Build a signed identity announce as serialized bytes (static — no `&self`).
-    ///
-    /// Used by the lifecycle monitor to send an announce immediately after a
-    /// transport connection is established, before the full `TransportHandle`
-    /// is available in that context.
-    fn create_identity_announce_bytes(
-        identity: &NodeIdentity,
-        user_agent: &str,
-    ) -> Result<Vec<u8>> {
-        let mut message = WireMessage {
-            protocol: IDENTITY_ANNOUNCE_PROTOCOL.to_string(),
-            data: vec![],
-            from: *identity.peer_id(),
-            timestamp: Self::current_timestamp_secs()?,
-            user_agent: user_agent.to_owned(),
-            public_key: Vec::new(),
-            signature: Vec::new(),
-        };
-
-        Self::sign_wire_message(&mut message, identity)?;
         Self::serialize_wire_message(&message)
     }
 
@@ -1523,20 +1533,19 @@ impl TransportHandle {
     /// The previous implementation used a single consumer task to drain
     /// every inbound message in the entire node. At 60 peers this kept up
     /// comfortably, but at 1000 peers it became the dominant serialisation
-    /// point: each message pass through this loop took three async write
-    /// locks (`peer_to_channel`, `channel_to_peers`, `peer_user_agents`)
-    /// and an awaited `register_connection_peer_id` call before the next
-    /// message could even be looked at. Responses arrived late, past the
-    /// 25 s caller timeout, producing the `[STEP 6 FAILED]` and
-    /// `[STEP 5a FAILED] Response channel closed (receiver timed out)`
-    /// cascades observed in the 1000-node testnet logs.
+    /// point — every message ran through the same task before the next
+    /// could even be looked at, and responses arrived past the caller's
+    /// 25 s timeout. Sharding by hash of the source IP gives each shard
+    /// its own consumer running in parallel, so per-peer lock contention
+    /// is distributed across N simultaneous workers. Messages from the
+    /// **same source IP** always route to the **same shard**, preserving
+    /// per-source ordering. The dispatcher task is light (hash + channel
+    /// send) so it is never the bottleneck.
     ///
-    /// Sharding by hash of the source IP gives each shard its own consumer
-    /// running in parallel, so lock contention is now distributed across N
-    /// simultaneous writers instead of serialised behind a single task.
-    /// Messages from the **same peer** always route to the **same shard**
-    /// (ordering is preserved per peer). The dispatcher task is light
-    /// (hash + channel send) so it is never the bottleneck.
+    /// Note that since the identity-exchange refactor, the shard consumer
+    /// only writes to `active_requests` and `peer_user_agents`. Peer↔channel
+    /// registration moved to [`Self::connection_lifecycle_monitor_with_rx`]
+    /// where it runs once per QUIC handshake instead of once per message.
     async fn start_message_receiving_system(&self) -> Result<()> {
         info!(
             "Starting message receiving system ({} dispatch shards)",
@@ -1567,11 +1576,8 @@ impl TransportHandle {
 
             let event_tx = self.event_tx.clone();
             let active_requests = Arc::clone(&self.active_requests);
-            let peer_to_channel = Arc::clone(&self.peer_to_channel);
-            let channel_to_peers = Arc::clone(&self.channel_to_peers);
             let peer_user_agents = Arc::clone(&self.peer_user_agents);
             let self_peer_id = *self.node_identity.peer_id();
-            let dual_node_for_peer_reg = Arc::clone(&self.dual_node);
 
             handles.push(tokio::spawn(async move {
                 Self::run_shard_consumer(
@@ -1579,11 +1585,8 @@ impl TransportHandle {
                     shard_rx,
                     event_tx,
                     active_requests,
-                    peer_to_channel,
-                    channel_to_peers,
                     peer_user_agents,
                     self_peer_id,
-                    dual_node_for_peer_reg,
                 )
                 .await;
             }));
@@ -1653,21 +1656,24 @@ impl TransportHandle {
     /// Each shard runs one of these in its own `tokio::spawn` task. Shard
     /// assignment is by hash of the source IP, so messages from the same
     /// peer always go through the same shard (ordering is preserved per
-    /// peer). Shared state (`peer_to_channel`, `active_requests`, etc.) is
-    /// still behind global `RwLock`s but the lock hold times are now
-    /// spread across [`MESSAGE_DISPATCH_SHARDS`] concurrent consumers
-    /// instead of being fully serialised.
+    /// peer). Shared state (`active_requests`, `peer_user_agents`) is
+    /// behind `RwLock`s but lock hold times are spread across
+    /// [`MESSAGE_DISPATCH_SHARDS`] concurrent consumers.
+    ///
+    /// The peer↔channel mapping is *not* maintained here — it is established
+    /// synchronously by [`Self::connection_lifecycle_monitor_with_rx`] when
+    /// the TLS handshake completes. The shard consumer's job is purely
+    /// message dispatch: parse the wire frame, route request/response
+    /// envelopes, opportunistically refresh the peer's user-agent string,
+    /// and broadcast unsolicited messages as `P2PEvent::Message`.
     #[allow(clippy::too_many_arguments)]
     async fn run_shard_consumer(
         shard_idx: usize,
         mut shard_rx: tokio::sync::mpsc::Receiver<(SocketAddr, Vec<u8>)>,
         event_tx: broadcast::Sender<P2PEvent>,
         active_requests: Arc<RwLock<HashMap<String, PendingRequest>>>,
-        peer_to_channel: Arc<RwLock<HashMap<PeerId, HashSet<String>>>>,
-        channel_to_peers: Arc<RwLock<HashMap<String, HashSet<PeerId>>>>,
         peer_user_agents: Arc<RwLock<HashMap<PeerId, String>>>,
         self_peer_id: PeerId,
-        dual_node_for_peer_reg: Arc<DualStackNetworkNode>,
     ) {
         info!("Message dispatch shard {shard_idx} started");
         while let Some((from_addr, bytes)) = shard_rx.recv().await {
@@ -1685,63 +1691,22 @@ impl TransportHandle {
                     authenticated_node_id,
                     user_agent: peer_user_agent,
                 }) => {
-                    // If the message was signed, record the app↔channel mapping.
-                    // A peer may be reachable over multiple channels simultaneously
-                    // (e.g. QUIC + Bluetooth), so we add to the set — never replace.
-                    // Skip our own identity to avoid self-registration via echoed messages.
+                    // Lazily refresh the peer's user-agent string from any
+                    // signed message. The peer↔channel mapping is already
+                    // populated by the lifecycle monitor at TLS-handshake
+                    // time, so we don't touch it here. Skip echoes of our
+                    // own identity.
                     if let Some(ref app_id) = authenticated_node_id
                         && *app_id != self_peer_id
+                        && !peer_user_agent.is_empty()
                     {
-                        // Hold `peer_to_channel` across the transport-level
-                        // `register_connection_peer_id` call so the app-level
-                        // map and the transport's internal addr→peer map are
-                        // consistent for any concurrent reader. Without this,
-                        // there is a microsecond window in which a hole-punch
-                        // lookup that depends on the registration can fail
-                        // spuriously even though the app-level map already
-                        // says the peer is known.
-                        let mut p2c = peer_to_channel.write().await;
-                        let is_new_peer = !p2c.contains_key(app_id);
-                        let channels = p2c.entry(*app_id).or_default();
-                        let inserted = channels.insert(channel_id.clone());
-                        if inserted {
-                            channel_to_peers
-                                .write()
-                                .await
-                                .entry(channel_id.clone())
-                                .or_default()
-                                .insert(*app_id);
+                        let mut uas = peer_user_agents.write().await;
+                        match uas.get(app_id) {
+                            Some(existing) if existing == &peer_user_agent => {}
+                            _ => {
+                                uas.insert(*app_id, peer_user_agent);
+                            }
                         }
-
-                        // Register peer ID at the low-level transport
-                        // endpoint so PUNCH_ME_NOW relay can find this
-                        // peer by identity instead of socket address.
-                        dual_node_for_peer_reg
-                            .register_connection_peer_id(from_addr, *app_id.to_bytes())
-                            .await;
-
-                        // Drop the lock before emitting events so subscribers
-                        // that re-enter the registry don't deadlock.
-                        drop(p2c);
-
-                        if is_new_peer {
-                            peer_user_agents
-                                .write()
-                                .await
-                                .insert(*app_id, peer_user_agent.clone());
-                            broadcast_event(
-                                &event_tx,
-                                P2PEvent::PeerConnected(*app_id, peer_user_agent.clone()),
-                            );
-                        }
-                    }
-
-                    // Identity announces are internal plumbing — don't
-                    // emit as app-level messages.
-                    if let P2PEvent::Message { ref topic, .. } = event
-                        && topic == IDENTITY_ANNOUNCE_PROTOCOL
-                    {
-                        continue;
                     }
 
                     if let P2PEvent::Message {
@@ -1911,6 +1876,14 @@ impl TransportHandle {
 
 impl TransportHandle {
     /// Connection lifecycle monitor — processes saorsa-transport connection events.
+    ///
+    /// On `ConnectionEvent::Established` the peer's app-level [`PeerId`] is
+    /// derived synchronously from the TLS-authenticated SPKI carried in the
+    /// event, and the `peer_to_channel` / `channel_to_peer` maps are
+    /// populated immediately. This eliminates the asynchronous identity
+    /// announce protocol and the 15 s wait window that came with it: by the
+    /// time `connect_peer` returns, the peer identity is either already
+    /// resolved or will be within a few scheduler ticks.
     #[allow(clippy::too_many_arguments)]
     async fn connection_lifecycle_monitor_with_rx(
         dual_node: Arc<DualStackNetworkNode>,
@@ -1923,10 +1896,10 @@ impl TransportHandle {
         _geo_provider: Arc<BgpGeoProvider>,
         shutdown: CancellationToken,
         peer_to_channel: Arc<RwLock<HashMap<PeerId, HashSet<String>>>>,
-        channel_to_peers: Arc<RwLock<HashMap<String, HashSet<PeerId>>>>,
+        channel_to_peer: Arc<RwLock<HashMap<String, PeerId>>>,
         peer_user_agents: Arc<RwLock<HashMap<PeerId, String>>>,
-        node_identity: Arc<NodeIdentity>,
-        user_agent: String,
+        identity_notify: Arc<Notify>,
+        self_peer_id: PeerId,
     ) {
         info!("Connection lifecycle monitor started (pre-subscribed receiver)");
 
@@ -1940,7 +1913,8 @@ impl TransportHandle {
                     match recv {
                         Ok(event) => match event {
                             ConnectionEvent::Established {
-                                remote_address, ..
+                                remote_address,
+                                public_key,
                             } => {
                                 let channel_id = remote_address.to_string();
                                 debug!(
@@ -1950,43 +1924,99 @@ impl TransportHandle {
 
                                 active_connections.write().await.insert(channel_id.clone());
 
-                                let mut peers_lock = peers.write().await;
-                                if let Some(peer_info) = peers_lock.get_mut(&channel_id) {
-                                    peer_info.status = ConnectionStatus::Connected;
-                                    peer_info.connected_at = Instant::now();
-                                } else {
-                                    debug!("Registering new incoming channel: {}", channel_id);
-                                    peers_lock.insert(
-                                        channel_id.clone(),
-                                        PeerInfo {
-                                            channel_id: channel_id.clone(),
-                                            addresses: vec![MultiAddr::quic(remote_address)],
-                                            status: ConnectionStatus::Connected,
-                                            last_seen: Instant::now(),
-                                            connected_at: Instant::now(),
-                                            protocols: Vec::new(),
-                                            heartbeat_count: 0,
-                                        },
+                                {
+                                    let mut peers_lock = peers.write().await;
+                                    if let Some(peer_info) = peers_lock.get_mut(&channel_id) {
+                                        peer_info.status = ConnectionStatus::Connected;
+                                        peer_info.connected_at = Instant::now();
+                                    } else {
+                                        debug!("Registering new incoming channel: {}", channel_id);
+                                        peers_lock.insert(
+                                            channel_id.clone(),
+                                            PeerInfo {
+                                                channel_id: channel_id.clone(),
+                                                addresses: vec![MultiAddr::quic(remote_address)],
+                                                status: ConnectionStatus::Connected,
+                                                last_seen: Instant::now(),
+                                                connected_at: Instant::now(),
+                                                protocols: Vec::new(),
+                                                heartbeat_count: 0,
+                                            },
+                                        );
+                                    }
+                                }
+
+                                // Resolve the peer's app-level identity from the
+                                // SPKI bytes carried in the TLS handshake. The
+                                // raw-public-key TLS verifier already validated
+                                // the signature; here we just decode the same
+                                // bytes back into a PeerId.
+                                let Some(spki_bytes) = public_key else {
+                                    warn!(
+                                        channel = %channel_id,
+                                        "Connection established without TLS public key — \
+                                         channel will not be authenticated and is unusable",
+                                    );
+                                    continue;
+                                };
+
+                                let app_peer_id = match decode_peer_id_from_spki(&spki_bytes) {
+                                    Ok(pid) => pid,
+                                    Err(e) => {
+                                        warn!(
+                                            channel = %channel_id,
+                                            error = %e,
+                                            "Failed to decode peer SPKI into PeerId — \
+                                             channel will not be authenticated",
+                                        );
+                                        continue;
+                                    }
+                                };
+
+                                if app_peer_id == self_peer_id {
+                                    debug!(
+                                        channel = %channel_id,
+                                        "Skipping self-connection in lifecycle monitor",
+                                    );
+                                    continue;
+                                }
+
+                                // Register peer↔channel mapping immediately,
+                                // holding the peer_to_channel lock across the
+                                // transport-level peer-id registration so the
+                                // app map and the transport addr→peer map are
+                                // consistent for any concurrent reader.
+                                let is_new_peer;
+                                {
+                                    let mut p2c = peer_to_channel.write().await;
+                                    let mut c2p = channel_to_peer.write().await;
+                                    is_new_peer = !p2c.contains_key(&app_peer_id);
+                                    p2c.entry(app_peer_id)
+                                        .or_default()
+                                        .insert(channel_id.clone());
+                                    c2p.insert(channel_id.clone(), app_peer_id);
+                                    dual_node
+                                        .register_connection_peer_id(
+                                            remote_address,
+                                            *app_peer_id.to_bytes(),
+                                        )
+                                        .await;
+                                }
+
+                                // Wake any wait_for_peer_identity callers
+                                // blocked on this channel becoming authenticated.
+                                identity_notify.notify_waiters();
+
+                                // Emit PeerConnected for the first sighting.
+                                // The user_agent stays empty until the first
+                                // signed wire message arrives — see
+                                // run_shard_consumer.
+                                if is_new_peer {
+                                    broadcast_event(
+                                        &event_tx,
+                                        P2PEvent::PeerConnected(app_peer_id, String::new()),
                                     );
                                 }
-
-                                // Send identity announce so the remote peer can authenticate us.
-                                match Self::create_identity_announce_bytes(&node_identity, &user_agent) {
-                                    Ok(announce_bytes) => {
-                                        if let Err(e) = dual_node
-                                            .send_to_peer_optimized(&remote_address, &announce_bytes)
-                                            .await
-                                        {
-                                            warn!("Failed to send identity announce to {channel_id}: {e}");
-                                        }
-                                    }
-                                    Err(e) => {
-                                        warn!("Failed to create identity announce: {e}");
-                                    }
-                                }
-
-                                // PeerConnected is emitted when the remote receives and
-                                // verifies our identity announce — not at transport level.
                             }
                             ConnectionEvent::Lost { remote_address, reason }
                             | ConnectionEvent::Failed { remote_address, reason } => {
@@ -2000,7 +2030,7 @@ impl TransportHandle {
                                 Self::remove_channel_mappings_static(
                                     &channel_id,
                                     &peer_to_channel,
-                                    &channel_to_peers,
+                                    &channel_to_peer,
                                     &peer_user_agents,
                                     &event_tx,
                                 ).await;
@@ -2024,6 +2054,27 @@ impl TransportHandle {
             }
         }
     }
+}
+
+/// Decode a TLS-carried SPKI byte string into the corresponding [`PeerId`].
+///
+/// The bytes come from saorsa-transport's `extract_public_key_bytes_from_connection`,
+/// which returns the contents of the rustls `CertificateDer`. For raw-public-key
+/// connections (RFC 7250) those bytes are the X.509 SubjectPublicKeyInfo
+/// containing the ML-DSA-65 public key — the same encoding produced by
+/// `create_subject_public_key_info`. The TLS verifier already validated the
+/// signature; this is purely a byte-to-PeerId derivation.
+///
+/// Both `extract_public_key_from_spki` and `peer_id_from_public_key` operate
+/// on the same `MlDsaPublicKey` type re-exported from `saorsa-transport`, so
+/// no intermediate copy through raw bytes is necessary.
+fn decode_peer_id_from_spki(spki_bytes: &[u8]) -> Result<PeerId> {
+    let public_key: MlDsaPublicKey = extract_public_key_from_spki(spki_bytes).map_err(|e| {
+        P2PError::Identity(crate::error::IdentityError::InvalidFormat(
+            format!("invalid SPKI bytes from TLS handshake: {e:?}").into(),
+        ))
+    })?;
+    Ok(peer_id_from_public_key(&public_key))
 }
 
 // ============================================================================
@@ -2071,8 +2122,11 @@ impl TransportHandle {
     }
 
     /// Map an app-level PeerId to a channel ID in both `peer_to_channel` and
-    /// `channel_to_peers` (test helper). The bidirectional mapping ensures
-    /// `remove_channel` correctly cleans up both maps.
+    /// `channel_to_peer` (test helper). The bidirectional mapping ensures
+    /// `remove_channel` correctly cleans up both maps. Also fires
+    /// `identity_notify` so any blocked `wait_for_peer_identity` callers
+    /// observe the new mapping immediately, mirroring the production
+    /// lifecycle-monitor path.
     pub(crate) async fn inject_peer_to_channel(&self, peer_id: PeerId, channel_id: String) {
         self.peer_to_channel
             .write()
@@ -2080,11 +2134,95 @@ impl TransportHandle {
             .entry(peer_id)
             .or_default()
             .insert(channel_id.clone());
-        self.channel_to_peers
+        self.channel_to_peer
             .write()
             .await
-            .entry(channel_id)
-            .or_default()
-            .insert(peer_id);
+            .insert(channel_id, peer_id);
+        self.identity_notify.notify_waiters();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `wait_for_peer_identity` must return immediately when the channel
+    /// is already populated. This is the fast path after the identity
+    /// refactor: TLS-derived peer registration happens synchronously in
+    /// the lifecycle monitor, so by the time most callers reach this
+    /// helper the mapping is already in place.
+    ///
+    /// Uses `multi_thread` because `new_for_tests` internally calls
+    /// `Handle::current().block_on(...)` and the single-threaded test
+    /// runtime forbids nested blocking.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn wait_for_peer_identity_returns_pre_populated_immediately() {
+        let handle =
+            tokio::task::spawn_blocking(|| TransportHandle::new_for_tests().expect("test handle"))
+                .await
+                .expect("spawn_blocking must succeed");
+        let peer = PeerId::random();
+        let channel_id = "127.0.0.1:1234".to_string();
+
+        handle
+            .inject_peer_to_channel(peer, channel_id.clone())
+            .await;
+
+        let resolved = tokio::time::timeout(
+            Duration::from_millis(50),
+            handle.wait_for_peer_identity(&channel_id, Duration::from_secs(5)),
+        )
+        .await
+        .expect("must resolve well below timeout")
+        .expect("must return Ok for known channel");
+
+        assert_eq!(
+            resolved, peer,
+            "wait_for_peer_identity must return the injected peer ID",
+        );
+    }
+
+    /// When a `channel_to_peer` insert lands AFTER the waiter starts but
+    /// BEFORE its first poll of `notified()`, the waiter must still wake.
+    /// This guards against the `Notify::notified()` registration race
+    /// that the previous polling-loop implementation tolerated by accident
+    /// and that the new event-driven path must handle correctly via
+    /// `Notified::enable()`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn wait_for_peer_identity_wakes_on_concurrent_insert() {
+        let handle = Arc::new(
+            tokio::task::spawn_blocking(|| TransportHandle::new_for_tests().expect("test handle"))
+                .await
+                .expect("spawn_blocking must succeed"),
+        );
+        let peer = PeerId::random();
+        let channel_id = "127.0.0.1:5678".to_string();
+
+        let waiter_handle = Arc::clone(&handle);
+        let waiter_channel = channel_id.clone();
+        let waiter = tokio::spawn(async move {
+            waiter_handle
+                .wait_for_peer_identity(&waiter_channel, Duration::from_secs(5))
+                .await
+        });
+
+        // Yield so the waiter has a chance to enter wait_for_peer_identity
+        // and reach `notified.as_mut().enable()`.
+        tokio::task::yield_now().await;
+
+        handle
+            .inject_peer_to_channel(peer, channel_id.clone())
+            .await;
+
+        let resolved = tokio::time::timeout(Duration::from_millis(500), waiter)
+            .await
+            .expect("waiter must wake within 500ms of insert")
+            .expect("waiter task should not panic")
+            .expect("waiter should return Ok for the inserted channel");
+
+        assert_eq!(
+            resolved, peer,
+            "wait_for_peer_identity must return the inserted peer ID",
+        );
     }
 }

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -721,16 +721,18 @@ impl TransportHandle {
             .await;
     }
 
-    /// Set a preferred coordinator for hole-punching to a specific target.
-    /// The preferred coordinator is a peer that referred us to the target
-    /// during a DHT lookup, so it has a connection to the target.
-    pub async fn set_hole_punch_preferred_coordinator(
+    /// Set an ordered list of preferred coordinators for hole-punching to a
+    /// specific target.
+    ///
+    /// See [`crate::transport::saorsa_transport_adapter::SaorsaDualStackTransport::set_hole_punch_preferred_coordinators`]
+    /// for the rotation semantics.
+    pub async fn set_hole_punch_preferred_coordinators(
         &self,
         target: SocketAddr,
-        coordinator: SocketAddr,
+        coordinators: Vec<SocketAddr>,
     ) {
         self.dual_node
-            .set_hole_punch_preferred_coordinator(target, coordinator)
+            .set_hole_punch_preferred_coordinators(target, coordinators)
             .await;
     }
 


### PR DESCRIPTION
## Summary

- **Eliminates the asynchronous identity-announce protocol** that was the proximate cause of consistent 15 s identity-exchange failures on the symmetric-NAT testnet. saorsa-core's `NodeIdentity` ML-DSA-65 keypair is now installed as saorsa-transport's TLS keypair, so every QUIC handshake authenticates the same peer ID that signs application messages. The lifecycle monitor derives the peer ID synchronously from the SPKI bytes carried in `ConnectionEvent::Established` and registers the peer↔channel mapping immediately — the 15 s wait window simply ceases to exist.
- **Re-keys channel state by peer identity**: `channel_to_peers: HashMap<String, HashSet<PeerId>>` collapses to `channel_to_peer: HashMap<String, PeerId>` because TLS authenticates exactly one identity per QUIC connection. `peer_user_agents` is now lazily populated by the shard consumer from any signed wire message (TLS doesn't carry user-agent strings).
- **Coalesces concurrent dials by peer ID**: a new `inflight_dials: DashMap<PeerId, Arc<Notify>>` field on `DhtNetworkManager` plus a `dial_or_await_inflight` helper guarantees one in-flight dial per peer across all four call sites (`send_dht_request`, self-lookup, bootstrap, iterative-lookup batch). Concurrent callers wait on the same `Notify` and re-check via `is_peer_connected` after the wake. An `InflightDialGuard` provides RAII so the entry is cleaned up and waiters are woken even on panic or cancellation.
- **Notify race fix**: `wait_for_peer_identity` calls `Notified::enable()` synchronously after pinning so it registers with the `Notify` *before* the map check, closing the registration race that the previous polling-loop implementation tolerated by accident.
- **Companion changes in saorsa-transport**: see saorsa-labs/saorsa-transport#52 for the rotation hardening (drop per-round `post_direct` probe, bump per-coordinator timeout to 4 s, peer-ID dedup at accept) that this PR depends on.

## Why

Testnet validation with mixed open/symmetric NAT nodes showed connections succeeding but identity exchange failing at exactly 15 seconds. Tracing it:

1. saorsa-core's DHT layer issued multiple parallel `dial_addresses` calls per peer.
2. Each call entered saorsa-transport's coordinator-rotation loop and produced N parallel hole-punch attempts that polluted the SocketAddr-keyed dedup tables under symmetric NAT, accumulating duplicate connections.
3. saorsa-core's lifecycle monitor sent a fire-and-forget signed identity announce on `ConnectionEvent::Established` and `wait_for_peer_identity` polled for the remote's matching announce with a 15 s timeout.
4. When the duplicate-connection cleanup closed the wrong connection (the one the announce was being sent over, or the one the polling loop was watching), the announce never landed and the wait deterministically blew past 15 s.

This PR closes the gap **structurally**: TLS already authenticates an ML-DSA-65 public key per QUIC connection, so we use that instead of inventing our own announce protocol on top. The companion saorsa-transport PR removes the racing dial paths that produced the duplicates in the first place.

## Approach (4 fixes, scoped together as one PR per repo)

### Fix 1 — TLS-derived peer identity (this PR)

- `NodeIdentity::clone_keypair()` exposes the ML-DSA-65 keypair.
- `DualStackNetworkNode::new_with_options` and `P2PNetworkNode::new_with_options` accept an optional `(MlDsaPublicKey, MlDsaSecretKey)` and pass it to `P2pConfig::builder().keypair(...)`.
- `connection_lifecycle_monitor_with_rx` consumes the `public_key` field on `ConnectionEvent::Established` (previously discarded with `..`), decodes it via a new `decode_peer_id_from_spki` helper, and inserts the peer↔channel mapping in the same critical section as the transport's `register_connection_peer_id` call.
- `IDENTITY_ANNOUNCE_PROTOCOL`, `create_identity_announce_bytes`, and the announce-send branch in the lifecycle monitor are deleted.
- `BOOTSTRAP_IDENTITY_TIMEOUT_SECS` and `IDENTITY_EXCHANGE_TIMEOUT` drop from 15 s → 2 s. They remain as defensive safety nets only.

### Fix 2 — peer-id-keyed channel state (this PR)

- `channel_to_peers: HashMap<String, HashSet<PeerId>>` → `channel_to_peer: HashMap<String, PeerId>`.
- `peers_on_channel` → `peer_on_channel: -> Option<PeerId>`.
- `peer_user_agents` populated lazily from signed wire messages.
- All call sites updated.

### Fix 3 — dial coalescing in `DhtNetworkManager` (this PR)

- New `inflight_dials: Arc<DashMap<PeerId, Arc<Notify>>>` field and `dial_or_await_inflight` helper.
- `InflightDialGuard` provides RAII guarantees on `Drop`.
- New direct dependency: `dashmap = "6"`.
- All four `dial_addresses` call sites route through the helper.

### Fix 4 — coordinator rotation hardening (saorsa-labs/saorsa-transport#52)

- Bump `PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT` from 1.5 s → 4 s.
- Drop the per-rotation `post_direct` probe; replace with a single end-of-chain probe.
- Add peer-ID dedup at `P2pEndpoint::accept` so symmetric-NAT rebinds collapse to one authoritative connection.

## Tests

Three new unit tests added:

- `inflight_dial_guard_releases_slot_and_wakes_waiters_on_drop` — verifies the RAII semantics of `InflightDialGuard` with a raw DashMap + Notify.
- `wait_for_peer_identity_returns_pre_populated_immediately` — confirms the fast path resolves within 50 ms when the channel is already populated.
- `wait_for_peer_identity_wakes_on_concurrent_insert` — reproduces the `Notify::notified()` registration race and verifies that `Notified::enable()` closes it.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` clean
- [x] `cargo test --lib` — 298 unit tests pass (was 295; 3 new)
- [x] `cargo test --tests` — all 55 integration tests pass (lifecycle, two-node messaging, DHT self-advertisement, sybil protection, trust flow, stale-session reconnect)
- [ ] Symmetric/open NAT testnet rerun: confirm 15 s identity-exchange-failure log line is gone, peers identify within milliseconds of `ConnectionEvent::Established`.
- [ ] Verify `peer_user_agent` is populated lazily after the first signed message arrives (no regression in DHT-participant detection).
- [ ] Confirm `dial_or_await_inflight` coalescing under load: only one `dial_addresses` invocation per peer across an iterative-lookup batch.

## Breaking change

Removes `IDENTITY_ANNOUNCE_PROTOCOL` from the wire protocol. New peers cannot identify themselves to old peers and vice versa; both sides of every connection must run this version or later. Per discussion, no backwards-compatibility shim is provided.

## Depends on

- saorsa-labs/saorsa-transport#52 — must merge first so the rotation-side fixes land alongside the identity-side fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR structurally eliminates the 15 s identity-exchange failure by deriving peer identity synchronously from the TLS-handshake SPKI, removes the identity-announce wire protocol, and adds dial-coalescing (`InflightDialGuard`) plus multi-referrer ranking to prevent the parallel-dial storm that triggered duplicate-connection cleanup under symmetric NAT.

- **P1 — `Cargo.toml`**: `saorsa-transport` is pointed at a local path (`../saorsa-transport`) that will not exist in CI or any checkout without the sibling repo. Must be restored to a git/registry reference before merge.
- **P2 — `PeerConnected` user-agent**: the event now always carries an empty string; any consumer that reads the user-agent at join time will silently regress until the first signed message arrives, with no follow-up event to signal the update.
- **P2 — unauthenticated channels not closed**: when SPKI decoding fails in the lifecycle monitor the connection is warned-and-continued but never torn down, leaving a half-open slot.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the local path dependency is replaced with a proper git/registry reference; all other findings are P2.

One P1 finding (local path dep) blocks builds outside the developer's machine. The core logic — TLS-derived identity, Notify-based wait, dial coalescing, referrer ranking — is well-reasoned, thoroughly tested (298 unit + 55 integration tests), and correctly closes the 15 s identity-exchange race. All remaining findings are P2.

Cargo.toml (local path dep), src/transport_handle.rs (empty user-agent in PeerConnected, unauthenticated channel not closed)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Adds dashmap = "6" dependency and switches saorsa-transport to a local path reference — the path dependency will break any build outside the developer's machine and must be replaced with a git/registry ref before merge. |
| src/transport_handle.rs | Core identity-exchange refactor: removes identity-announce protocol, derives peer ID synchronously from TLS SPKI, replaces polling loop with Notify-based wait_for_peer_identity, and collapses channel_to_peers to channel_to_peer. Logic is sound; unauthenticated connections are warned but not closed, and PeerConnected now carries an empty user-agent. |
| src/dht_network_manager.rs | Adds dial coalescing via InflightDialGuard + DashMap, multi-referrer ranking (rank_referrers / merge_referrer_observation), and shuffled bootstrap visit order. Well-tested; minor entropy-reuse concern in shuffled_indices for lists >= 18 elements. |
| src/transport/saorsa_transport_adapter.rs | Upgrades set_hole_punch_preferred_coordinator to accept an ordered Vec of coordinators, and threads the optional TLS keypair through new_with_options on both P2PNetworkNode and DualStackNetworkNode. Changes are mechanical and correct. |
| src/identity/node_identity.rs | Adds clone_keypair() to expose the ML-DSA-65 keypair for TLS injection — minimal, correct addition. |
| src/network.rs | Reduces BOOTSTRAP_IDENTITY_TIMEOUT_SECS from 15 s to 2 s to match the synchronous TLS-derived identity path; minor doc-comment link fixes. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as send_dht_request / bootstrap
    participant DNM as DhtNetworkManager
    participant ID as inflight_dials (DashMap)
    participant TR as saorsa-transport (QUIC)
    participant LM as connection_lifecycle_monitor
    participant WFP as wait_for_peer_identity

    Caller->>DNM: dial_or_await_inflight(peer_id, addrs, referrers)
    DNM->>TR: is_peer_connected(peer_id) [fast path]
    alt Already connected
        TR-->>DNM: true
        DNM-->>Caller: Some(channel_id)
    else Not connected
        DNM->>ID: entry(peer_id) → Vacant
        ID-->>DNM: Owner(Notify)
        Note over DNM: InflightDialGuard created (RAII)
        DNM->>TR: set_hole_punch_preferred_coordinators(ranked_referrers)
        DNM->>TR: connect_peer(addr)
        TR->>TR: QUIC + TLS handshake (ML-DSA-65)
        TR-->>LM: ConnectionEvent::Established { public_key: SPKI }
        LM->>LM: decode_peer_id_from_spki(spki_bytes)
        LM->>LM: write peer_to_channel + channel_to_peer
        LM->>TR: register_connection_peer_id(addr, peer_id)
        LM->>WFP: identity_notify.notify_waiters()
        LM-->>DNM: PeerConnected event (user_agent = "")
        Note over DNM: InflightDialGuard dropped → inflight.remove + notify_waiters
        DNM-->>Caller: Some(channel_id)
    end

    par Concurrent secondary callers
        Caller->>DNM: dial_or_await_inflight(same peer_id)
        DNM->>ID: entry(peer_id) → Occupied
        ID-->>DNM: Waiter(Notify)
        DNM->>DNM: notified().await
        Note over DNM: Woken by InflightDialGuard::drop
        DNM->>TR: is_peer_connected(peer_id)
        TR-->>DNM: true/false
        DNM-->>Caller: Some(channel_id) or None
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/transport_handle.rs`, line 2117-2122 ([link](https://github.com/saorsa-labs/saorsa-core/blob/c8b71be5f748794eef460f7a157b2270337e5684/src/transport_handle.rs#L2117-L2122)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`PeerConnected` now emits an empty user-agent string**

   Previously `PeerConnected` carried the user-agent from the identity-announce payload; now it unconditionally carries `String::new()`. Any consumer that checks the user-agent field on `PeerConnected` — e.g. to distinguish `node` from `light` mode peers at join time — will silently observe an empty string until the first signed application message arrives. The shard consumer will eventually backfill `peer_user_agents`, but it never re-fires `PeerConnected`, so the window of incorrect user-agent data is unbounded.

   Consider emitting a new `P2PEvent::PeerUserAgentUpdated` (or similar) when the user-agent is first populated in `run_shard_consumer`, so consumers that need it can reliably detect it without polling `peer_user_agent()`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/transport_handle.rs
   Line: 2117-2122

   Comment:
   **`PeerConnected` now emits an empty user-agent string**

   Previously `PeerConnected` carried the user-agent from the identity-announce payload; now it unconditionally carries `String::new()`. Any consumer that checks the user-agent field on `PeerConnected` — e.g. to distinguish `node` from `light` mode peers at join time — will silently observe an empty string until the first signed application message arrives. The shard consumer will eventually backfill `peer_user_agents`, but it never re-fires `PeerConnected`, so the window of incorrect user-agent data is unbounded.

   Consider emitting a new `P2PEvent::PeerUserAgentUpdated` (or similar) when the user-agent is first populated in `run_shard_consumer`, so consumers that need it can reliably detect it without polling `peer_user_agent()`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/dht_network_manager.rs`, line 263-278 ([link](https://github.com/saorsa-labs/saorsa-core/blob/c8b71be5f748794eef460f7a157b2270337e5684/src/dht_network_manager.rs#L263-L278)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Entropy reuse for bootstrap lists larger than 17 entries**

   `shuffled_indices` draws two bytes per swap step at `idx = (len - 1 - i) * 2`. For `len ≤ 17` the 32-byte entropy buffer from `PeerId::random()` is sufficient (max `idx+1 = 31`). At `len = 18`, the step for `i = 1` lands at `idx = 32`, which wraps to byte 0 and 1 — the same bytes already used for `i = 16`. Repeated entropy bytes bias the shuffle for lists of 18+ bootstrap peers. The comment correctly notes typical lists are 2-5 entries, but the invariant should be documented or asserted.

   A minimal fix is to assert or clamp the input, or use `rand::thread_rng` for larger inputs.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/dht_network_manager.rs
   Line: 263-278

   Comment:
   **Entropy reuse for bootstrap lists larger than 17 entries**

   `shuffled_indices` draws two bytes per swap step at `idx = (len - 1 - i) * 2`. For `len ≤ 17` the 32-byte entropy buffer from `PeerId::random()` is sufficient (max `idx+1 = 31`). At `len = 18`, the step for `i = 1` lands at `idx = 32`, which wraps to byte 0 and 1 — the same bytes already used for `i = 16`. Repeated entropy bytes bias the shuffle for lists of 18+ bootstrap peers. The comment correctly notes typical lists are 2-5 entries, but the invariant should be documented or asserted.

   A minimal fix is to assert or clamp the input, or use `rand::thread_rng` for larger inputs.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `src/transport_handle.rs`, line 2054-2062 ([link](https://github.com/saorsa-labs/saorsa-core/blob/c8b71be5f748794eef460f7a157b2270337e5684/src/transport_handle.rs#L2054-L2062)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unauthenticated connection is silently dropped, not closed**

   When `public_key` is `None` or SPKI decoding fails, the lifecycle monitor logs a warning and `continue`s — leaving the QUIC connection open at the transport level without an authenticated `channel_to_peer` entry. The result is a half-open channel: it consumes a connection slot, can receive bytes via the shard consumer (which has no matching peer mapping), and is never explicitly closed. Consider calling `dual_node.disconnect_peer(…)` or equivalent to tear down the unauthenticated channel after logging the warning.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/transport_handle.rs
   Line: 2054-2062

   Comment:
   **Unauthenticated connection is silently dropped, not closed**

   When `public_key` is `None` or SPKI decoding fails, the lifecycle monitor logs a warning and `continue`s — leaving the QUIC connection open at the transport level without an authenticated `channel_to_peer` entry. The result is a half-open channel: it consumes a connection slot, can receive bytes via the shard consumer (which has no matching peer mapping), and is never explicitly closed. Consider calling `dual_node.disconnect_peer(…)` or equivalent to tear down the unauthenticated channel after logging the warning.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Cargo.toml
Line: 63

Comment:
**Local path dependency must not be merged**

`saorsa-transport = { path = "../saorsa-transport" }` is a development-convenience reference that requires the sibling checkout to exist at exactly `../saorsa-transport`. Any CI run, fresh clone, or production build without that sibling directory will fail to compile. The PR description says this PR *depends on* saorsa-labs/saorsa-transport#52, so this should be restored to a git or registry reference pointing at the merged `rc-2026.4.1` commit once that companion PR lands.

```suggestion
saorsa-transport = { git = "https://github.com/saorsa-labs/saorsa-transport.git", branch = "rc-2026.4.1" }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/transport_handle.rs
Line: 2117-2122

Comment:
**`PeerConnected` now emits an empty user-agent string**

Previously `PeerConnected` carried the user-agent from the identity-announce payload; now it unconditionally carries `String::new()`. Any consumer that checks the user-agent field on `PeerConnected` — e.g. to distinguish `node` from `light` mode peers at join time — will silently observe an empty string until the first signed application message arrives. The shard consumer will eventually backfill `peer_user_agents`, but it never re-fires `PeerConnected`, so the window of incorrect user-agent data is unbounded.

Consider emitting a new `P2PEvent::PeerUserAgentUpdated` (or similar) when the user-agent is first populated in `run_shard_consumer`, so consumers that need it can reliably detect it without polling `peer_user_agent()`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/dht_network_manager.rs
Line: 263-278

Comment:
**Entropy reuse for bootstrap lists larger than 17 entries**

`shuffled_indices` draws two bytes per swap step at `idx = (len - 1 - i) * 2`. For `len ≤ 17` the 32-byte entropy buffer from `PeerId::random()` is sufficient (max `idx+1 = 31`). At `len = 18`, the step for `i = 1` lands at `idx = 32`, which wraps to byte 0 and 1 — the same bytes already used for `i = 16`. Repeated entropy bytes bias the shuffle for lists of 18+ bootstrap peers. The comment correctly notes typical lists are 2-5 entries, but the invariant should be documented or asserted.

A minimal fix is to assert or clamp the input, or use `rand::thread_rng` for larger inputs.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/transport_handle.rs
Line: 2054-2062

Comment:
**Unauthenticated connection is silently dropped, not closed**

When `public_key` is `None` or SPKI decoding fails, the lifecycle monitor logs a warning and `continue`s — leaving the QUIC connection open at the transport level without an authenticated `channel_to_peer` entry. The result is a half-open channel: it consumes a connection slot, can receive bytes via the shard consumer (which has no matching peer mapping), and is never explicitly closed. Consider calling `dual_node.disconnect_peer(…)` or equivalent to tear down the unauthenticated channel after logging the warning.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat!(transport): use TLS-derived peer I..."](https://github.com/saorsa-labs/saorsa-core/commit/c8b71be5f748794eef460f7a157b2270337e5684) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27640987)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->