### PR TITLE
fix: prevent DHT background tasks from blocking shutdown under active traffic

### DIFF
--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -553,15 +553,20 @@ impl DhtNetworkManager {
                     () = shutdown.cancelled() => break,
                 }
 
-                if let Err(e) = this.trigger_self_lookup().await {
-                    warn!("Periodic self-lookup failed: {e}");
+                // Wrap the work in a select so shutdown cancels in-progress
+                // operations rather than waiting for them to complete. Without
+                // this, iterative DHT lookups under active traffic can block
+                // for minutes, preventing the task from noticing shutdown.
+                tokio::select! {
+                    () = shutdown.cancelled() => break,
+                    _ = async {
+                        if let Err(e) = this.trigger_self_lookup().await {
+                            warn!("Periodic self-lookup failed: {e}");
+                        }
+                        this.revalidate_stale_k_closest().await;
+                        this.maybe_rebootstrap().await;
+                    } => {}
                 }
-
-                // Evict any stale K-closest peers that fail to respond.
-                this.revalidate_stale_k_closest().await;
-
-                // Check if routing table is depleted after the self-lookup.
-                this.maybe_rebootstrap().await;
             }
         });
         *handle_slot.write().await = Some(handle);
@@ -585,53 +590,63 @@ impl DhtNetworkManager {
                     () = shutdown.cancelled() => break,
                 }
 
-                let stale_indices = this
-                    .dht
-                    .read()
-                    .await
-                    .stale_bucket_indices(STALE_BUCKET_THRESHOLD)
-                    .await;
+                // Wrap the work in a select so shutdown cancels in-progress
+                // lookups rather than waiting for all buckets to be refreshed.
+                let shutdown_ref = &shutdown;
+                tokio::select! {
+                    () = shutdown.cancelled() => break,
+                    _ = async {
+                        let stale_indices = this
+                            .dht
+                            .read()
+                            .await
+                            .stale_bucket_indices(STALE_BUCKET_THRESHOLD)
+                            .await;
 
-                if stale_indices.is_empty() {
-                    trace!("Bucket refresh: no stale buckets");
-                    continue;
-                }
+                        if stale_indices.is_empty() {
+                            trace!("Bucket refresh: no stale buckets");
+                            return;
+                        }
 
-                debug!("Bucket refresh: {} stale buckets", stale_indices.len());
-                let k = this.k_value();
+                        debug!("Bucket refresh: {} stale buckets", stale_indices.len());
+                        let k = this.k_value();
 
-                for bucket_idx in stale_indices {
-                    let random_key = {
-                        let dht = this.dht.read().await;
-                        dht.generate_random_key_for_bucket(bucket_idx)
-                    };
-                    let Some(key) = random_key else {
-                        continue;
-                    };
+                        for bucket_idx in stale_indices {
+                            if shutdown_ref.is_cancelled() {
+                                break;
+                            }
+                            let random_key = {
+                                let dht = this.dht.read().await;
+                                dht.generate_random_key_for_bucket(bucket_idx)
+                            };
+                            let Some(key) = random_key else {
+                                continue;
+                            };
 
-                    let key_bytes: Key = *key.as_bytes();
-                    match this.find_closest_nodes_network(&key_bytes, k).await {
-                        Ok(nodes) => {
-                            trace!(
-                                "Bucket refresh[{bucket_idx}]: discovered {} peers",
-                                nodes.len()
-                            );
-                            for dht_node in nodes {
-                                if dht_node.peer_id == this.config.peer_id {
-                                    continue;
+                            let key_bytes: Key = *key.as_bytes();
+                            match this.find_closest_nodes_network(&key_bytes, k).await {
+                                Ok(nodes) => {
+                                    trace!(
+                                        "Bucket refresh[{bucket_idx}]: discovered {} peers",
+                                        nodes.len()
+                                    );
+                                    for dht_node in nodes {
+                                        if dht_node.peer_id == this.config.peer_id {
+                                            continue;
+                                        }
+                                        this.dial_addresses(&dht_node.peer_id, &dht_node.addresses, None)
+                                            .await;
+                                    }
                                 }
-                                this.dial_addresses(&dht_node.peer_id, &dht_node.addresses, None)
-                                    .await;
+                                Err(e) => {
+                                    debug!("Bucket refresh[{bucket_idx}] lookup failed: {e}");
+                                }
                             }
                         }
-                        Err(e) => {
-                            debug!("Bucket refresh[{bucket_idx}] lookup failed: {e}");
-                        }
-                    }
-                }
 
-                // Check if routing table is depleted after refresh.
-                this.maybe_rebootstrap().await;
+                        this.maybe_rebootstrap().await;
+                    } => {}
+                }
             }
         });
         *handle_slot.write().await = Some(handle);
