### PR TITLE
perf(network): parallelize bootstrap peer dials with bounded concurrency

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -27,6 +27,7 @@ use crate::error::{IdentityError, NetworkError, P2PError, P2pResult as Result};
 use crate::MultiAddr;
 use crate::identity::node_identity::{NodeIdentity, peer_id_from_public_key};
 use crate::quantum_crypto::saorsa_transport_integration::{MlDsaPublicKey, MlDsaSignature};
+use futures::StreamExt;
 use parking_lot::Mutex as ParkingMutex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -144,6 +145,14 @@ const BOOTSTRAP_PEER_BATCH_SIZE: usize = 20;
 /// budget enough headroom for two QUIC handshake retries on a high-latency
 /// link.
 const BOOTSTRAP_IDENTITY_TIMEOUT_SECS: u64 = 15;
+
+/// Maximum number of bootstrap peers dialed concurrently in Phase B.
+///
+/// Bounds the fan-out of CLI + cached bootstrap dials so simultaneous
+/// QUIC+PQC handshakes don't spike CPU or saturate the UDP socket. Chosen
+/// low on purpose: each dial runs a full ML-KEM key exchange and ML-DSA
+/// verification, and a cold-start node has no spare compute budget.
+const MAX_CONCURRENT_BOOTSTRAP_DIALS: usize = 4;
 
 /// Serde helper — returns `true`.
 const fn default_true() -> bool {
@@ -1893,8 +1902,12 @@ impl P2PNode {
         &self,
         close_group_cache: Option<&CloseGroupCache>,
     ) -> Result<()> {
-        // Each entry is a list of addresses for a single peer.
-        let mut bootstrap_addr_sets: Vec<Vec<MultiAddr>> = Vec::new();
+        // Each entry is a list of addresses for a single peer. Close-group
+        // peers are dialed serially to preserve trust-priority ordering; CLI
+        // and cached bootstrap peers are dialed concurrently to cut cold-start
+        // latency when some peers are slow or dead.
+        let mut serial_addr_sets: Vec<Vec<MultiAddr>> = Vec::new();
+        let mut parallel_addr_sets: Vec<Vec<MultiAddr>> = Vec::new();
         let mut used_cache = false;
         let mut seen_addresses = std::collections::HashSet::new();
 
@@ -1944,7 +1957,7 @@ impl P2PNode {
                             seen_addresses.insert(sa);
                         }
                     }
-                    bootstrap_addr_sets.push(new_addresses);
+                    serial_addr_sets.push(new_addresses);
                     added_from_close_group += 1;
                 }
             }
@@ -1968,7 +1981,7 @@ impl P2PNode {
                     continue;
                 };
                 seen_addresses.insert(socket_addr);
-                bootstrap_addr_sets.push(vec![multiaddr.clone()]);
+                parallel_addr_sets.push(vec![multiaddr.clone()]);
             }
         }
 
@@ -1994,7 +2007,7 @@ impl P2PNode {
                                 seen_addresses.insert(sa);
                             }
                         }
-                        bootstrap_addr_sets.push(new_addresses);
+                        parallel_addr_sets.push(new_addresses);
                         added_from_cache += 1;
                     }
                 }
@@ -2008,7 +2021,7 @@ impl P2PNode {
             }
         }
 
