### PR TITLE
perf(dht): cut Kademlia lookup latency on cold clients

### DIFF
--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -29,6 +29,7 @@ use crate::{
     network::NodeConfig,
 };
 use anyhow::Context as _;
+use futures::stream::{FuturesUnordered, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::{IpAddr, SocketAddr};
@@ -1232,10 +1233,22 @@ impl DhtNetworkManager {
                 batch.len()
             );
 
-            // Query nodes in parallel
-            // saorsa-transport connection multiplexing lets us keep a single transport socket
-            // while still querying multiple peers concurrently.
-            let query_futures: Vec<_> = batch
+            // Query nodes in parallel.
+            //
+            // saorsa-transport connection multiplexing lets us keep a single
+            // transport socket while still querying multiple peers
+            // concurrently.
+            //
+            // We drive the α queries through `FuturesUnordered` so we can
+            // advance the lookup as soon as there's *something* to work
+            // with. Waiting for every query (`join_all`) lets a single dead
+            // peer — whose dial cascade can take 20–30s — block the whole
+            // iteration; instead, once the first response arrives, we bound
+            // the wait on the stragglers to `ITERATION_GRACE_TIMEOUT_SECS`
+            // and move on with whatever responses came in by then. Any
+            // still-pending queries are dropped (and their futures cancelled)
+            // when the stream goes out of scope.
+            let query_stream: FuturesUnordered<_> = batch
                 .iter()
                 .map(|node| {
                     let peer_id = node.peer_id;
@@ -1259,7 +1272,7 @@ impl DhtNetworkManager {
                 })
                 .collect();
 
-            let results = futures::future::join_all(query_futures).await;
+            let results = Self::collect_iteration_results(query_stream).await;
 
             for (peer_id, result) in results {
                 queried_nodes.insert(peer_id);
@@ -1463,6 +1476,39 @@ impl DhtNetworkManager {
         a.peer_id
             .distance(&target_key)
             .cmp(&b.peer_id.distance(&target_key))
+    }
+
+    /// Drain an iteration's α queries with a bounded wait after first response.
+    ///
+    /// Waits for the first query to complete, then grants the remaining
+    /// queries up to `ITERATION_GRACE_TIMEOUT_SECS` to finish before giving
+    /// up on them and returning whatever has arrived. Any still-pending
+    /// futures are dropped (and cancelled) when the stream is returned.
+    async fn collect_iteration_results<S>(mut stream: S) -> Vec<(PeerId, Result<DhtNetworkResult>)>
+    where
+        S: futures::Stream<Item = (PeerId, Result<DhtNetworkResult>)> + Unpin,
+    {
+        let mut results = Vec::new();
+
+        // Block for the first response — if nothing arrives the iteration
+        // has no new information to work with, so we do need to wait here.
+        let Some(first) = stream.next().await else {
+            return results;
+        };
+        results.push(first);
+
+        // Bounded drain: accept whichever stragglers finish within the
+        // grace window, then move on. `timeout` cancels the inner future
+        // on expiry, which drops the remaining query futures.
+        let grace = Duration::from_secs(ITERATION_GRACE_TIMEOUT_SECS);
+        let _ = tokio::time::timeout(grace, async {
+            while let Some(next) = stream.next().await {
+                results.push(next);
+            }
+        })
+        .await;
+
+        results
     }
 
     /// Return the K-closest candidate nodes, excluding the requester.
@@ -3119,6 +3165,18 @@ impl DhtNetworkManager {
 /// above the relay stage (~10s) so it never truncates the NAT traversal
 /// cascade.
 const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 15;
+
+/// Maximum additional wait for outstanding α queries after the first
+/// response in a Kademlia lookup iteration arrives.
+///
+/// `send_dht_request` runs a full dial cascade (direct → hole-punch → relay)
+/// before the RPC wait even starts, and that cascade can legitimately take
+/// over 20s when the candidate is NAT'd or unresponsive. Waiting for every
+/// α query to finish — as `join_all` does — lets one dead peer stall the
+/// iteration far beyond the point where Kademlia has enough information to
+/// proceed. Once the first response is in, we have new candidates for the
+/// next iteration and can safely cap the wait on the stragglers.
+const ITERATION_GRACE_TIMEOUT_SECS: u64 = 10;
 
 /// Default maximum concurrent DHT operations
 const DEFAULT_MAX_CONCURRENT_OPS: usize = 100;

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -3176,7 +3176,12 @@ const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 15;
 /// iteration far beyond the point where Kademlia has enough information to
 /// proceed. Once the first response is in, we have new candidates for the
 /// next iteration and can safely cap the wait on the stragglers.
-const ITERATION_GRACE_TIMEOUT_SECS: u64 = 10;
+///
+/// Sized at 5s: a peer with an already-open channel replies in well under
+/// a second, so this leaves ample slack for legitimate stragglers while
+/// letting us abandon dial cascades that are almost certainly going to
+/// fail anyway.
+const ITERATION_GRACE_TIMEOUT_SECS: u64 = 5;
 
 /// Default maximum concurrent DHT operations
 const DEFAULT_MAX_CONCURRENT_OPS: usize = 100;


### PR DESCRIPTION
## Summary
Two related changes in `dht_network_manager.rs` that together cut a measured cold-start `ant file download` from ~173 s to ~97 s (-44%):

1. **`perf(dht)`: bound iteration wait after first response.** Each lookup iteration fires α concurrent queries and was waiting for all of them (`join_all`). Because `send_dht_request` does the full dial cascade inline, one NAT'd candidate could stall the iteration for 20–30 s — far past the point where Kademlia already has enough new candidates to advance. Drive the α queries through `FuturesUnordered`: block for the first response, then bound stragglers with `ITERATION_GRACE_TIMEOUT_SECS`. Any still-pending futures are dropped when the stream goes out of scope.

2. **`perf(dht)`: tune the grace to 5 s.** Initial value of 10 s turned out to fire on most iterations of a slow lookup — five consecutive iterations each took exactly ~10 s waiting on dead peers. Dropping to 5 s halves that worst case while still leaving ample slack for a straggler with an already-open channel.

## Motivation
Measured on repeated `ant file download` runs of the same 4 MB, 3-chunk file against the public network:

| Phase | Baseline | With grace 10 s | With grace 5 s |
|---|---|---|---|
| Bootstrap connect | 50 s | 51 s | 56 s |
| DHT peer discovery | 20 s | 16 s | 16 s |
| Self-lookups* | 0 s | 0 s | 0 s |
| Download (3 chunks) | 102 s | 73 s | **26 s** |
| **Total wall** | 173 s | 140 s | **~97 s** |

*Self-lookup skip is a separate PR (#87).

Per-iteration evidence (slow chunk, grace 10 s → 5 s): five consecutive iterations that capped at 10.2–11.2 s each dropped to near-instant iterations, cutting the slow chunk from 73 s to ~26 s.

## Test plan
- [x] `cargo check --all-targets` on `saorsa-core` and the downstream `ant-core` / `ant-cli` workspace
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Four successive `ant file download` runs against public network, confirming the reductions in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)