@@ -660,41 +675,48 @@ impl DhtNetworkManager {
                     () = shutdown.cancelled() => break,
                 }
 
-                // Build current local DHT node record (includes coordinator hints)
-                let local_node = this.local_dht_node().await;
-                if local_node.addresses.is_empty() {
-                    continue;
+                // Wrap the work in a select so shutdown cancels in-progress
+                // publish operations.
+                tokio::select! {
+                    () = shutdown.cancelled() => break,
+                    _ = async {
+                        // Build current local DHT node record (includes coordinator hints)
+                        let local_node = this.local_dht_node().await;
+                        if local_node.addresses.is_empty() {
+                            return;
+                        }
+
+                        // Only republish if we have coordinator hints
+                        let hint_count = Self::extract_coordinator_hints(&local_node).len();
+                        if hint_count == 0 {
+                            trace!("Hint republish: no coordinator hints to publish");
+                            return;
+                        }
+
+                        // Send to K closest peers
+                        let k = this.k_value();
+                        let self_key: Key = *this.config.peer_id.as_bytes();
+                        let closest = this.find_closest_nodes_local(&self_key, k).await;
+
+                        let peer_count = closest.len();
+                        let hint_addrs: Vec<String> = local_node
+                            .addresses
+                            .iter()
+                            .filter(|a| {
+                                a.peer_id()
+                                    .map_or(false, |pid| *pid != local_node.peer_id)
+                            })
+                            .map(|a| format!("{}", a))
+                            .collect();
+                        info!(
+                            "Publishing {} coordinator hint(s) to {} connected peers: {:?}",
+                            hint_count, peer_count, hint_addrs
+                        );
+
+                        this.publish_address_to_peers(local_node.addresses, &closest)
+                            .await;
+                    } => {}
                 }
-
-                // Only republish if we have coordinator hints
-                let hint_count = Self::extract_coordinator_hints(&local_node).len();
-                if hint_count == 0 {
-                    trace!("Hint republish: no coordinator hints to publish");
-                    continue;
-                }
-
-                // Send to K closest peers
-                let k = this.k_value();
-                let self_key: Key = *this.config.peer_id.as_bytes();
-                let closest = this.find_closest_nodes_local(&self_key, k).await;
-
-                let peer_count = closest.len();
-                let hint_addrs: Vec<String> = local_node
-                    .addresses
-                    .iter()
-                    .filter(|a| {
-                        a.peer_id()
-                            .map_or(false, |pid| *pid != local_node.peer_id)
-                    })
-                    .map(|a| format!("{}", a))
-                    .collect();
-                info!(
-                    "Publishing {} coordinator hint(s) to {} connected peers: {:?}",
-                    hint_count, peer_count, hint_addrs
-                );
-
-                this.publish_address_to_peers(local_node.addresses, &closest)
-                    .await;
             }
         });
         *handle_slot.write().await = Some(handle);
