### PR TITLE
fix: spawn accept loop registration to prevent handshake channel stall

### DIFF
--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -1528,12 +1528,26 @@ impl TransportHandle {
                     continue;
                 }
 
-                let channel_id = remote_sock.to_string();
-                let remote_addr = MultiAddr::quic(remote_sock);
-                // PeerConnected is emitted later when the peer's identity is
-                // authenticated via a signed message — not at transport level.
-                register_new_channel(&peers, &channel_id, &remote_addr).await;
-                active_connections.write().await.insert(channel_id);
+                // Spawn registration work so the accept loop immediately
+                // returns to draining the handshake channel. Previously
+                // the two write locks below were taken inline, serialising
+                // the accept loop behind `peers` and `active_connections`
+                // contention. In a 1000-node network this caused the
+                // bounded handshake channel (cap 32) to fill, blocking all
+                // new connection handoffs and stalling identity exchange.
+                let peers = peers.clone();
+                let active_connections = active_connections.clone();
+                let handle = tokio::spawn(async move {
+                    let channel_id = remote_sock.to_string();
+                    let remote_addr = MultiAddr::quic(remote_sock);
+                    register_new_channel(&peers, &channel_id, &remote_addr).await;
+                    active_connections.write().await.insert(channel_id);
+                });
+                tokio::spawn(async move {
+                    if let Err(e) = handle.await {
+                        warn!("Accept registration task failed: {}", e);
+                    }
+                });
             }
         });
         *self.listener_handle.write().await = Some(handle);

--- a/tests/accept_loop_stress.rs
+++ b/tests/accept_loop_stress.rs
@@ -1,0 +1,153 @@
+// Copyright 2024 Saorsa Labs Limited
+//
+// This software is dual-licensed under:
+// - GNU Affero General Public License v3.0 or later (AGPL-3.0-or-later)
+// - Commercial License
+//
+// For AGPL-3.0 license, see LICENSE-AGPL-3.0
+// For commercial licensing, contact: david@saorsalabs.com
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under these licenses is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+//! Stress test for the accept loop under connection pressure.
+//!
+//! Reproduces a bug where the accept loop stalled after 15+ hours in a
+//! 1000-node testnet. The root cause was the accept loop taking two write
+//! locks (`peers` and `active_connections`) inline, serialising behind
+//! contention and causing the bounded handshake channel (cap 32) to fill.
+//!
+//! This test creates one server node and floods it with 40 concurrent
+//! client connections. All must complete identity exchange within a
+//! reasonable time. Before the fix, the accept loop would fall behind
+//! and identity exchanges would timeout.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use saorsa_core::{NodeConfig, P2PNode};
+use std::time::Duration;
+use tokio::time::timeout;
+
+fn test_config() -> NodeConfig {
+    NodeConfig::builder()
+        .local(true)
+        .port(0)
+        .ipv6(false)
+        .build()
+        .expect("test config should be valid")
+}
+
+/// Flood a single node with 40 concurrent connections and verify all
+/// connected clients complete identity exchange. This exercises the
+/// accept loop's ability to drain the handshake channel under pressure.
+///
+/// The test distinguishes two failure modes:
+/// - **Connection failure**: QUIC connection couldn't be established
+///   (resource limits on loopback — tolerated)
+/// - **Identity exchange timeout**: connected but accept loop stalled
+///   (the bug this test guards against — must be zero)
+#[tokio::test]
+async fn accept_loop_handles_concurrent_connection_flood() {
+    let server = P2PNode::new(test_config()).await.unwrap();
+    server.start().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let server_addr = server
+        .listen_addrs()
+        .await
+        .into_iter()
+        .find(|a| a.is_ipv4())
+        .expect("server should have an IPv4 listen address");
+
+    const NUM_CLIENTS: usize = 40;
+    let mut handles = Vec::with_capacity(NUM_CLIENTS);
+
+    // Stagger connection starts by 50ms to avoid overwhelming the single
+    // machine's UDP/QUIC stack. In production the accept loop stalls under
+    // sustained load over hours, not instantaneous bursts.
+    for i in 0..NUM_CLIENTS {
+        let addr = server_addr.clone();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        handles.push(tokio::spawn(async move {
+            let client = P2PNode::new(test_config()).await.unwrap();
+            client.start().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            let channel_id = match timeout(Duration::from_secs(5), client.connect_peer(&addr))
+                .await
+            {
+                Ok(Ok(id)) => id,
+                Ok(Err(e)) => return Err(format!("client {i} connect failed: {e}")),
+                Err(_) => return Err(format!("client {i} connect timed out")),
+            };
+
+            match timeout(
+                Duration::from_secs(10),
+                client.wait_for_peer_identity(&channel_id, Duration::from_secs(10)),
+            )
+            .await
+            {
+                Ok(Ok(peer_id)) => Ok((i, peer_id)),
+                Ok(Err(e)) => Err(format!(
+                    "client {i} IDENTITY EXCHANGE FAILED (accept loop stall): {e}"
+                )),
+                Err(_) => Err(format!(
+                    "client {i} IDENTITY EXCHANGE TIMED OUT (accept loop stall)"
+                )),
+            }
+        }));
+    }
+
+    let mut identity_ok = 0;
+    let mut connect_failures = 0;
+    let mut identity_failures = 0;
+
+    for handle in handles {
+        match timeout(Duration::from_secs(30), handle).await {
+            Ok(Ok(Ok((i, _peer_id)))) => {
+                identity_ok += 1;
+                eprintln!("Client {i}: identity exchange OK");
+            }
+            Ok(Ok(Err(msg))) => {
+                if msg.contains("IDENTITY EXCHANGE") {
+                    identity_failures += 1;
+                    eprintln!("FAIL: {msg}");
+                } else {
+                    connect_failures += 1;
+                    eprintln!("SKIP: {msg}");
+                }
+            }
+            Ok(Err(e)) => {
+                connect_failures += 1;
+                eprintln!("SKIP: task join error: {e}");
+            }
+            Err(_) => {
+                identity_failures += 1;
+                eprintln!("FAIL: task timed out at 30s (accept loop stall)");
+            }
+        }
+    }
+
+    eprintln!(
+        "\nResults: {identity_ok} identity OK, \
+         {connect_failures} connect failures (tolerated), \
+         {identity_failures} identity failures (NOT tolerated)"
+    );
+
+    // Allow up to 5% identity failures — on a single machine with 40
+    // concurrent QUIC endpoints, occasional transient timeouts are expected.
+    // The bug this guards against causes >50% failure rates.
+    let max_identity_failures = NUM_CLIENTS / 20 + 1; // ~7.5% tolerance = 3
+    assert!(
+        identity_failures <= max_identity_failures,
+        "Too many identity exchange failures: {identity_failures}/{NUM_CLIENTS} \
+         (max tolerated: {max_identity_failures}). \
+         This indicates the accept loop is stalling under connection pressure."
+    );
+    assert!(
+        identity_ok >= NUM_CLIENTS * 9 / 10,
+        "At least 90% of clients must complete identity exchange. \
+         Only {identity_ok}/{NUM_CLIENTS} succeeded."
+    );
+}


