### PR TITLE
fix: randomize hint republish interval and reduce log verbosity

### DIFF
--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -94,11 +94,14 @@ const SELF_LOOKUP_INTERVAL_MAX: Duration = Duration::from_secs(600); // 10 minut
 /// Periodic refresh cadence for stale k-buckets.
 const BUCKET_REFRESH_INTERVAL: Duration = Duration::from_secs(600); // 10 minutes
 
-/// How often NAT nodes republish their coordinator hints to connected peers.
-/// Keeps hints fresh so stale coordinator addresses get replaced before they
-/// accumulate NACK failures. Short enough to track coordinator churn, long
-/// enough to avoid flooding.
-const HINT_REPUBLISH_INTERVAL: Duration = Duration::from_secs(120); // 2 minutes
+/// Minimum interval for NAT coordinator hint republishing (randomized between
+/// min and max). Keeps hints fresh so stale coordinator addresses get replaced
+/// before they accumulate NACK failures. Randomized to prevent thundering-herd
+/// spikes when many nodes republish simultaneously.
+const HINT_REPUBLISH_INTERVAL_MIN: Duration = Duration::from_secs(90); // 1.5 minutes
+
+/// Maximum interval for NAT coordinator hint republishing.
+const HINT_REPUBLISH_INTERVAL_MAX: Duration = Duration::from_secs(150); // 2.5 minutes
 
 /// Routing table size below which automatic re-bootstrap is triggered.
 const AUTO_REBOOTSTRAP_THRESHOLD: usize = 3;
