### PR TITLE
feat(network): skip post-bootstrap self-lookups in client mode

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -2109,13 +2109,23 @@ impl P2PNode {
         // Perform two consecutive self-lookups to fully refresh the close
         // neighborhood. The second lookup may discover peers that joined or
         // became reachable during the first lookup (Section 11.2 step 5).
-        const SELF_LOOKUP_ROUNDS: u8 = 2;
-        for i in 1..=SELF_LOOKUP_ROUNDS {
-            if let Err(e) = self.dht_manager().trigger_self_lookup().await {
-                warn!("Post-bootstrap self-lookup {i}/{SELF_LOOKUP_ROUNDS} failed: {e}");
-            } else {
-                debug!("Post-bootstrap self-lookup {i}/{SELF_LOOKUP_ROUNDS} completed");
+        //
+        // Client-mode nodes don't serve the DHT, so they don't need an
+        // accurate close neighborhood — they just need enough peers to route
+        // lookups for their own requests, which `bootstrap_from_peers` above
+        // already provides. Skipping the self-lookups here cuts cold-start
+        // latency by tens of seconds when α-sized batches include dead peers.
+        if matches!(self.config.mode, NodeMode::Node) {
+            const SELF_LOOKUP_ROUNDS: u8 = 2;
+            for i in 1..=SELF_LOOKUP_ROUNDS {
+                if let Err(e) = self.dht_manager().trigger_self_lookup().await {
+                    warn!("Post-bootstrap self-lookup {i}/{SELF_LOOKUP_ROUNDS} failed: {e}");
+                } else {
+                    debug!("Post-bootstrap self-lookup {i}/{SELF_LOOKUP_ROUNDS} completed");
+                }
             }
+        } else {
+            debug!("Skipping post-bootstrap self-lookups (client mode)");
         }
 
         // Mark node as bootstrapped - we have connected to bootstrap peers


### PR DESCRIPTION
## Summary
- Client-mode nodes (`NodeMode::Client`) now skip the two consecutive post-bootstrap self-lookups in `P2PNode::start()`. Full nodes (`NodeMode::Node`) keep the existing behaviour.
- Client startup previously spent ~100+ seconds in `dht_manager().trigger_self_lookup()` calls whose purpose is to refresh the *close* neighbourhood for peers that serve DHT queries. A client that only routes its own lookups doesn't need that — `bootstrap_from_peers` already seeds enough coverage to resolve its requests.

## Motivation
Measured cold-start of an `ant file download` (4 MB file, 3 chunks) against the public network:

| | Before | After this PR |
|---|---|---|
| Bootstrap dial | 53 s | 50 s |
| DHT peer discovery | (folded into self-lookup) | 20 s |
| Post-bootstrap self-lookups | **117 s** | **0 s** (skipped) |
| Download | 15 s | 102 s *(tall pole moved, see separate PR on lookup latency)* |
| Total wall | ~186 s | ~173 s |

The self-lookup cost was dominated by a handful of α-triples of FindNode queries all landing on NAT'd or dead peers whose dial cascades took ~30 s each. Skipping the two lookups entirely eliminates that phase for clients.

## Test plan
- [x] `cargo check --all-targets` on `saorsa-core` and the downstream `ant-core` / `ant-cli` workspace
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] End-to-end `ant file download` against public network: `Skipping post-bootstrap self-lookups (client mode)` logged at DEBUG, file retrieved successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates the two post-bootstrap self-lookup rounds on `NodeMode::Node`, skipping them entirely for `NodeMode::Client` nodes and logging a debug message instead. The change is minimal, well-commented, and correctly preserves all surrounding bootstrap logic (peer connection, `bootstrap_from_peers`, bootstrapped flag, and close-group cache) for both modes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, low-risk optimization with no correctness or safety concerns.

The only finding is a P2 style suggestion about future-proofing the `else` branch against new `NodeMode` variants. No logic errors, no panics, no security issues, and the surrounding bootstrap flow is unaffected for both modes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/network.rs | Wraps the two post-bootstrap self-lookup rounds in a `NodeMode::Node`-only guard; client-mode nodes skip them and emit a debug log. Logic, error handling, and surrounding flow are correct. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[P2PNode::start] --> B[Connect to bootstrap peers]
    B -->|success| C[bootstrap_from_peers]
    B -->|failure| Z[return Ok - background discovery]
    C --> D{NodeMode?}
    D -->|Node| E[Round 1: trigger_self_lookup]
    E --> F[Round 2: trigger_self_lookup]
    F --> G[Mark bootstrapped]
    D -->|Client| H[debug: Skipping self-lookups]
    H --> G
    G --> I{close_group_cache_dir set?}
    I -->|yes| J[save_close_group_cache]
    I -->|no| K[return Ok]
    J --> K
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/network.rs
Line: 2127-2129

Comment:
**`else` silently absorbs future `NodeMode` variants**

The `else` branch is currently equivalent to "client mode," but if a third variant (e.g. `NodeMode::Observer`) were added later it would silently skip self-lookups without any intentional decision being made. Using an explicit `NodeMode::Client` arm would make the intent self-documenting and catch new variants at compile time.

```suggestion
        } else if matches!(self.config.mode, NodeMode::Client) {
            debug!("Skipping post-bootstrap self-lookups (client mode)");
        }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(network): skip post-bootstrap self-..."](https://github.com/saorsa-labs/saorsa-core/commit/4ef787b0f2a2c081cfb35f9dc3d05cf5d3c5fdca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28552876)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->