-        if bootstrap_addr_sets.is_empty() {
+        if serial_addr_sets.is_empty() && parallel_addr_sets.is_empty() {
             info!("No bootstrap peers configured and no cached peers available");
             return Ok(());
         }
@@ -2019,52 +2032,30 @@ impl P2PNode {
         let mut successful_connections = 0;
         let mut connected_peer_ids: Vec<PeerId> = Vec::new();
 
-        for addrs in &bootstrap_addr_sets {
-            for addr in addrs {
-                match self.connect_peer(addr).await {
-                    Ok(channel_id) => {
-                        // Wait for the remote peer's signed identity announce
-                        // so we get a real cryptographic PeerId.
-                        match self
-                            .transport
-                            .wait_for_peer_identity(&channel_id, identity_timeout)
-                            .await
-                        {
-                            Ok(real_peer_id) => {
-                                successful_connections += 1;
-                                connected_peer_ids.push(real_peer_id);
+        // Phase A: serial close-group dials to preserve trust-priority ordering.
+        for addrs in &serial_addr_sets {
+            if let Some(peer_id) = self
+                .dial_bootstrap_addr_set(addrs, used_cache, identity_timeout)
+                .await
+            {
+                successful_connections += 1;
+                connected_peer_ids.push(peer_id);
+            }
+        }
 
-                                // Update bootstrap cache with successful connection
-                                if let Some(ref bootstrap_manager) = self.bootstrap_manager {
-                                    let manager = bootstrap_manager.read().await;
-                                    if let Some(sa) = addr.socket_addr() {
-                                        manager.record_success(&sa, 100).await;
-                                    }
-                                }
-                                break; // Successfully connected, move to next peer
-                            }
-                            Err(e) => {
-                                warn!(
-                                    "Timeout waiting for identity from bootstrap peer {}: {}, \
-                                     closing channel {}",
-                                    addr, e, channel_id
-                                );
-                                self.disconnect_channel(&channel_id).await;
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        warn!("Failed to connect to bootstrap peer {}: {}", addr, e);
-
-                        // Update bootstrap cache with failed connection
-                        if used_cache && let Some(ref bootstrap_manager) = self.bootstrap_manager {
-                            let manager = bootstrap_manager.read().await;
-                            if let Some(sa) = addr.socket_addr() {
-                                manager.record_failure(&sa).await;
-                            }
-                        }
-                    }
-                }
+        // Phase B: concurrent dials of CLI + cached bootstrap peers, bounded
+        // by `MAX_CONCURRENT_BOOTSTRAP_DIALS` to cap simultaneous QUIC+PQC
+        // handshakes.
+        let mut parallel_stream = futures::stream::iter(
+            parallel_addr_sets
+                .iter()
+                .map(|addrs| self.dial_bootstrap_addr_set(addrs, used_cache, identity_timeout)),
+        )
+        .buffer_unordered(MAX_CONCURRENT_BOOTSTRAP_DIALS);
+        while let Some(result) = parallel_stream.next().await {
+            if let Some(peer_id) = result {
+                successful_connections += 1;
+                connected_peer_ids.push(peer_id);
             }
         }
 
@@ -2146,6 +2137,55 @@ impl P2PNode {
         }
 
         Ok(())
+    }
+
+    /// Dial a single bootstrap peer's address set, stopping at the first
+    /// address that completes the identity handshake. Records success/failure
+    /// in the bootstrap cache and returns the remote peer's cryptographic
+    /// PeerId on success. Safe to call concurrently for different peers.
+    async fn dial_bootstrap_addr_set(
+        &self,
+        addrs: &[MultiAddr],
+        used_cache: bool,
+        identity_timeout: Duration,
+    ) -> Option<PeerId> {
+        for addr in addrs {
+            match self.connect_peer(addr).await {
+                Ok(channel_id) => match self
+                    .transport
+                    .wait_for_peer_identity(&channel_id, identity_timeout)
+                    .await
+                {
+                    Ok(real_peer_id) => {
+                        if let Some(ref bootstrap_manager) = self.bootstrap_manager {
+                            let manager = bootstrap_manager.read().await;
+                            if let Some(sa) = addr.socket_addr() {
+                                manager.record_success(&sa, 100).await;
+                            }
+                        }
+                        return Some(real_peer_id);
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Timeout waiting for identity from bootstrap peer {}: {}, \
+                             closing channel {}",
+                            addr, e, channel_id
+                        );
+                        self.disconnect_channel(&channel_id).await;
+                    }
+                },
+                Err(e) => {
+                    warn!("Failed to connect to bootstrap peer {}: {}", addr, e);
+                    if used_cache && let Some(ref bootstrap_manager) = self.bootstrap_manager {
+                        let manager = bootstrap_manager.read().await;
+                        if let Some(sa) = addr.socket_addr() {
+                            manager.record_failure(&sa).await;
+                        }
+                    }
+                }
+            }
+        }
+        None
     }
 
     /// Persist the current close group peers and their trust scores to disk.


### PR DESCRIPTION
## Summary
- Phase A dials close-group cache peers serially to preserve trust-priority ordering (unchanged).
- Phase B dials CLI-configured and cached bootstrap peers concurrently via `futures::stream::buffer_unordered`, capped at `MAX_CONCURRENT_BOOTSTRAP_DIALS = 4` to bound simultaneous QUIC+PQC handshakes.
- Previously, a single dead peer at a 15s identity timeout could stall the entire bootstrap batch. With 4-wide concurrency, up to ~20 cached peers complete in ~5 waves worst case instead of sequentially.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` clean
- [x] `cargo test --lib bootstrap` — 18/18 pass
- [ ] Manual verification: cold-start a node with mixed live/dead bootstrap peers, confirm reduced time-to-first-connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR parallelizes Phase B of bootstrap peer dialing using `futures::stream::buffer_unordered` capped at `MAX_CONCURRENT_BOOTSTRAP_DIALS = 4`, reducing the worst-case cold-start latency from `N × 15 s` to `⌈N/4⌉ × 15 s` for dead peers. Phase A (close-group cache peers) remains serial to preserve trust-priority ordering.

The implementation is clean, well-commented, and correctly scoped: `dial_bootstrap_addr_set` takes `&self` so concurrent calls are safe, deduplication logic is unaffected, and all peer IDs are collected before running `bootstrap_from_peers`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a clean, well-bounded concurrency improvement with no correctness or safety issues.

All findings are P2 or lower. The parallelization correctly uses `buffer_unordered` with `&self` (no mutable aliasing), preserves Phase A trust ordering, and collects all peer IDs before DHT discovery. No panics, no unwraps, no security concerns introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/network.rs | Adds `MAX_CONCURRENT_BOOTSTRAP_DIALS = 4`, imports `futures::StreamExt`, and replaces the serial Phase B loop with `buffer_unordered(4)`. Logic is correct; `dial_bootstrap_addr_set` is `&self` so concurrent calls are safe. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Node as P2PNode
    participant PhA as Phase A (Serial)
    participant PhB as Phase B (buffer_unordered ≤ 4)
    participant DHT as bootstrap_from_peers

    Note over Node: connect_bootstrap_peers()

    Node->>PhA: close_group_cache peers (trust-priority order)
    loop for each close-group peer
        PhA->>PhA: dial_bootstrap_addr_set() — serial
    end
    PhA-->>Node: connected_peer_ids (Phase A)

    Node->>PhB: CLI + cached bootstrap peers (up to 20)
    par up to 4 concurrent dials
        PhB->>PhB: dial_bootstrap_addr_set(peer 1)
        PhB->>PhB: dial_bootstrap_addr_set(peer 2)
        PhB->>PhB: dial_bootstrap_addr_set(peer 3)
        PhB->>PhB: dial_bootstrap_addr_set(peer 4)
    end
    Note over PhB: As each completes, next peer starts (buffer_unordered)
    PhB-->>Node: connected_peer_ids (Phase B)

    Node->>DHT: bootstrap_from_peers(all peer IDs)
    DHT-->>Node: DHT populated
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/network.rs
Line: 2163

Comment:
**Hardcoded latency in `record_success`**

`record_success(&sa, 100)` always records 100 ms regardless of the actual round-trip time. Now that dials run concurrently, the wall-clock time of each handshake is trivially measurable (e.g. `Instant::now()` before `connect_peer` / after `wait_for_peer_identity`). Keeping a hardcoded value means the bootstrap cache can't rank peers by true latency, defeating part of the purpose of the success metric.

This is pre-existing and not introduced by this PR, but the refactor here is a natural opportunity to wire up real timing.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(network): parallelize bootstrap pee..."](https://github.com/saorsa-labs/saorsa-core/commit/43acfa9cdc969976dad39bbd483fd6890834a591) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28612145)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->