### PR TITLE
fix: increase clock skew tolerance from 30s to 5min (symmetric)

### DIFF
--- a/src/adaptive/dht.rs
+++ b/src/adaptive/dht.rs
@@ -81,7 +81,7 @@ impl AdaptiveDhtConfig {
 /// consumer's responsibility via [`ApplicationSuccess`](Self::ApplicationSuccess).
 ///
 /// Consumer-reported events carry a weight multiplier that controls the
-/// severity of the update (clamped to [`MAX_CONSUMER_WEIGHT`]).
+/// severity of the update (clamped to `MAX_CONSUMER_WEIGHT`).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TrustEvent {
     // === Negative signals (core) ===

--- a/src/network.rs
+++ b/src/network.rs
@@ -235,7 +235,7 @@ pub struct NodeConfig {
     ///
     /// Controls whether peers with low trust scores are eligible for
     /// swap-out from the routing table when better candidates arrive. Use
-    /// [`NodeConfigBuilder::trust_enforcement`] for a simple on/off toggle.
+    /// `NodeConfigBuilder::trust_enforcement` for a simple on/off toggle.
     ///
     /// Default: enabled with a swap threshold of 0.35.
     #[serde(default)]
@@ -741,7 +741,7 @@ const QUIC_TEARDOWN_GRACE: Duration = Duration::from_millis(100);
 /// - Handle network events and peer lifecycle
 ///
 /// Transport concerns (connections, messaging, events) are delegated to
-/// [`TransportHandle`](crate::transport_handle::TransportHandle).
+/// `TransportHandle`.
 pub struct P2PNode {
     /// Node configuration
     config: NodeConfig,
@@ -978,7 +978,7 @@ impl P2PNode {
     ///
     /// # Returns
     ///
-    /// A [`PeerResponse`] on success, or an error on timeout / connection failure.
+    /// A `PeerResponse` on success, or an error on timeout / connection failure.
     ///
     /// # Example
     ///
@@ -1613,13 +1613,20 @@ impl P2PNode {
 /// can pass it directly to `send_message()`. This eliminates a spoofing
 /// vector where a peer could claim an arbitrary identity via the payload.
 ///
-/// Maximum allowed clock skew for message timestamps (5 minutes).
-/// This is intentionally lenient for initial deployment to accommodate nodes with
-/// misconfigured clocks or high-latency network conditions. Can be tightened (e.g., to 60s)
-/// once the network stabilizes and node clock synchronization improves.
+/// Maximum allowed clock skew for message timestamps.
+///
+/// A decentralized network cannot assume participants have accurate clocks.
+/// Consumer devices commonly have clocks that drift by minutes (no NTP, wrong
+/// timezone offset applied to UTC, suspended laptops, VMs without guest
+/// additions, etc.). Both past and future windows must be symmetric and
+/// generous enough that normal clock drift does not partition the network.
+///
+/// 5 minutes in both directions provides replay protection while tolerating
+/// the clock skew observed in real-world deployments (31-42 seconds was
+/// measured between a macOS client and NTP-synced VPS nodes).
 const MAX_MESSAGE_AGE_SECS: u64 = 300;
-/// Maximum allowed future timestamp (30 seconds to account for clock drift)
-const MAX_FUTURE_SECS: u64 = 30;
+/// Maximum allowed future timestamp — symmetric with the past window.
+const MAX_FUTURE_SECS: u64 = 300;
 
 /// Convenience constructor for `P2PError::Network(NetworkError::ProtocolError(...))`.
 fn protocol_error(msg: impl std::fmt::Display) -> P2PError {


### PR DESCRIPTION
## Summary

The future-dated message rejection window was 30 seconds. This is too tight for a decentralized network where consumer devices routinely have inaccurate clocks.

## The problem

During testnet testing, a macOS client had a clock that was 31-42 seconds behind the NTP-synced VPS nodes. This caused every message from the network to be rejected as "future-dated", which broke identity exchange and made uploads impossible:

```
WARN Rejecting future-dated message from 143.198.98.122:10000 (timestamp 1775612843 is 31 seconds ahead)
```

The stale message window was already 5 minutes but the future window was only 30 seconds. This asymmetry meant any node with a slightly slow clock was partitioned from the network.

## The fix

Both windows are now symmetric at 5 minutes (`MAX_FUTURE_SECS: 30 -> 300`). Replay protection is still effective since messages are signed with the sender's identity.

## Test plan
- [x] `cfd` passes (clippy + fmt + cargo doc --deny=warnings)
- [x] 282 tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR increases the future-timestamp tolerance window from 30 seconds to 5 minutes (`MAX_FUTURE_SECS: 30 → 300`) so it is symmetric with the existing 5-minute stale window, fixing real-world network partitioning caused by consumer devices with clocks drifting 31–42 seconds behind NTP-synced VPS nodes. The `src/adaptive/dht.rs` change is a doc-only fix replacing an unresolvable intra-doc link to a private constant with a plain code span, preventing a `--deny=warnings` build failure.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a well-motivated single-constant bump backed by real testnet measurements, and all remaining findings are P2 style suggestions.

Both findings are P2: one is a defensive `saturating_add` style preference (the overflow is impossible in practice), and the other suggests adding boundary tests. Neither represents a present defect or regression. The fix itself is correct, symmetric, and well-documented.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The widened acceptance window (300 s instead of 30 s) slightly expands the theoretical replay window from ~330 s to 600 s, but messages are signed with ML-DSA-65 over the timestamp, preventing cross-sender forgery. Without a nonce/dedup cache (pre-existing architecture) the timestamp window is the only anti-replay layer, which is unchanged in character.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/network.rs | MAX_FUTURE_SECS changed from 30 to 300 (symmetric with MAX_MESSAGE_AGE_SECS); doc comment updated with testnet-observed rationale; no logic changes to validation code. |
| src/adaptive/dht.rs | Doc-only fix: replaces `[`MAX_CONSUMER_WEIGHT`]` intra-doc link (unresolvable for a private const) with a plain backtick span to fix `--deny=warnings` in cargo doc. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming WireMessage] --> B[Deserialize postcard bytes]
    B --> C{Deserialize OK?}
    C -- No --> REJECT1[return None]
    C -- Yes --> D[Get current Unix timestamp: now]
    D --> E{timestamp < now - MAX_MESSAGE_AGE_SECS 300s stale window}
    E -- Yes --> REJECT2[warn: stale message return None]
    E -- No --> F{timestamp > now + MAX_FUTURE_SECS 300s future window was 30s}
    F -- Yes --> REJECT3[warn: future-dated message return None]
    F -- No --> G{signature present?}
    G -- Yes --> H[verify_message_signature ML-DSA-65]
    H -- Fail --> REJECT4[warn: sig verify failed return None]
    H -- OK --> I[authenticated_node_id = Some peer_id]
    G -- No --> J[authenticated_node_id = None]
    I --> K[return ParsedMessage]
    J --> K
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/network.rs`, line 1674 ([link](https://github.com/saorsa-labs/saorsa-core/blob/3183f1d4f412d79974dc2325fc90a7009b68a0a0/src/network.rs#L1674)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Use `saturating_add` for future-timestamp guard**

   `now + MAX_FUTURE_SECS` is an unchecked `u64` addition. In debug builds Rust panics on overflow; in release it wraps silently, which would cause the check to accept arbitrarily-large timestamps. The value can never overflow in practice (current Unix epoch ~1.78 B << `u64::MAX`), but `saturating_add` makes the intent explicit and is zero-cost.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/network.rs
   Line: 1674

   Comment:
   **Use `saturating_add` for future-timestamp guard**

   `now + MAX_FUTURE_SECS` is an unchecked `u64` addition. In debug builds Rust panics on overflow; in release it wraps silently, which would cause the check to accept arbitrarily-large timestamps. The value can never overflow in practice (current Unix epoch ~1.78 B << `u64::MAX`), but `saturating_add` makes the intent explicit and is zero-cost.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/network.rs
Line: 1674

Comment:
**Use `saturating_add` for future-timestamp guard**

`now + MAX_FUTURE_SECS` is an unchecked `u64` addition. In debug builds Rust panics on overflow; in release it wraps silently, which would cause the check to accept arbitrarily-large timestamps. The value can never overflow in practice (current Unix epoch ~1.78 B << `u64::MAX`), but `saturating_add` makes the intent explicit and is zero-cost.

```suggestion
    if message.timestamp > now.saturating_add(MAX_FUTURE_SECS) {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/network.rs
Line: 1627-1629

Comment:
**No boundary tests for timestamp rejection**

The test suite uses only `current_timestamp()`, so it never exercises the rejection paths that were just changed. A regression that accidentally sets `MAX_FUTURE_SECS = 3` (a typo) or breaks the `>` comparison would go unnoticed. Two small tests — one with `current_timestamp() + MAX_FUTURE_SECS + 1` and one with `current_timestamp() - MAX_MESSAGE_AGE_SECS - 1` — would pin the behaviour permanently.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: increase clock skew tolerance from ..."](https://github.com/saorsa-labs/saorsa-core/commit/3183f1d4f412d79974dc2325fc90a7009b68a0a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27668951)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->