### PR TITLE
fix(transport): dispatch v4 peers to v4 socket on Windows (split-stack)

### DIFF
--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -850,6 +850,15 @@ pub struct DualStackNetworkNode<T: LinkTransport = P2pLinkTransport> {
     is_dual_stack: bool,
 }
 
+/// Return value of [`DualStackNetworkNode::pick_stacks_for`]: the primary and
+/// optional fallback `(node, wire_addr)` pair to use when sending to a given
+/// address. Either element may be `None` if that stack is absent or would be a
+/// wasted attempt for the target family.
+type PickedStacks<'a, T> = (
+    Option<(&'a P2PNetworkNode<T>, SocketAddr)>,
+    Option<(&'a P2PNetworkNode<T>, SocketAddr)>,
+);
+
 #[allow(dead_code)]
 impl DualStackNetworkNode<P2pLinkTransport> {
     /// Set the target peer ID for a hole-punch attempt to a specific address.
@@ -1178,44 +1187,43 @@ impl DualStackNetworkNode<P2pLinkTransport> {
     /// In dual-stack mode, converts plain IPv4 addresses to the mapped form
     /// expected by the v6 transport before sending.
     pub async fn send_to_peer_optimized(&self, addr: &SocketAddr, data: &[u8]) -> Result<()> {
-        // Preserve the underlying error(s) from the v6 and v4 stacks so the
-        // caller can surface them at WARN level. The previous implementation
-        // dropped both errors and returned a hardcoded
-        // "send_to_peer_optimized failed on both stacks" which made every
-        // transport failure look identical in the logs.
-        let mut v6_err: Option<anyhow::Error> = None;
-        let mut v4_err: Option<anyhow::Error> = None;
+        // Preserve the underlying error(s) so the caller can surface them at
+        // WARN level. The previous implementation returned a hardcoded
+        // "failed on both stacks" which made every transport failure look
+        // identical in the logs.
+        let (primary, fallback) = self.pick_stacks_for(addr);
+        let mut primary_err: Option<anyhow::Error> = None;
+        let mut fallback_err: Option<anyhow::Error> = None;
 
-        if let Some(v6) = &self.v6 {
-            let wire_addr = self.to_mapped_if_needed(addr);
-            match v6.send_to_peer_optimized(&wire_addr, data).await {
+        if let Some((node, wire_addr)) = primary {
+            match node.send_to_peer_optimized(&wire_addr, data).await {
                 Ok(()) => return Ok(()),
                 Err(e) => {
-                    warn!("[DUAL SEND] IPv6 send to {} failed: {:#}", addr, e);
-                    v6_err = Some(e);
+                    let family = if wire_addr.is_ipv6() { "IPv6" } else { "IPv4" };
+                    warn!("[DUAL SEND] {family} send to {} failed: {:#}", addr, e);
+                    primary_err = Some(e);
                 }
             }
         }
-        if let Some(v4) = &self.v4 {
-            match v4.send_to_peer_optimized(addr, data).await {
+        if let Some((node, wire_addr)) = fallback {
+            match node.send_to_peer_optimized(&wire_addr, data).await {
                 Ok(()) => return Ok(()),
                 Err(e) => {
-                    warn!("[DUAL SEND] IPv4 send to {} failed: {:#}", addr, e);
-                    v4_err = Some(e);
+                    let family = if wire_addr.is_ipv6() { "IPv6" } else { "IPv4" };
+                    warn!("[DUAL SEND] {family} send to {} failed: {:#}", addr, e);
+                    fallback_err = Some(e);
                 }
             }
         }
 
-        // Inline the actual error cause so callers using `{}` (not `{:#}`)
-        // see the real failure reason, not just which IP stack was tried.
-        let err = match (v6_err, v4_err) {
-            (Some(v6), Some(v4)) => anyhow::anyhow!(
-                "send_to_peer_optimized to {addr} failed on both stacks — v6: {v6}, v4: {v4}"
+        let err = match (primary_err, fallback_err) {
+            (Some(p), Some(f)) => anyhow::anyhow!(
+                "send_to_peer_optimized to {addr} failed on both stacks — primary: {p}, fallback: {f}"
             ),
-            (Some(v6), None) => anyhow::anyhow!("send_to_peer_optimized to {addr} failed: {v6}"),
-            (None, Some(v4)) => anyhow::anyhow!("send_to_peer_optimized to {addr} failed: {v4}"),
+            (Some(p), None) => anyhow::anyhow!("send_to_peer_optimized to {addr} failed: {p}"),
+            (None, Some(f)) => anyhow::anyhow!("send_to_peer_optimized to {addr} failed: {f}"),
             (None, None) => anyhow::anyhow!(
-                "send_to_peer_optimized to {addr}: neither v6 nor v4 stack available"
+                "send_to_peer_optimized to {addr}: no stack available for this address family"
             ),
         };
         Err(err)
@@ -1223,15 +1231,29 @@ impl DualStackNetworkNode<P2pLinkTransport> {
 
     /// Disconnect a peer, closing the underlying QUIC connection.
     ///
-    /// Tries both IPv6 and IPv4 stacks. In dual-stack mode, converts
-    /// plain IPv4 to mapped form for the v6 transport.
+    /// In dual-stack mode both stacks may hold connection state, so issue
+    /// disconnects to both. In split-stack mode only the stack matching the
+    /// target family holds the connection — issuing a disconnect to the
+    /// wrong stack is wasted (and on Windows actively triggers
+    /// WSAEADDRNOTAVAIL against a v6-only socket with a v4 target).
     pub async fn disconnect_peer_by_addr(&self, addr: &SocketAddr) {
-        if let Some(ref v6) = self.v6 {
-            let wire_addr = self.to_mapped_if_needed(addr);
-            v6.disconnect_peer_quic(&wire_addr).await;
+        if self.is_dual_stack {
+            if let Some(ref v6) = self.v6 {
+                let wire_addr = self.to_mapped_if_needed(addr);
+                v6.disconnect_peer_quic(&wire_addr).await;
+            }
+            if let Some(ref v4) = self.v4 {
+                v4.disconnect_peer_quic(addr).await;
+            }
+            return;
         }
-        if let Some(ref v4) = self.v4 {
-            v4.disconnect_peer_quic(addr).await;
+
+        let (primary, fallback) = self.pick_stacks_for(addr);
+        if let Some((node, wire_addr)) = primary {
+            node.disconnect_peer_quic(&wire_addr).await;
+        }
+        if let Some((node, wire_addr)) = fallback {
+            node.disconnect_peer_quic(&wire_addr).await;
         }
     }
 
@@ -1313,6 +1335,54 @@ impl<T: LinkTransport + Send + Sync + 'static> DualStackNetworkNode<T> {
             return SocketAddr::V6(SocketAddrV6::new(v4.ip().to_ipv6_mapped(), v4.port(), 0, 0));
         }
         *addr
+    }
+
+    /// Pick the primary and fallback nodes for sending to `addr`, plus the
+    /// wire-format address to use for each.
+    ///
+    /// In **dual-stack** mode (`is_dual_stack=true`) we hold only a v6 socket
+    /// that handles both families via kernel mapping, so v6 is primary for
+    /// every target and v4 addresses are rewritten to `[::ffff:x.x.x.x]` at
+    /// the wire. This path is the historical Linux behaviour.
+    ///
+    /// In **split-stack** mode (`is_dual_stack=false`, both v6 and v4 sockets
+    /// bound) the v6 socket is v6-only and cannot send to a v4 target —
+    /// on Windows that materialises as `WSAEADDRNOTAVAIL`, on others as a
+    /// silent drop. Dispatch by target family so v4 targets go to the v4
+    /// socket directly, v6 targets go to the v6 socket, and no mapped
+    /// addresses are ever synthesized. The fallback stack is only tried as
+    /// a last resort (e.g. if the primary socket has vanished).
+    fn pick_stacks_for<'a>(&'a self, addr: &SocketAddr) -> PickedStacks<'a, T> {
+        // Dual-stack: always v6 first with mapping, v4 second untouched.
+        if self.is_dual_stack {
+            let primary = self
+                .v6
+                .as_ref()
+                .map(|n| (n, self.to_mapped_if_needed(addr)));
+            let fallback = self.v4.as_ref().map(|n| (n, *addr));
+            return (primary, fallback);
+        }
+
+        // Split-stack: route by target family.
+        match addr {
+            SocketAddr::V4(_) => {
+                let primary = self.v4.as_ref().map(|n| (n, *addr));
+                // Fallback to v6 with mapping only if we have no v4 socket.
+                let fallback = if primary.is_none() {
+                    self.v6
+                        .as_ref()
+                        .map(|n| (n, self.to_mapped_if_needed(addr)))
+                } else {
+                    None
+                };
+                (primary, fallback)
+            }
+            SocketAddr::V6(_) => {
+                let primary = self.v6.as_ref().map(|n| (n, *addr));
+                // No meaningful v4 fallback for a v6 target.
+                (primary, None)
+            }
+        }
     }
 
     /// Happy Eyeballs connect: race IPv6 and IPv4 attempts.
@@ -1468,21 +1538,26 @@ impl<T: LinkTransport + Send + Sync + 'static> DualStackNetworkNode<T> {
         out
     }
 
-    /// Send to peer by address; tries IPv6 first, then IPv4.
-    /// In dual-stack mode, converts plain IPv4 to mapped form for v6.
+    /// Send to peer by address. In dual-stack mode the v6 socket handles
+    /// both families (with v4 rewritten to mapped form). In split-stack
+    /// mode, dispatch by target family so v4 targets go to the v4 socket
+    /// directly — avoids WSAEADDRNOTAVAIL on Windows where the v6 socket
+    /// is v6-only.
     pub async fn send_to_peer_raw(&self, addr: &SocketAddr, data: &[u8]) -> Result<()> {
-        if let Some(v6) = &self.v6 {
-            let wire_addr = self.to_mapped_if_needed(addr);
-            if v6.send_to_peer_raw(&wire_addr, data).await.is_ok() {
-                return Ok(());
-            }
-        }
-        if let Some(v4) = &self.v4
-            && v4.send_to_peer_raw(addr, data).await.is_ok()
+        let (primary, fallback) = self.pick_stacks_for(addr);
+        if let Some((node, wire_addr)) = primary
+            && node.send_to_peer_raw(&wire_addr, data).await.is_ok()
         {
             return Ok(());
         }
-        Err(anyhow::anyhow!("send_to_peer_raw failed on both stacks"))
+        if let Some((node, wire_addr)) = fallback
+            && node.send_to_peer_raw(&wire_addr, data).await.is_ok()
+        {
+            return Ok(());
+        }
+        Err(anyhow::anyhow!(
+            "send_to_peer_raw to {addr} failed on all available stacks"
+        ))
     }
 
     /// Send to peer by address.

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -859,6 +859,92 @@ type PickedStacks<'a, T> = (
     Option<(&'a P2PNetworkNode<T>, SocketAddr)>,
 );
 
+/// Which concrete stack a [`DispatchPlan`] slot points at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StackRole {
+    V4,
+    V6,
+}
+
+/// One slot of a [`DispatchPlan`]: which stack to use, and whether the v4
+/// address must be rewritten to `[::ffff:x.x.x.x]` form for the v6 wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct StackChoice {
+    role: StackRole,
+    /// True iff the caller should wrap a plain-IPv4 `addr` as IPv4-mapped IPv6
+    /// before handing it to the chosen node. Only ever set when routing a
+    /// v4 target through the v6 socket in dual-stack mode.
+    mapped: bool,
+}
+
+/// Primary + fallback stack decision produced by [`decide_dispatch`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct DispatchPlan {
+    primary: Option<StackChoice>,
+    fallback: Option<StackChoice>,
+}
+
+/// Pure decision: given the dual-stack state and target address family, which
+/// stack(s) should a send/disconnect go to, and does the v4 address need
+/// mapping to the v6 wire form?
+///
+/// Isolated from the `DualStackNetworkNode` struct so the (is_dual_stack ×
+/// has_v6 × has_v4 × addr.family) matrix is unit-testable without having to
+/// bind real sockets.
+///
+/// Invariant maintained by every constructor in this module:
+/// `is_dual_stack ⟺ (has_v6 && !has_v4)`. That makes the "v4-target, no v4
+/// socket, split-stack" branch unreachable in practice — `has_v4=false &&
+/// !is_dual_stack` forces `has_v6=false`. The function still returns a
+/// well-defined plan (an empty one) for that shape so callers can't observe
+/// a panic if the invariant is ever loosened.
+fn decide_dispatch(
+    is_dual_stack: bool,
+    has_v6: bool,
+    has_v4: bool,
+    addr_is_v4: bool,
+) -> DispatchPlan {
+    if is_dual_stack {
+        // Dual-stack (Linux default): the v6 socket handles both families via
+        // kernel mapping. v4 addresses are rewritten to `[::ffff:x.x.x.x]` at
+        // the wire; v6 addresses pass through untouched.
+        //
+        // Under the invariant `has_v4=false` here, but we still compute a v4
+        // fallback slot defensively for the case where a caller hand-builds
+        // a node with both sockets AND `is_dual_stack=true`.
+        let primary = has_v6.then_some(StackChoice {
+            role: StackRole::V6,
+            mapped: addr_is_v4,
+        });
+        let fallback = has_v4.then_some(StackChoice {
+            role: StackRole::V4,
+            mapped: false,
+        });
+        return DispatchPlan { primary, fallback };
+    }
+
+    // Split-stack: route strictly by target family. The v6 socket is v6-only
+    // (Windows default) and cannot reach v4 targets; the v4 socket cannot
+    // reach v6 targets. No mapped addresses are ever synthesised — mapping
+    // onto a v6-only socket is exactly the WSAEADDRNOTAVAIL bug this
+    // dispatcher exists to avoid.
+    let primary = if addr_is_v4 {
+        has_v4.then_some(StackChoice {
+            role: StackRole::V4,
+            mapped: false,
+        })
+    } else {
+        has_v6.then_some(StackChoice {
+            role: StackRole::V6,
+            mapped: false,
+        })
+    };
+    DispatchPlan {
+        primary,
+        fallback: None,
+    }
+}
+
 #[allow(dead_code)]
 impl DualStackNetworkNode<P2pLinkTransport> {
     /// Set the target peer ID for a hole-punch attempt to a specific address.
@@ -1185,13 +1271,17 @@ impl DualStackNetworkNode<P2pLinkTransport> {
     /// bidirectional communication.
     ///
     /// Dispatch (see [`Self::pick_stacks_for`]):
-    /// - **Dual-stack** (single v6 socket accepting mapped v4): send on v6
-    ///   first — plain IPv4 targets are converted to `[::ffff:x.x.x.x]` —
-    ///   with v4 as fallback if present.
-    /// - **Split-stack** (separate v4/v6 sockets, common on Windows): route
-    ///   by target family. IPv4 targets go to the v4 socket, IPv6 targets
-    ///   go to the v6 socket. Cross-family fallback is only used when the
-    ///   matching socket is absent entirely.
+    /// - **Dual-stack** (`is_dual_stack=true`, single v6 socket handling both
+    ///   families via kernel mapping): the v6 socket is used; plain IPv4
+    ///   targets are rewritten to `[::ffff:x.x.x.x]` before the wire write.
+    /// - **Split-stack** (`is_dual_stack=false`, family-specific sockets —
+    ///   typical on Windows): route by target family so v4 targets go to
+    ///   the v4 socket and v6 targets go to the v6 socket. No mapped
+    ///   addresses are synthesised.
+    ///
+    /// Mapped-v4 targets (`[::ffff:x.x.x.x]`) arriving here — e.g. via a
+    /// DHT record learned from a dual-stack peer — are un-mapped at the
+    /// dispatch boundary, so they are routed by their true family.
     ///
     /// On failure, the returned error preserves the underlying transport
     /// cause instead of a generic "failed on both stacks" message.
@@ -1240,23 +1330,13 @@ impl DualStackNetworkNode<P2pLinkTransport> {
 
     /// Disconnect a peer, closing the underlying QUIC connection.
     ///
-    /// In dual-stack mode both stacks may hold connection state, so issue
-    /// disconnects to both. In split-stack mode only the stack matching the
-    /// target family holds the connection — issuing a disconnect to the
-    /// wrong stack is wasted (and on Windows actively triggers
-    /// WSAEADDRNOTAVAIL against a v6-only socket with a v4 target).
+    /// Delegates to [`Self::pick_stacks_for`] so the stack carrying the
+    /// peer is targeted in split-stack mode, and the single v6 socket
+    /// (with mapping for v4 targets) is targeted in dual-stack mode.
+    /// Issuing a disconnect to the wrong stack is wasted — on Windows it
+    /// actively triggers WSAEADDRNOTAVAIL against a v6-only socket with a
+    /// v4 target.
     pub async fn disconnect_peer_by_addr(&self, addr: &SocketAddr) {
-        if self.is_dual_stack {
-            if let Some(ref v6) = self.v6 {
-                let wire_addr = self.to_mapped_if_needed(addr);
-                v6.disconnect_peer_quic(&wire_addr).await;
-            }
-            if let Some(ref v4) = self.v4 {
-                v4.disconnect_peer_quic(addr).await;
-            }
-            return;
-        }
-
         let (primary, fallback) = self.pick_stacks_for(addr);
         if let Some((node, wire_addr)) = primary {
             node.disconnect_peer_quic(&wire_addr).await;
@@ -1349,49 +1429,58 @@ impl<T: LinkTransport + Send + Sync + 'static> DualStackNetworkNode<T> {
     /// Pick the primary and fallback nodes for sending to `addr`, plus the
     /// wire-format address to use for each.
     ///
-    /// In **dual-stack** mode (`is_dual_stack=true`) we hold only a v6 socket
-    /// that handles both families via kernel mapping, so v6 is primary for
-    /// every target and v4 addresses are rewritten to `[::ffff:x.x.x.x]` at
-    /// the wire. This path is the historical Linux behaviour.
+    /// The decision matrix lives in [`decide_dispatch`]; this method resolves
+    /// the chosen [`StackChoice`] slots against `self.v6` / `self.v4` and
+    /// constructs the appropriate wire address.
     ///
-    /// In **split-stack** mode (`is_dual_stack=false`, both v6 and v4 sockets
-    /// bound) the v6 socket is v6-only and cannot send to a v4 target —
-    /// on Windows that materialises as `WSAEADDRNOTAVAIL`, on others as a
-    /// silent drop. Dispatch by target family so v4 targets go to the v4
-    /// socket directly, v6 targets go to the v6 socket, and no mapped
-    /// addresses are ever synthesized. The fallback stack is only tried as
-    /// a last resort (e.g. if the primary socket has vanished).
+    /// ### Normalisation at the boundary
+    ///
+    /// A mapped-v4 target (`[::ffff:x.x.x.x]`) arriving here is un-mapped
+    /// before the family-based dispatch. Without this, a mapped-v4 learned
+    /// from a DHT record or forwarded from the v6 socket's events would
+    /// reach the v6 socket in split-stack mode and trip `WSAEADDRNOTAVAIL`
+    /// on Windows — the same bug family the dispatcher exists to solve.
+    ///
+    /// ### Modes
+    ///
+    /// - **Dual-stack** (`is_dual_stack=true`, Linux default): the v6 socket
+    ///   handles both families via kernel mapping. v4 targets are rewritten
+    ///   to `[::ffff:x.x.x.x]` at the wire.
+    /// - **Split-stack** (`is_dual_stack=false`, typically Windows):
+    ///   dispatch by the target's true family. `v6.is_some()`/`v4.is_some()`
+    ///   can be any combination — by construction at least one must be Some
+    ///   for the caller to reach here usefully.
     fn pick_stacks_for<'a>(&'a self, addr: &SocketAddr) -> PickedStacks<'a, T> {
-        // Dual-stack: always v6 first with mapping, v4 second untouched.
-        if self.is_dual_stack {
-            let primary = self
-                .v6
-                .as_ref()
-                .map(|n| (n, self.to_mapped_if_needed(addr)));
-            let fallback = self.v4.as_ref().map(|n| (n, *addr));
-            return (primary, fallback);
-        }
+        let addr = saorsa_transport::shared::normalize_socket_addr(*addr);
 
-        // Split-stack: route by target family.
-        match addr {
-            SocketAddr::V4(_) => {
-                let primary = self.v4.as_ref().map(|n| (n, *addr));
-                // Fallback to v6 with mapping only if we have no v4 socket.
-                let fallback = if primary.is_none() {
-                    self.v6
-                        .as_ref()
-                        .map(|n| (n, self.to_mapped_if_needed(addr)))
+        let plan = decide_dispatch(
+            self.is_dual_stack,
+            self.v6.is_some(),
+            self.v4.is_some(),
+            addr.is_ipv4(),
+        );
+
+        let resolve = |choice: StackChoice| -> Option<(&'a P2PNetworkNode<T>, SocketAddr)> {
+            let node = match choice.role {
+                StackRole::V4 => self.v4.as_ref()?,
+                StackRole::V6 => self.v6.as_ref()?,
+            };
+            let wire = if choice.mapped {
+                if let SocketAddr::V4(v4) = addr {
+                    SocketAddr::V6(SocketAddrV6::new(v4.ip().to_ipv6_mapped(), v4.port(), 0, 0))
                 } else {
-                    None
-                };
-                (primary, fallback)
-            }
-            SocketAddr::V6(_) => {
-                let primary = self.v6.as_ref().map(|n| (n, *addr));
-                // No meaningful v4 fallback for a v6 target.
-                (primary, None)
-            }
-        }
+                    addr
+                }
+            } else {
+                addr
+            };
+            Some((node, wire))
+        };
+
+        (
+            plan.primary.and_then(resolve),
+            plan.fallback.and_then(resolve),
+        )
     }
 
     /// Happy Eyeballs connect: race IPv6 and IPv4 attempts.
@@ -1709,6 +1798,8 @@ fn normalize_connection_event(event: ConnectionEvent) -> ConnectionEvent {
 
 #[cfg(test)]
 mod tests {
+    use super::{DispatchPlan, StackChoice, StackRole, decide_dispatch};
+
     /// Test TDD: verify no duplicate peer registration
     ///
     /// Fixed: Event forwarder no longer tracks peers, only broadcasts events.
@@ -1720,5 +1811,153 @@ mod tests {
         // The fix is verified by:
         // - test_send_to_peer_string: Exercises connect_to_peer with add_peer call
         // Integration tests verify the ConnectionEvent broadcasts work correctly.
+    }
+
+    // ------------------------------------------------------------------
+    // `decide_dispatch`: exhaustive dispatch matrix.
+    //
+    // The constructor invariant is `is_dual_stack ⟺ (has_v6 && !has_v4)`.
+    // These tests cover every reachable combination plus the defensive
+    // paths the function still handles cleanly if the invariant is ever
+    // loosened.
+    // ------------------------------------------------------------------
+
+    const V6: StackChoice = StackChoice {
+        role: StackRole::V6,
+        mapped: false,
+    };
+    const V6_MAPPED: StackChoice = StackChoice {
+        role: StackRole::V6,
+        mapped: true,
+    };
+    const V4: StackChoice = StackChoice {
+        role: StackRole::V4,
+        mapped: false,
+    };
+
+    #[test]
+    fn decide_dispatch_dual_stack_v4_target_maps_onto_v6() {
+        // Linux default: v6 socket handles both families; v4 target gets
+        // rewritten to `[::ffff:x.x.x.x]` form at the wire.
+        assert_eq!(
+            decide_dispatch(true, true, false, true),
+            DispatchPlan {
+                primary: Some(V6_MAPPED),
+                fallback: None,
+            }
+        );
+    }
+
+    #[test]
+    fn decide_dispatch_dual_stack_v6_target_no_mapping() {
+        assert_eq!(
+            decide_dispatch(true, true, false, false),
+            DispatchPlan {
+                primary: Some(V6),
+                fallback: None,
+            }
+        );
+    }
+
+    #[test]
+    fn decide_dispatch_split_stack_both_sockets_v4_target_uses_v4() {
+        // Windows split-stack: v4 target goes to the v4 socket directly.
+        // No mapping, no attempt on the v6 socket (which is v6-only).
+        assert_eq!(
+            decide_dispatch(false, true, true, true),
+            DispatchPlan {
+                primary: Some(V4),
+                fallback: None,
+            }
+        );
+    }
+
+    #[test]
+    fn decide_dispatch_split_stack_both_sockets_v6_target_uses_v6() {
+        assert_eq!(
+            decide_dispatch(false, true, true, false),
+            DispatchPlan {
+                primary: Some(V6),
+                fallback: None,
+            }
+        );
+    }
+
+    #[test]
+    fn decide_dispatch_split_stack_v4_only_v4_target() {
+        assert_eq!(
+            decide_dispatch(false, false, true, true),
+            DispatchPlan {
+                primary: Some(V4),
+                fallback: None,
+            }
+        );
+    }
+
+    #[test]
+    fn decide_dispatch_split_stack_v4_only_v6_target_is_unroutable() {
+        // A v6 target with only a v4 socket bound can't be reached. Plan
+        // must be empty — callers surface this as
+        // `no stack available for this address family`.
+        assert_eq!(
+            decide_dispatch(false, false, true, false),
+            DispatchPlan::default()
+        );
+    }
+
+    #[test]
+    fn decide_dispatch_split_stack_v6_only_v6_target() {
+        assert_eq!(
+            decide_dispatch(false, true, false, false),
+            DispatchPlan {
+                primary: Some(V6),
+                fallback: None,
+            }
+        );
+    }
+
+    #[test]
+    fn decide_dispatch_split_stack_v6_only_v4_target_is_unroutable() {
+        // Reachable only if the invariant is loosened (today
+        // `v6.is_some() && !v4.is_some()` forces `is_dual_stack=true`),
+        // but the function must still return a well-defined plan. No
+        // mapping onto a v6-only socket — that's the WSAEADDRNOTAVAIL
+        // bug the dispatcher exists to avoid.
+        assert_eq!(
+            decide_dispatch(false, true, false, true),
+            DispatchPlan::default()
+        );
+    }
+
+    #[test]
+    fn decide_dispatch_no_stacks() {
+        for addr_is_v4 in [true, false] {
+            assert_eq!(
+                decide_dispatch(false, false, false, addr_is_v4),
+                DispatchPlan::default()
+            );
+        }
+    }
+
+    #[test]
+    fn decide_dispatch_dual_stack_with_defensive_v4_fallback() {
+        // Defensive: if a caller hand-builds a node with both sockets
+        // AND `is_dual_stack=true`, the fallback slot is populated so
+        // the dual-stack path still has a second attempt available.
+        // This combination is unreachable via the public constructors.
+        assert_eq!(
+            decide_dispatch(true, true, true, true),
+            DispatchPlan {
+                primary: Some(V6_MAPPED),
+                fallback: Some(V4),
+            }
+        );
+        assert_eq!(
+            decide_dispatch(true, true, true, false),
+            DispatchPlan {
+                primary: Some(V6),
+                fallback: Some(V4),
+            }
+        );
     }
 }

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -1182,10 +1182,19 @@ impl DualStackNetworkNode<P2pLinkTransport> {
     /// Send to peer using P2pEndpoint's optimized send method.
     ///
     /// Uses P2pEndpoint::send() which corresponds with recv() for proper
-    /// bidirectional communication. Tries IPv6 first, then IPv4.
+    /// bidirectional communication.
     ///
-    /// In dual-stack mode, converts plain IPv4 addresses to the mapped form
-    /// expected by the v6 transport before sending.
+    /// Dispatch (see [`Self::pick_stacks_for`]):
+    /// - **Dual-stack** (single v6 socket accepting mapped v4): send on v6
+    ///   first — plain IPv4 targets are converted to `[::ffff:x.x.x.x]` —
+    ///   with v4 as fallback if present.
+    /// - **Split-stack** (separate v4/v6 sockets, common on Windows): route
+    ///   by target family. IPv4 targets go to the v4 socket, IPv6 targets
+    ///   go to the v6 socket. Cross-family fallback is only used when the
+    ///   matching socket is absent entirely.
+    ///
+    /// On failure, the returned error preserves the underlying transport
+    /// cause instead of a generic "failed on both stacks" message.
     pub async fn send_to_peer_optimized(&self, addr: &SocketAddr, data: &[u8]) -> Result<()> {
         // Preserve the underlying error(s) so the caller can surface them at
         // WARN level. The previous implementation returned a hardcoded


### PR DESCRIPTION
## Summary
On Windows, every outbound UDP send to an IPv4 peer went through the v6 endpoint — which on Windows holds a v6-only socket by default — and was rewritten to `[::ffff:x.x.x.x]` form by `saorsa-transport`'s `ensure_ipv6`. WinSock returns `WSAEADDRNOTAVAIL` (os error 10049) for that combination, producing a storm of transport warnings and a ~5 s wasted handshake timeout per v4 peer before the code fell through to the v4 socket. Windows builds effectively couldn't connect to a healthy peer set.

Dispatch by target family when `DualStackNetworkNode` is in split-stack mode (Windows default), so v4 targets go to the v4 socket directly and no mapped addresses are ever synthesized. Dual-stack mode (Linux default, single v6 socket with kernel mapping) is untouched.

## Root cause

`tokio::net::UdpSocket::bind([::]:port)` produces a v6-only socket by default on Windows (unlike Linux where `net.ipv6.bindv6only=0` makes it dual-stack). So `DualStackNetworkNode::new_with_options` ends up with *both* a v6 and a v4 socket on Windows, and `is_dual_stack = v6.is_some() && v4.is_none()` correctly resolves to `false`.

But three send/disconnect paths were hardcoded to "v6 first, v4 fallback" regardless of the target's family:

- `send_to_peer_optimized` (line 1180)
- `send_to_peer_raw` (line 1471)
- `disconnect_peer_by_addr` (line 1228)

For a v4 target, the v6 endpoint path ran `Endpoint::connect` → `ensure_ipv6` (`saorsa-transport/src/high_level/endpoint.rs:362`) → `[::ffff:v4]` → `send_to` on a v6-only socket → WSAEADDRNOTAVAIL. The v4 socket retry succeeded, but only after the wasted timeout.

## Fix

Factor the primary/fallback selection into a single `pick_stacks_for(addr)` helper with a named return type (`PickedStacks<'a, T>`):

- **Dual-stack mode** (`is_dual_stack=true`, Linux-style single v6 socket): v6 primary with mapping, v4 fallback untouched. **Unchanged from today.**
- **Split-stack mode** (`is_dual_stack=false`, two native sockets held): dispatch by target family. v4 → v4 socket directly, v6 → v6 socket directly. No mapped addresses synthesized. Fallback to the other stack only if the primary is absent.

All three call sites updated to use the helper. `connect_happy_eyeballs` was already family-aware and needs no change.

## Empirical validation — Windows 11, mainnet bootstrap, ant-cli v0.1.4 with local patch

| Signal | Before fix | After fix |
|---|---:|---:|
| `os error 10049` in logs | hundreds per run | **0** |
| Outbound `[::ffff:x.x.x.x]` dial attempts | hundreds | **0** |
| `Connected to autonomi network` peer count (120 s run) | ~0 | **39** |
| Time-to-connect | ~20 min | **< 60 s** |

The only `[::ffff:...]` addresses remaining in logs are *incoming* `ObservedAddress` frames from peers reporting our external address back to us (they see us through their dual-stack socket on Linux) — inbound, not outbound dials. Those are unaffected by this fix, which is correct.

Residual bootstrap WARN timeouts in the after-fix run are home-network / ISP UDP return-path issues, unrelated to this bug.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` clean
- [x] `cargo test --lib` — 282/282 pass (280 passed + 2 ignored, matches baseline)
- [x] Smoke-tested: patched ant-cli against mainnet bootstrap on Windows 11, RUST_LOG=trace, confirms zero WSAEADDRNOTAVAIL and connects in < 60 s

## Notes
- Linux / macOS behaviour is genuinely untouched — the split-stack path is only reachable when the caller hands over both a v6 and a v4 bind address AND the v6 socket didn't capture the v4 half of the port. On Linux with default `bindv6only=0` the v6 socket captures both halves, `is_dual_stack` stays `true`, and dispatch goes down the existing mapping path.
- Independent of #90 (IPv4-preference reordering in DHT / bootstrap) — that PR changes dial ordering; this one changes where a given send goes. No file overlap, either can land first.
- No new unit tests added — the dispatch logic is a pure function of `(is_dual_stack, v6.is_some(), v4.is_some(), addr.family)`, and constructing a `DualStackNetworkNode<T>` for a unit test requires real socket binds. Happy to add a test if reviewers want — would extract the dispatch decision into a `fn decide(...)` that takes plain args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Windows-specific bug where outbound UDP sends to IPv4 peers were routed through the v6-only socket (which Windows creates for `bind([::]:port)` unlike Linux's dual-stack default), producing `WSAEADDRNOTAVAIL` (os error 10049) storms and ~5 s wasted handshake timeouts per v4 peer. The fix introduces a `pick_stacks_for(addr)` helper that centralises stack-dispatch logic: in split-stack mode (Windows: separate v4 and v6 sockets), traffic is dispatched by target address family with no IPv4-mapped address synthesis; in dual-stack mode (Linux: single v6 socket with kernel mapping), behaviour is completely unchanged. All three send/disconnect call sites are updated to use the helper, and error messages now include the target address and stack identity for better diagnostics.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted fix for a well-diagnosed Windows-specific bug with no changes to the Linux/macOS code path.

All remaining findings are P2 or lower. The `pick_stacks_for` dispatch logic is correct given the constructor invariant (`is_dual_stack = v6.is_some() && v4.is_none()`), dual-stack mode is genuinely unchanged, and the empirical validation table in the PR description confirms the fix works end-to-end on Windows 11 mainnet.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/transport/saorsa_transport_adapter.rs | Adds `pick_stacks_for` helper and updates `send_to_peer_optimized`, `send_to_peer_raw`, and `disconnect_peer_by_addr` to dispatch by target address family in split-stack mode; dual-stack (Linux) path is untouched. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pick_stacks_for(addr)"] --> B{is_dual_stack?}
    B -->|true - Linux/macOS single v6 socket| C["primary = v6 + to_mapped_if_needed(addr)\nfallback = v4 (addr unchanged)"]
    B -->|false - Windows split-stack| D{addr family?}
    D -->|SocketAddr::V4| E{v4 socket present?}
    E -->|yes| F["primary = v4 socket, addr as-is\nfallback = None"]
    E -->|no - degenerate| G["primary = None\nfallback = None\n(v6 also absent per invariant)"]
    D -->|SocketAddr::V6| H["primary = v6 socket, addr as-is\nfallback = None\n(no v4 fallback for v6 targets)"]
    C --> I["send / disconnect via primary\non failure → try fallback"]
    F --> I
    G --> I
    H --> I
```

<sub>Reviews (1): Last reviewed commit: ["fix(transport): dispatch v4 peers to v4 ..."](https://github.com/saorsa-labs/saorsa-core/commit/f3fc46bb77f0a2cf690fab21c00302513ad39658) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28765087)</sub>

<!-- /greptile_comment -->