### PR TITLE
perf(network): prefer IPv4 over IPv6 when dialing peers

### DIFF
--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -1646,13 +1646,23 @@ impl DhtNetworkManager {
         queried.insert(self.config.peer_id);
     }
 
-    /// Return all dialable addresses from a list of [`MultiAddr`] values.
+    /// Return all dialable addresses from a list of [`MultiAddr`] values,
+    /// with IPv4 ordered before IPv6.
     ///
     /// Only QUIC addresses are considered dialable. Unspecified (`0.0.0.0`)
     /// addresses are rejected. Loopback addresses are accepted for local/test
     /// use.
+    ///
+    /// The IPv4-first preference centralises here so every caller — dial
+    /// loops (`dial_addresses`), single-pick helpers (`first_dialable_address`
+    /// and its downstream uses for hole-punch hints, routing-table touches,
+    /// PublishAddress, etc.) — inherits the same bias without duplicating the
+    /// sort. IPv6 NAT traversal is less mature on consumer networks, so IPv4
+    /// attempts tend to succeed faster when both families are available.
+    /// Stable sort preserves the caller's relative ordering within each
+    /// family (trust-sort, XOR-distance, etc. stay meaningful).
     fn dialable_addresses(addresses: &[MultiAddr]) -> Vec<MultiAddr> {
-        addresses
+        let mut filtered: Vec<MultiAddr> = addresses
             .iter()
             .filter(|addr| {
                 let Some(sa) = addr.dialable_socket_addr() else {
@@ -1669,7 +1679,9 @@ impl DhtNetworkManager {
                 true
             })
             .cloned()
-            .collect()
+            .collect();
+        filtered.sort_by_key(|a| !a.is_ipv4());
+        filtered
     }
 
     /// Return the first dialable address from a list of [`MultiAddr`] values.

--- a/src/network.rs
+++ b/src/network.rs
@@ -1928,7 +1928,7 @@ impl P2PNode {
 
             let mut added_from_close_group = 0usize;
             for peer in &sorted_peers {
-                let new_addresses: Vec<MultiAddr> = peer
+                let mut new_addresses: Vec<MultiAddr> = peer
                     .addresses
                     .iter()
                     .filter(|a| {
@@ -1937,6 +1937,12 @@ impl P2PNode {
                     })
                     .cloned()
                     .collect();
+
+                // Prefer IPv4 over IPv6: IPv6 NAT traversal is less mature
+                // on consumer networks, so an IPv4 attempt tends to succeed
+                // faster when both are available. Stable sort preserves the
+                // relative order within each family.
+                new_addresses.sort_by_key(|a| !a.is_ipv4());
 
                 if !new_addresses.is_empty() {
                     for addr in &new_addresses {
@@ -1982,11 +1988,14 @@ impl P2PNode {
                     let mut addrs = vec![cached.primary_address];
                     addrs.extend(cached.addresses);
                     // Only add addresses we haven't seen from CLI peers
-                    let new_addresses: Vec<MultiAddr> = addrs
+                    let mut new_addresses: Vec<MultiAddr> = addrs
                         .into_iter()
                         .filter(|a| !seen_addresses.contains(a))
                         .map(MultiAddr::quic)
                         .collect();
+
+                    // Prefer IPv4 over IPv6 within each peer's address set.
+                    new_addresses.sort_by_key(|a| !a.is_ipv4());
 
                     if !new_addresses.is_empty() {
                         for addr in &new_addresses {


### PR DESCRIPTION
## Summary
Prefer IPv4 over IPv6 at every per-peer dial site. Stable sort preserves the caller's relative ordering within each family (trust-sort, XOR-distance, etc. stay meaningful).

Two changes:
- **`DhtNetworkManager::dialable_addresses`** sorts IPv4-first in one place, so every caller inherits the bias: dial loops (`dial_addresses`), and single-pick helpers (`first_dialable_address` and its downstream uses for hole-punch hints, routing-table touches, PublishAddress).
- **`P2PNode::connect_bootstrap_peers`** sorts each close-group and cached bootstrap peer's address set before the dial loop, since bootstrap builds its own address list rather than going through the DHT helper. CLI-configured peers are single-address sets so ordering is a no-op there.

`TransportHandle::connect_peer` receives one `MultiAddr` at a time from saorsa-core, so Happy Eyeballs racing inside the transport isn't on our call path.

## Rationale
IPv6 NAT traversal is less mature on consumer networks. When a peer advertises both families, an IPv4 attempt tends to succeed faster — and since dial loops break on the first successful identity handshake, preferring IPv4 reduces wasted timeouts during cold-start and DHT routing.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` clean
- [x] `cargo test --lib` — 282/282 pass
- [ ] Manual verification: cold-start a node against peers with mixed IPv4/IPv6 addresses, confirm IPv4 is attempted first per peer

## Notes
Independent of #89 (bootstrap dial parallelization). The sort lives inside `dialable_addresses` / bootstrap address-list construction, unaffected by #89's `serial_addr_sets` / `parallel_addr_sets` rename — either merge order rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)