### PR DESCRIPTION
## Summary

- The accept loop in `TransportHandle` took two write locks inline (`peers` + `active_connections`) for every accepted connection. Under 1000-node scale, contention on these locks caused the loop to fall behind draining the bounded handshake channel (cap 32 in saorsa-transport). Once full, all new connection handoffs blocked, reader tasks were never spawned, and identity exchange timed out.
- Fix: spawn the registration work into a separate task so the accept loop immediately returns to draining the channel. Same pattern as the sharding fix already applied to the message receiving system.
- Includes a stress test (`tests/accept_loop_stress.rs`) that floods a node with 40 concurrent connections and asserts >90% complete identity exchange.

## Evidence from ant-rc-18 testnet (1000 nodes, 17+ hours)

Upload times degraded from ~175s to 358s+ after 17 hours. Root cause investigation:

- **Shard channel full warnings: 0** (PR #80 fix confirmed working)
- **Identity exchange timeouts: 208 in 30 minutes** on a single client
- Genesis bootstrap node: 7,253 "Accepted connection (unified path)" vs 6,174 "spawning reader task" — **1,079 connections lost** to the stalled channel
- Node-side comparison showed "Accepted connection" logged but reader task never spawned, matching the bounded channel(32) between `nat_traversal_api.rs:4062` and `p2p_endpoint.rs:2476`

## Companion PR

saorsa-labs/saorsa-transport `fix/handshake-channel-capacity` — increases the handshake channel from 32 to 1024 as a belt-and-suspenders measure.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test --test accept_loop_stress` passes (40 concurrent connections, >90% identity exchange success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the accept loop stall that caused 1,079 dropped connections and identity exchange timeouts on the `ant-rc-18` testnet by moving the two blocking write-lock operations (`peers` + `active_connections`) off the hot accept path into a detached `tokio::spawn` task — the same pattern already used by the sharded message dispatcher. The accompanying stress test (`tests/accept_loop_stress.rs`) validates ≥90% identity exchange success under 40 concurrent connections.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — all findings are P2 style/hardening suggestions; no blocking defects introduced.
- The fix is minimal and well-motivated by concrete testnet evidence. All remaining comments are P2: a doc inconsistency in the test, a slightly wider (but pre-existing) stale-entry window, and a dropped JoinHandle. None of these block correctness or production reliability at the scale this PR targets.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/transport_handle.rs | Accept loop now spawns registration work off the hot path; introduces a slightly wider stale-entry window vs. the previous inline approach, and drops the spawned JoinHandle silently. |
| tests/accept_loop_stress.rs | New stress test for the accept loop; contains a minor doc inconsistency (module comment says 50 clients, constant is 40) but the test logic and assertions are sound. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as Transport (QUIC)
    participant AL as Accept Loop
    participant RT as Registration Task (spawned)
    participant LM as Lifecycle Monitor

    T->>AL: accept_any() returns remote_sock
    AL->>AL: rate_limiter.check_ip()
    AL->>RT: tokio::spawn (peers.clone, active_connections.clone)
    Note over AL: immediately loops back to accept_any()
    AL->>T: accept_any() [ready for next connection]

    par Registration Task runs concurrently
        RT->>RT: "register_new_channel(&peers, channel_id, addr)"
        RT->>RT: active_connections.insert(channel_id)
    and Lifecycle Monitor handles transport events
        T->>LM: "ConnectionEvent::Established { remote_address }"
        LM->>LM: active_connections.insert(channel_id)
        LM->>LM: peers.insert or update status
        LM->>T: send_to_peer_optimized (identity announce)
        T-->>LM: ConnectionEvent::Lost / Failed
        LM->>LM: active_connections.remove(channel_id)
        LM->>LM: peers.remove(channel_id)
    end

    Note over RT,LM: ⚠ If Lost fires before RT runs,<br/>RT re-inserts a stale entry
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/accept_loop_stress.rs
Line: 21

Comment:
**Doc/constant mismatch**

The module-level doc says "floods it with **50** concurrent client connections" but `NUM_CLIENTS` is 40. The assertion comment on line 141 also refers to "5% rounded up" but `40 / 20 + 1 = 3` is actually 7.5% + rounding. These inconsistencies don't affect correctness but will confuse future readers.

```suggestion
//! This test creates one server node and floods it with 40 concurrent
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/transport_handle.rs
Line: 1538-1545

Comment:
**Stale entry window widened by spawned task**

The spawned task's window is larger than the previous inline version: the Tokio scheduler can now delay it until after the connection lifecycle monitor has fully processed an `Established` + `Lost`/`Failed` pair. When that happens, the task re-inserts a disconnected channel into both `peers` and `active_connections`, and nothing will ever remove it (the lifecycle monitor already fired its `Lost` event). The stale channel then shows up in `is_connection_active()` and `list_active_connections()` until the next send attempt to it cleans it up.

The lifecycle monitor at `connection_lifecycle_monitor_with_rx` (lines ~1989–2008) already handles inbound registration via `ConnectionEvent::Established`, including the same `peers` insert if the channel is unknown. If `accept_any()` and `ConnectionEvent::Established` always fire for the same connections, the register-in-spawned-task path is redundant and could be dropped entirely, eliminating the race.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/transport_handle.rs
Line: 1540-1545

Comment:
**Dropped `JoinHandle` silences task failures**

The handle returned by `tokio::spawn` is immediately dropped, so any panic or unexpected error inside the registration task is swallowed without logging. The codebase's strict no-panic rule makes this unlikely to matter in practice, but it diverges from the careful error-reporting pattern used elsewhere (e.g., the shard consumer tasks which are collected into `recv_handles` and awaited on shutdown).

Consider at minimum logging a warning if the spawned task's handle can be joined in a background collection, or wrapping the body with `if let Err(e) = ...` on the write calls (even though they can't currently fail).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: spawn accept loop registration to p..."](https://github.com/saorsa-labs/saorsa-core/commit/bafc14832180023fdc8872381de1c61029f2db9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28352102)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->