@@ -455,7 +458,7 @@ impl DhtNetworkManager {
             let hint_count = Self::extract_coordinator_hints(node).len();
             let addrs: Vec<String> = node.addresses.iter().map(|a| format!("{}", a)).collect();
             if hint_count > 0 {
-                info!(
+                debug!(
                     "FindNode response includes {} coordinator hint(s) for peer {}",
                     hint_count,
                     hex::encode(&node.peer_id.to_bytes()[..8])
@@ -636,7 +639,7 @@ impl DhtNetworkManager {
 
     /// Spawn the periodic coordinator hint republish task.
     ///
-    /// Every [`HINT_REPUBLISH_INTERVAL`], builds the local node's DHT record
+    /// Every [`HINT_REPUBLISH_INTERVAL_MIN`]–[`HINT_REPUBLISH_INTERVAL_MAX`], builds the local node's DHT record
     /// (including coordinator hints), then sends a `PublishAddress` with those
     /// addresses to the K closest peers. Receiving nodes merge the hints into
     /// their routing table so they can propagate them in FindNode responses.
@@ -647,8 +650,13 @@ impl DhtNetworkManager {
 
         let handle = tokio::spawn(async move {
             loop {
+                let interval = Self::randomised_interval(
+                    HINT_REPUBLISH_INTERVAL_MIN,
+                    HINT_REPUBLISH_INTERVAL_MAX,
+                );
+
                 tokio::select! {
-                    () = tokio::time::sleep(HINT_REPUBLISH_INTERVAL) => {}
+                    () = tokio::time::sleep(interval) => {}
                     () = shutdown.cancelled() => break,
                 }
 
@@ -859,7 +867,7 @@ impl DhtNetworkManager {
                 if let Some(target_addr) = Self::first_dialable_address(&direct)
                     .and_then(|a| a.dialable_socket_addr())
                 {
-                    info!(
+                    debug!(
                         "Setting {} coordinator hint(s) for NAT node {} from DHT record",
                         hint_addrs.len(),
                         hex::encode(&entry.node.peer_id.to_bytes()[..8])
@@ -886,7 +894,7 @@ impl DhtNetworkManager {
                         .await
                 };
                 if stored > 0 {
-                    info!(
+                    debug!(
                         "Merged {} coordinator hint(s) into routing table for peer {}",
                         stored,
                         hex::encode(&entry.node.peer_id.to_bytes()[..8])
@@ -1273,7 +1281,7 @@ impl DhtNetworkManager {
                                     Self::first_dialable_address(&direct)
                                         .and_then(|a| a.dialable_socket_addr())
                                 {
-                                    info!(
+                                    debug!(
                                         "Setting {} coordinator hint(s) for NAT node {} from DHT record",
                                         hint_addrs.len(),
                                         hex::encode(&node.peer_id.to_bytes()[..8])
@@ -1304,7 +1312,7 @@ impl DhtNetworkManager {
                                     .await
                                 };
                                 if stored > 0 {
-                                    info!(
+                                    debug!(
                                         "Merged {} coordinator hint(s) into routing table for peer {}",
                                         stored,
                                         hex::encode(&node.peer_id.to_bytes()[..8])
@@ -1744,7 +1752,7 @@ impl DhtNetworkManager {
         // Send message via network layer, reconnecting on demand if needed.
         let peer_hex = peer_id.to_hex();
         let local_hex = self.config.peer_id.to_hex();
-        info!(
+        debug!(
             "[STEP 1] {} -> {}: Sending {:?} request (msg_id: {})",
             local_hex, peer_hex, message.payload, message_id
         );
@@ -1860,7 +1868,7 @@ impl DhtNetworkManager {
             .await
         {
             Ok(_) => {
-                info!(
+                debug!(
                     "[STEP 2] {} -> {}: Message sent successfully, waiting for response...",
                     local_hex, peer_hex
                 );
@@ -1870,7 +1878,7 @@ impl DhtNetworkManager {
                     .wait_for_response(&message_id, response_rx, peer_id)
                     .await;
                 match &result {
-                    Ok(r) => info!(
+                    Ok(r) => debug!(
                         "[STEP 6] {} <- {}: Got response: {:?}",
                         local_hex,
                         peer_hex,
@@ -2227,7 +2235,7 @@ impl DhtNetworkManager {
                 }
 
                 if !hints.is_empty() {
-                    info!(
+                    debug!(
                         "Received {} coordinator hint(s) for peer {} via publish",
                         hints.len(),
                         authenticated_sender
@@ -2237,7 +2245,7 @@ impl DhtNetworkManager {
                         .merge_coordinator_hints(authenticated_sender, hints)
                         .await;
                     if stored > 0 {
-                        info!(
+                        debug!(
                             "Merged {} coordinator hint(s) into routing table for peer {}",
                             stored,
                             authenticated_sender


### PR DESCRIPTION
## Summary

- Randomize the coordinator hint republish interval from a fixed 120s to a range of 90-150s, preventing thundering-herd bandwidth and CPU spikes when all nodes republish simultaneously
- Downgrade 7 high-frequency coordinator hint and DHT request tracing log lines from `info!` to `debug!`, reducing log volume from ~45,000 to ~930 entries per spike minute (48x reduction)

## Problem

On a 67-node testnet, the fixed `HINT_REPUBLISH_INTERVAL = 120s` caused all nodes to publish coordinator hints to their K-closest peers at roughly the same time (since they all started within minutes of each other). This produced:
- Synchronized bandwidth spikes of 8-14 MB/s per node every 2 minutes
- CPU spikes from 5% baseline to 10-22%
- 23,000-45,000 log entries per spike minute vs 5,000-7,000 baseline (per node)

## Changes

- Replace `HINT_REPUBLISH_INTERVAL` (120s fixed) with `HINT_REPUBLISH_INTERVAL_MIN` (90s) / `HINT_REPUBLISH_INTERVAL_MAX` (150s), using the existing `randomised_interval()` helper
- Downgrade to `debug!`: `[STEP 1/2/6]` DHT request tracing, `FindNode response includes coordinator hints`, `Setting/Merged coordinator hints`, `Received coordinator hints via publish`
- Keep `Publishing N coordinator hints to M peers` at `info!` (fires once per cycle per node, useful for monitoring)

## Test plan

- [x] Deployed on 67-node testnet (`ant-test-herd-fix`) across 4 cloud providers with 20% NAT
- [x] Verified CPU spikes significantly reduced on Grafana
- [x] Verified log volume reduced ~48x during hint republish cycles
- [x] Verified all nodes discover peers and maintain routing tables
- [x] Verified NAT traversal still works (0 false symmetric NAT detections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR randomizes the coordinator hint republish interval (90–150 s) and downgrades several high-frequency log lines from `info!` to `debug!` to address thundering-herd bandwidth and log-volume spikes observed on a 67-node testnet. The interval randomization is implemented correctly, but the log-level reduction is incomplete.

- Three "Setting/Merged coordinator hints" `info!` log lines in `find_closest_nodes_network` (lines 1284, 1315) and the `PublishAddress` request handler (line 2248) were not downgraded to `debug!` as the PR description claims — the equivalent lines in the bootstrap path were correctly changed, but these higher-frequency lookup and per-receive-publish paths were missed.
- The doc-comment at line 642 references the removed `HINT_REPUBLISH_INTERVAL` constant and will produce a rustdoc broken-link warning.

<h3>Confidence Score: 3/5</h3>

The interval jitter is correct and safe to merge, but the log-reduction fix is incomplete — three `info!` lines were missed, partially defeating the stated goal.

Two P1 findings: "Setting/Merged coordinator hints" in the iterative lookup path (lines 1284, 1315) and the PublishAddress handler (line 2248) remain at `info!` despite the PR explicitly claiming they were downgraded. These are high-frequency paths that fire on every self-lookup and every received publish, so the log-volume reduction will be less than the ~48x claimed. The core interval-randomization change is correct and low-risk.

src/dht_network_manager.rs — lines 1284, 1315 (find_closest_nodes_network) and line 2248 (PublishAddress handler) need `info!` → `debug!` downgrade.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/dht_network_manager.rs | Interval randomization (90-150s) is correctly implemented via the existing `randomised_interval` helper; however, "Setting/Merged coordinator hints" log lines at `info!` in `find_closest_nodes_network` (lines 1284, 1315) and the `PublishAddress` handler (line 2248) were not downgraded to `debug!` as stated, partially defeating the log-volume reduction goal. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/dht_network_manager.rs`, line 1284-1319 ([link](https://github.com/saorsa-labs/saorsa-core/blob/5c81353471afee14e8d81615a1eb45e795c1c52a/src/dht_network_manager.rs#L1284-L1319)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missed `info!` → `debug!` downgrade in iterative lookup path**

   The PR description states "Setting/Merged coordinator hints" were downgraded to `debug!`, but two occurrences inside `find_closest_nodes_network` were left at `info!`. This path fires on every self-lookup (every 5-10 min, alpha=3) and processes each NAT node with hints per iteration, meaning these lines contribute significantly to the spike volume the PR is trying to reduce.

   The equivalent log lines in `bootstrap_from_peers` (lines ~870, ~897) were correctly downgraded to `debug!`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/dht_network_manager.rs
   Line: 1284-1319

   Comment:
   **Missed `info!` → `debug!` downgrade in iterative lookup path**

   The PR description states "Setting/Merged coordinator hints" were downgraded to `debug!`, but two occurrences inside `find_closest_nodes_network` were left at `info!`. This path fires on every self-lookup (every 5-10 min, alpha=3) and processes each NAT node with hints per iteration, meaning these lines contribute significantly to the spike volume the PR is trying to reduce.

   The equivalent log lines in `bootstrap_from_peers` (lines ~870, ~897) were correctly downgraded to `debug!`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/dht_network_manager.rs`, line 2248-2252 ([link](https://github.com/saorsa-labs/saorsa-core/blob/5c81353471afee14e8d81615a1eb45e795c1c52a/src/dht_network_manager.rs#L2248-L2252)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Another missed `info!` → `debug!` downgrade in `PublishAddress` handler**

   "Merged coordinator hint(s) into routing table" fires in the `PublishAddress` request handler every time a node receives published hints. With 67 nodes each republishing to ~20 K-closest peers per cycle, up to 20 × 67 = 1,340 executions of this path fire per cycle. The PR description explicitly lists this message as one to downgrade, and the `Received coordinator hints via publish` guard at line 2238 was already changed, but this second `info!` on the `stored > 0` branch was not.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/dht_network_manager.rs
   Line: 2248-2252

   Comment:
   **Another missed `info!` → `debug!` downgrade in `PublishAddress` handler**

   "Merged coordinator hint(s) into routing table" fires in the `PublishAddress` request handler every time a node receives published hints. With 67 nodes each republishing to ~20 K-closest peers per cycle, up to 20 × 67 = 1,340 executions of this path fire per cycle. The PR description explicitly lists this message as one to downgrade, and the `Received coordinator hints via publish` guard at line 2238 was already changed, but this second `info!` on the `stored > 0` branch was not.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `src/dht_network_manager.rs`, line 642 ([link](https://github.com/saorsa-labs/saorsa-core/blob/5c81353471afee14e8d81615a1eb45e795c1c52a/src/dht_network_manager.rs#L642)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale doc-comment references removed constant**

   The doc comment still links to `` [`HINT_REPUBLISH_INTERVAL`] `` which was replaced by `HINT_REPUBLISH_INTERVAL_MIN`/`HINT_REPUBLISH_INTERVAL_MAX` in this PR. `rustdoc` will emit a broken-link warning for this.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/dht_network_manager.rs
   Line: 642

   Comment:
   **Stale doc-comment references removed constant**

   The doc comment still links to `` [`HINT_REPUBLISH_INTERVAL`] `` which was replaced by `HINT_REPUBLISH_INTERVAL_MIN`/`HINT_REPUBLISH_INTERVAL_MAX` in this PR. `rustdoc` will emit a broken-link warning for this.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/dht_network_manager.rs
Line: 1284-1319

Comment:
**Missed `info!` → `debug!` downgrade in iterative lookup path**

The PR description states "Setting/Merged coordinator hints" were downgraded to `debug!`, but two occurrences inside `find_closest_nodes_network` were left at `info!`. This path fires on every self-lookup (every 5-10 min, alpha=3) and processes each NAT node with hints per iteration, meaning these lines contribute significantly to the spike volume the PR is trying to reduce.

The equivalent log lines in `bootstrap_from_peers` (lines ~870, ~897) were correctly downgraded to `debug!`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/dht_network_manager.rs
Line: 2248-2252

Comment:
**Another missed `info!` → `debug!` downgrade in `PublishAddress` handler**

"Merged coordinator hint(s) into routing table" fires in the `PublishAddress` request handler every time a node receives published hints. With 67 nodes each republishing to ~20 K-closest peers per cycle, up to 20 × 67 = 1,340 executions of this path fire per cycle. The PR description explicitly lists this message as one to downgrade, and the `Received coordinator hints via publish` guard at line 2238 was already changed, but this second `info!` on the `stored > 0` branch was not.

```suggestion
                        debug!(
                            "Merged {} coordinator hint(s) into routing table for peer {}",
                            stored,
                            authenticated_sender
                        );
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/dht_network_manager.rs
Line: 642

Comment:
**Stale doc-comment references removed constant**

The doc comment still links to `` [`HINT_REPUBLISH_INTERVAL`] `` which was replaced by `HINT_REPUBLISH_INTERVAL_MIN`/`HINT_REPUBLISH_INTERVAL_MAX` in this PR. `rustdoc` will emit a broken-link warning for this.

```suggestion
    /// Every interval between [`HINT_REPUBLISH_INTERVAL_MIN`] and [`HINT_REPUBLISH_INTERVAL_MAX`],
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: randomize hint republish interval a..."](https://github.com/saorsa-labs/saorsa-core/commit/5c81353471afee14e8d81615a1eb45e795c1c52a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28102814)</sub>

<!-- /greptile_comment -->