### PR TITLE
chore: update Cargo.lock for v0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Summary
- Updates `Cargo.lock` to reflect the v0.23.0 version bump that was missed in the RC merge

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)