### PR TITLE
fix: clock skew tolerance 30s -> 5min (proven by Mac upload to NAT testnet)

### DIFF
--- a/src/adaptive/dht.rs
+++ b/src/adaptive/dht.rs
@@ -81,7 +81,7 @@ impl AdaptiveDhtConfig {
 /// consumer's responsibility via [`ApplicationSuccess`](Self::ApplicationSuccess).
 ///
 /// Consumer-reported events carry a weight multiplier that controls the
-/// severity of the update (clamped to [`MAX_CONSUMER_WEIGHT`]).
+/// severity of the update (clamped to `MAX_CONSUMER_WEIGHT`).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TrustEvent {
     // === Negative signals (core) ===

--- a/src/network.rs
+++ b/src/network.rs
@@ -235,7 +235,7 @@ pub struct NodeConfig {
     ///
     /// Controls whether peers with low trust scores are eligible for
     /// swap-out from the routing table when better candidates arrive. Use
-    /// [`NodeConfigBuilder::trust_enforcement`] for a simple on/off toggle.
+    /// `NodeConfigBuilder::trust_enforcement` for a simple on/off toggle.
     ///
     /// Default: enabled with a swap threshold of 0.35.
     #[serde(default)]
@@ -741,7 +741,7 @@ const QUIC_TEARDOWN_GRACE: Duration = Duration::from_millis(100);
 /// - Handle network events and peer lifecycle
 ///
 /// Transport concerns (connections, messaging, events) are delegated to
-/// [`TransportHandle`](crate::transport_handle::TransportHandle).
+/// `TransportHandle`.
 pub struct P2PNode {
     /// Node configuration
     config: NodeConfig,
@@ -978,7 +978,7 @@ impl P2PNode {
     ///
     /// # Returns
     ///
-    /// A [`PeerResponse`] on success, or an error on timeout / connection failure.
+    /// A `PeerResponse` on success, or an error on timeout / connection failure.
     ///
     /// # Example
     ///
@@ -1613,13 +1613,20 @@ impl P2PNode {
 /// can pass it directly to `send_message()`. This eliminates a spoofing
 /// vector where a peer could claim an arbitrary identity via the payload.
 ///
-/// Maximum allowed clock skew for message timestamps (5 minutes).
-/// This is intentionally lenient for initial deployment to accommodate nodes with
-/// misconfigured clocks or high-latency network conditions. Can be tightened (e.g., to 60s)
-/// once the network stabilizes and node clock synchronization improves.
+/// Maximum allowed clock skew for message timestamps.
+///
+/// A decentralized network cannot assume participants have accurate clocks.
+/// Consumer devices commonly have clocks that drift by minutes (no NTP, wrong
+/// timezone offset applied to UTC, suspended laptops, VMs without guest
+/// additions, etc.). Both past and future windows must be symmetric and
+/// generous enough that normal clock drift does not partition the network.
+///
+/// 5 minutes in both directions provides replay protection while tolerating
+/// the clock skew observed in real-world deployments (31-42 seconds was
+/// measured between a macOS client and NTP-synced VPS nodes).
 const MAX_MESSAGE_AGE_SECS: u64 = 300;
-/// Maximum allowed future timestamp (30 seconds to account for clock drift)
-const MAX_FUTURE_SECS: u64 = 30;
+/// Maximum allowed future timestamp — symmetric with the past window.
+const MAX_FUTURE_SECS: u64 = 300;
 
 /// Convenience constructor for `P2PError::Network(NetworkError::ProtocolError(...))`.
 fn protocol_error(msg: impl std::fmt::Display) -> P2PError {


### PR DESCRIPTION
## Proven by live testnet upload from Mac

**3/3 uploads from a macOS client succeeded** (61s cold, 30-33s warm) to a 14-node NAT testnet across London, Amsterdam, NYC, and San Francisco. The Mac had 31 seconds of clock skew against the VPS nodes. Without this fix: 0/3 uploads.

## The change

```
- const MAX_FUTURE_SECS: u64 = 30;
+ const MAX_FUTURE_SECS: u64 = 300;
```

One constant. A decentralized network cannot reject messages from devices with slightly off clocks. 30 seconds was causing the network to partition for any node behind NTP by even half a minute.

## Testnet details

- 7 VMs on DigitalOcean (lon1, ams3, nyc1, sfo3)
- 14 node processes (3 bootstrap, 6 NAT, 2 public)
- 3 NAT nodes behind port-restricted iptables namespace simulation
- Upload client: macOS ARM (this Mac, 31s behind NTP)
- File: 10MB -> 3 chunks via self-encryption
- Payment: EVM batch on Arbitrum Sepolia
- 3 chunks stored on 4 peers each

## Reproduction

See saorsa-testnet PR for full reproduction scripts and documented results.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Widens the future-timestamp clock-skew window in `parse_protocol_message` from 30 s to 300 s, making it symmetric with the existing 5-minute past window (`MAX_MESSAGE_AGE_SECS`). The change is backed by measured 31–42 s of skew between a macOS client and NTP-synced VPS nodes, and validated by 3/3 successful testnet uploads that previously failed 0/3.

<h3>Confidence Score: 5/5</h3>

Safe to merge — testnet-proven fix with no logic errors; remaining findings are P2 style suggestions only.

Both changes are correct and well-motivated. The only open findings are a hardcoded literal in dead code and missing boundary tests — neither blocks merge.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

The wider future window (30 s → 5 min) marginally increases the replay-attack surface: a captured message can now be re-submitted up to 5 minutes after it was originally sent (matching the existing past window). However, the QUIC transport layer provides its own replay protection at the connection level, and 5 minutes is a standard industry tolerance (e.g., Kerberos). No higher-severity concerns identified.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/network.rs | Increases MAX_FUTURE_SECS from 30 → 300 (5 min) and expands the constant's doc comment; MAX_MESSAGE_AGE_SECS was already 300, so both windows are now symmetric. No logic errors; boundary tests are absent (P2). |
| src/adaptive/dht.rs | Doc-only fix: replaces broken rustdoc link syntax [`MAX_CONSUMER_WEIGHT`] with backtick-only `MAX_CONSUMER_WEIGHT`. No functional change. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming WireMessage bytes] --> B[Deserialize via postcard]
    B --> C{Timestamp < now - 300s?}
    C -- Yes --> D[Reject: stale message]
    C -- No --> E{Timestamp > now + 300s?}
    E -- Yes --> F[Reject: future-dated]
    E -- No --> G{Signature present?}
    G -- Yes --> H[Verify ML-DSA-65 signature]
    H -- Fail --> I[Reject: bad signature]
    H -- Pass --> J[Emit P2PEvent::Message with authenticated PeerId]
    G -- No --> K[Emit P2PEvent::Message source = transport peer ID]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/validation.rs`, line 461 ([link](https://github.com/saorsa-labs/saorsa-core/blob/3183f1d4f412d79974dc2325fc90a7009b68a0a0/src/validation.rs#L461)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Hardcoded `300` duplicates the new constant**

   `validation.rs` uses a literal `300` for the same future-timestamp guard that is now backed by `MAX_FUTURE_SECS` in `network.rs`. If the tolerance is tuned again, this copy will silently diverge. The struct is `#[allow(dead_code)]` today, but it's worth keeping the two in sync by referencing the shared constant (or at minimum adding an inline comment tying the value to `MAX_FUTURE_SECS`).

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/validation.rs
   Line: 461

   Comment:
   **Hardcoded `300` duplicates the new constant**

   `validation.rs` uses a literal `300` for the same future-timestamp guard that is now backed by `MAX_FUTURE_SECS` in `network.rs`. If the tolerance is tuned again, this copy will silently diverge. The struct is `#[allow(dead_code)]` today, but it's worth keeping the two in sync by referencing the shared constant (or at minimum adding an inline comment tying the value to `MAX_FUTURE_SECS`).

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/validation.rs
Line: 461

Comment:
**Hardcoded `300` duplicates the new constant**

`validation.rs` uses a literal `300` for the same future-timestamp guard that is now backed by `MAX_FUTURE_SECS` in `network.rs`. If the tolerance is tuned again, this copy will silently diverge. The struct is `#[allow(dead_code)]` today, but it's worth keeping the two in sync by referencing the shared constant (or at minimum adding an inline comment tying the value to `MAX_FUTURE_SECS`).

```suggestion
        if self.timestamp > now + 300 {
            // 5 minutes — matches network::MAX_FUTURE_SECS
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/network.rs
Line: 1627-1629

Comment:
**No test coverage for boundary conditions on the new 5-minute future window**

The existing tests only exercise the happy path (current timestamp). There are no tests that verify a message timestamped at `now + 299` is accepted and one at `now + 301` is rejected. Adding two boundary tests here would lock in the new value and catch any future accidental regression:

```rust
#[test]
fn test_parse_message_just_inside_future_window_is_accepted() {
    let ts = current_timestamp() + MAX_FUTURE_SECS - 1;
    let bytes = make_wire_bytes("test/v1", vec![1], "sender", ts);
    assert!(parse_protocol_message(&bytes, "peer").is_some());
}

#[test]
fn test_parse_message_beyond_future_window_is_rejected() {
    let ts = current_timestamp() + MAX_FUTURE_SECS + 10;
    let bytes = make_wire_bytes("test/v1", vec![1], "sender", ts);
    assert!(parse_protocol_message(&bytes, "peer").is_none());
}
```

(`MAX_FUTURE_SECS` would need to be `pub(crate)` or the literal `300` used in the test.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: increase clock skew tolerance from ..."](https://github.com/saorsa-labs/saorsa-core/commit/3183f1d4f412d79974dc2325fc90a7009b68a0a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27692367)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->