@@ -953,13 +975,21 @@ impl DhtNetworkManager {
         // Signal background tasks to stop
         self.dht.read().await.signal_shutdown();
 
-        // Join all background tasks
+        // Join all background tasks with a timeout. The tasks check
+        // `shutdown.cancelled()` but may be mid-operation when cancel fires.
+        // The select-wrapped work blocks (added to fix shutdown hangs under
+        // active traffic) should make tasks exit promptly, but as defense in
+        // depth we abort any task that doesn't stop within 10 seconds.
         async fn join_task(name: &str, slot: &RwLock<Option<tokio::task::JoinHandle<()>>>) {
-            if let Some(handle) = slot.write().await.take() {
-                match handle.await {
-                    Ok(()) => debug!("{name} task stopped cleanly"),
-                    Err(e) if e.is_cancelled() => debug!("{name} task was cancelled"),
-                    Err(e) => warn!("{name} task panicked: {e}"),
+            if let Some(mut handle) = slot.write().await.take() {
+                match tokio::time::timeout(std::time::Duration::from_secs(10), &mut handle).await {
+                    Ok(Ok(())) => debug!("{name} task stopped cleanly"),
+                    Ok(Err(e)) if e.is_cancelled() => debug!("{name} task was cancelled"),
+                    Ok(Err(e)) => warn!("{name} task panicked: {e}"),
+                    Err(_) => {
+                        warn!("{name} task did not stop within 10s, aborting");
+                        handle.abort();
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- DHT background tasks (self-lookup, bucket-refresh, hint-republish) did long-running network work outside their `tokio::select!` block, preventing shutdown cancellation from being noticed for minutes or hours under active client traffic
- Wrap each task's work block in `tokio::select!` with `shutdown.cancelled()` so in-progress operations are cancelled immediately
- Add 10-second timeout to task joins in `DhtNetworkManager::stop()` as defense in depth

## Context

Discovered during auto-upgrade testing on a 100-node testnet with 3 clients continuously uploading/downloading 10MB files. Nodes that attempted graceful shutdown while clients were active got stuck indefinitely at `DhtNetworkManager::stop()` — the task joins never completed because the tasks were mid-operation in iterative DHT lookups that kept discovering new peers.

On a quiet network, shutdown completed in ~1 second. Under active traffic, it hung forever.

## Test plan

- [x] Tested on 97-node testnet with active uploads — resolved hang for 98% of nodes (remaining 2% were in the replication engine, fixed separately in WithAutonomi/ant-node)
- [x] Tested on 151-node testnet with active uploads — 100% of nodes (151/151 services) restarted cleanly, 0 hangs, 0 upload failures throughout the rollout
- [x] `cargo test` passes
- [x] `cargo check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a real shutdown hang by wrapping the work blocks of the three periodic DHT background tasks (`self-lookup`, `bucket-refresh`, `hint-republish`) in a second `tokio::select!` arm on `shutdown.cancelled()`, so in-progress iterative lookups are dropped immediately rather than running to completion. A 10-second `join_task` timeout is added in `stop()` as defence in depth.

- The `join_task` timeout passes the `JoinHandle` by value into `tokio::time::timeout`, so when the 10-second deadline fires the handle is dropped (detached) rather than aborted — orphaned tasks continue holding `Arc<Self>` and may keep issuing network calls after the transport has stopped. The fix is to retain a `mut handle` and call `handle.abort()` in the `Err(_)` arm.

<h3>Confidence Score: 4/5</h3>

- The primary fix (select!-wrapped work blocks) is correct and well-tested; one P1 logic error in the timeout fallback means tasks are orphaned rather than aborted, but this code path is rarely hit in practice.
- The core shutdown-hang fix is sound and proven on large testnets. The single P1 issue — `join_task` dropping the handle instead of calling `handle.abort()` on timeout — means the defence-in-depth fallback silently fails: if a task somehow survives past 10 seconds it keeps running after `stop()` returns, holding `Arc<Self>` references and potentially issuing network calls on a stopped transport. This should be fixed before merge.
- src/dht_network_manager.rs — specifically the `join_task` inner function in `stop()` (lines 983–992)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dht_network_manager.rs | Wraps background task work bodies in `tokio::select!` with `shutdown.cancelled()` to allow cancellation mid-operation; adds 10-second `join_task` timeout in `stop()` as defence-in-depth, but the timeout drops rather than aborts the handle so stuck tasks are orphaned instead of terminated. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[stop called] --> B[leave_network]
    B --> C[shutdown.cancel]
    C --> D[dht.signal_shutdown]
    D --> E[join event-handler task with 10s timeout]
    E --> F[join self-lookup task with 10s timeout]
    F --> G[join bucket-refresh task with 10s timeout]
    G --> H[join hint-republish task with 10s timeout]
    H --> I[stop returns Ok]

    C -.->|cancelled fires| J[self-lookup work select breaks]
    C -.->|cancelled fires| K[bucket-refresh work select breaks]
    C -.->|cancelled fires| L[hint-republish work select breaks]

    E -->|timeout fires| M[handle dropped not aborted - task orphaned]
    F -->|timeout fires| M
    G -->|timeout fires| M
    H -->|timeout fires| M
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/dht_network_manager.rs
Line: 983-992

Comment:
**Task not actually aborted on timeout**

`tokio::time::timeout(dur, handle)` moves the `JoinHandle` *into* the timeout future. When the deadline fires and `Err(Elapsed)` is returned, the inner `JoinHandle` is dropped — and in Tokio, dropping a `JoinHandle` **detaches** the task; it does not abort it. The comment says "we abort any task that doesn't stop within 10 seconds" but the task actually keeps running, potentially holding `Arc<Self>` references and continuing to issue network calls after the transport has been shut down.

Fix by keeping the handle mutable so `.abort()` can be called on timeout:

```rust
async fn join_task(name: &str, slot: &RwLock<Option<tokio::task::JoinHandle<()>>>) {
    if let Some(mut handle) = slot.write().await.take() {
        match tokio::time::timeout(std::time::Duration::from_secs(10), &mut handle).await {
            Ok(Ok(())) => debug!("{name} task stopped cleanly"),
            Ok(Err(e)) if e.is_cancelled() => debug!("{name} task was cancelled"),
            Ok(Err(e)) => warn!("{name} task panicked: {e}"),
            Err(_) => {
                warn!("{name} task did not stop within 10s, aborting");
                handle.abort();
            }
        }
    }
}
```

`JoinHandle<T>: Unpin`, so `&mut handle` satisfies `timeout`'s `F: Future` bound without moving ownership.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prevent DHT background tasks from b..."](https://github.com/saorsa-labs/saorsa-core/commit/13966da2baaa9b0871cc4c411e1ecb0bdf32ccb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28348869)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->