### PR TITLE
fix(network): satisfy HRTB in parallel bootstrap dial closure

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -2093,8 +2093,11 @@ impl P2PNode {
         // handshakes.
         let mut parallel_stream = futures::stream::iter(
             parallel_addr_sets
-                .iter()
-                .map(|addrs| self.dial_bootstrap_addr_set(addrs, used_cache, identity_timeout)),
+                .into_iter()
+                .map(|addrs| async move {
+                    self.dial_bootstrap_addr_set(&addrs, used_cache, identity_timeout)
+                        .await
+                }),
         )
         .buffer_unordered(MAX_CONCURRENT_BOOTSTRAP_DIALS);
         while let Some(result) = parallel_stream.next().await {


### PR DESCRIPTION
## Summary

The parallel-bootstrap-dial closure introduced in `fec51a1` (`perf: parallelize bootstrap peer dials with bounded concurrency`) has a latent HRTB inference issue that silently breaks downstream crates which `tokio::spawn` the connect chain with `Send + 'static` bounds.

## Why the test matrix missed it

`.map(|addrs| self.dial_bootstrap_addr_set(addrs, ...))` takes `addrs: &Vec<MultiAddr>` and returns `impl Future<Output = Option<PeerId>>` that borrows from both `&self` and `&addrs`. The compiler can only infer `FnOnce<(&Vec<MultiAddr>,)>` for one specific lifetime; it cannot generalise to the higher-ranked bound `for<'a> FnOnce<(&'a Vec<MultiAddr>,)>` that's required for the containing future to be `Send`.

HRTB validation in Rust is **lazy** — the compiler only performs the check when a `Send + 'static` constraint is actually demanded. Every consumer currently in the tree does this:

```rust
Client::connect(...).await
```

A local `.await` doesn't force `Send` on the future (the future stays on the caller's task), so the HRTB check never runs and the closure looks fine. saorsa-core's own tests, `ant-node`, `ant-core`, and `ant-cli` all fall into this pattern, which is why the bug slipped in.

A downstream consumer that multi-thread-spawns the chain:

```rust
tokio::spawn(run_connection_loop(app, args))
```

...suddenly forces the HRTB check because `tokio::spawn` requires `Future + Send + 'static`. That's when the compiler refuses to prove `Send` through the closure and the build breaks with:

```
error: implementation of `FnOnce` is not general enough
  = note: closure with signature
    `fn(&'0 Vec<MultiAddr>) -> impl Future<Output = Option<PeerId>>`
    must implement `FnOnce<(&'1 Vec<MultiAddr>,)>`, for any two
    lifetimes `'0` and `'1`... but it actually implements
    `FnOnce<(&Vec<MultiAddr>,)>`
```

The error is reported at the consumer's `tokio::spawn` line, even though the offending closure lives here in saorsa-core.

## Fix

Consume `parallel_addr_sets` with `.into_iter()` so the closure receives an owned `Vec<MultiAddr>`. Move it into an `async move` block — the future now owns its input and only borrows from `&self`, whose lifetime is uniform across the whole call. No HRTB inference needed.

```diff
 let mut parallel_stream = futures::stream::iter(
     parallel_addr_sets
-        .iter()
-        .map(|addrs| self.dial_bootstrap_addr_set(addrs, used_cache, identity_timeout)),
+        .into_iter()
+        .map(|addrs| async move {
+            self.dial_bootstrap_addr_set(&addrs, used_cache, identity_timeout)
+                .await
+        }),
 )
 .buffer_unordered(MAX_CONCURRENT_BOOTSTRAP_DIALS);
```

## Behaviour

Strict no-op semantically:

- `parallel_addr_sets` is not read after the stream loop, so `.into_iter()` just drops the Vec one line earlier.
- Moving an owned `Vec<MultiAddr>` into each dial task is free — no clones, no extra allocations.
- `buffer_unordered(MAX_CONCURRENT_BOOTSTRAP_DIALS)` concurrency cap and first-address-wins semantics are unchanged.

## Verification

Patched the cached git checkout locally and rebuilt the consumer crate that was previously failing. Error goes away; ant-gui (non-trivial downstream that wraps `Client::connect` in `tokio::spawn`) compiles cleanly with the patch applied.

## Test plan

- [ ] `cargo test -p saorsa-core` still green
- [ ] `ant-node` / `ant-core` / `ant-cli` still build
- [ ] Downstream consumer that `tokio::spawn`s the connect chain now builds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a latent HRTB (Higher-Ranked Trait Bound) inference failure in the parallel bootstrap dial stream introduced in `fec51a1`. By switching from `.iter()` to `.into_iter()` and wrapping the call in `async move { ... }`, the closure's argument changes from a borrowed `&Vec<MultiAddr>` (requiring a higher-ranked lifetime bound) to an owned `Vec<MultiAddr>`, which eliminates the ambiguity that breaks `Send` inference when the containing future is spawned with `tokio::spawn`.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — the change is a minimal, semantically equivalent fix for a real compiler-visible HRTB bug.

The diff is 4 lines in a single function, the fix is idiomatic and correct (`into_iter()` + `async move` removes the higher-ranked lifetime from the closure argument), `bool` and `Duration` are `Copy` so they capture cleanly, and `parallel_addr_sets` is not read after this point so the ownership transfer is safe. No logic, concurrency semantics, or allocation behaviour changes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/network.rs | Switches `.iter()` to `.into_iter()` with `async move` wrapper to fix HRTB `Send` inference for the parallel bootstrap dial stream; semantically equivalent, no clones or allocations added. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as Caller (e.g. tokio::spawn)
    participant Connect as Client::connect
    participant Stream as futures::stream::iter
    participant Dial as dial_bootstrap_addr_set

    Note over Caller,Dial: Before fix — closure borrows &Vec<MultiAddr>
    Caller->>Connect: tokio::spawn(connect(...))
    Connect->>Stream: .iter().map(|addrs: &Vec| self.dial(..., addrs))
    Note over Stream: Future borrows &self AND &addrs<br/>Compiler can't prove Send for<br/>for<'a> FnOnce(&'a Vec<MultiAddr>)<br/>→ build error

    Note over Caller,Dial: After fix — closure receives owned Vec<MultiAddr>
    Caller->>Connect: tokio::spawn(connect(...))
    Connect->>Stream: .into_iter().map(|addrs: Vec| async move { self.dial(..., &addrs).await })
    Note over Stream: Future owns addrs, borrows only &self<br/>Single concrete lifetime — Send check passes
    Stream->>Dial: dial_bootstrap_addr_set(&addrs, ...)
    Dial-->>Stream: Option<PeerId>
    Stream-->>Connect: successful_connections / connected_peer_ids
```

<sub>Reviews (1): Last reviewed commit: ["fix(network): satisfy HRTB in parallel b..."](https://github.com/saorsa-labs/saorsa-core/commit/8a9b8077fc2c69c063a2509ad03b5ec45ef2cc4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29430986)</sub>

<!-- /greptile_comment -->