### PR TITLE
perf(logging): demote per-message INFO logs in transport hot path

### DIFF
--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -2284,11 +2284,16 @@ impl DhtNetworkManager {
         }
 
         // Send message via network layer, reconnecting on demand if needed.
-        let peer_hex = peer_id.to_hex();
-        let local_hex = self.config.peer_id.to_hex();
-        info!(
+        // Hex-encode peer IDs lazily inside each tracing macro: tracing only
+        // evaluates the macro's arguments when the level is enabled, so we
+        // pay the allocation cost only on warn (rare) or when DEBUG logging
+        // is explicitly turned on.
+        debug!(
             "[STEP 1] {} -> {}: Sending {:?} request (msg_id: {})",
-            local_hex, peer_hex, message.payload, message_id
+            self.config.peer_id.to_hex(),
+            peer_id.to_hex(),
+            message.payload,
+            message_id
         );
 
         // Ensure we have an identity-authenticated channel to the
@@ -2335,9 +2340,10 @@ impl DhtNetworkManager {
             .await
         {
             Ok(_) => {
-                info!(
+                debug!(
                     "[STEP 2] {} -> {}: Message sent successfully, waiting for response...",
-                    local_hex, peer_hex
+                    self.config.peer_id.to_hex(),
+                    peer_id.to_hex()
                 );
 
                 // Wait for response via oneshot channel with timeout
@@ -2345,15 +2351,17 @@ impl DhtNetworkManager {
                     .wait_for_response(&message_id, response_rx, peer_id)
                     .await;
                 match &result {
-                    Ok(r) => info!(
+                    Ok(r) => debug!(
                         "[STEP 6] {} <- {}: Got response: {:?}",
-                        local_hex,
-                        peer_hex,
+                        self.config.peer_id.to_hex(),
+                        peer_id.to_hex(),
                         std::mem::discriminant(r)
                     ),
                     Err(e) => warn!(
                         "[STEP 6 FAILED] {} <- {}: Response error: {}",
-                        local_hex, peer_hex, e
+                        self.config.peer_id.to_hex(),
+                        peer_id.to_hex(),
+                        e
                     ),
                 }
                 result
@@ -2361,7 +2369,8 @@ impl DhtNetworkManager {
             Err(e) => {
                 warn!(
                     "[STEP 1 FAILED] Failed to send DHT request to {}: {}",
-                    peer_hex, e
+                    peer_id.to_hex(),
+                    e
                 );
                 Err(e)
             }

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -1176,7 +1176,7 @@ impl TransportHandle {
         // shard, so two concurrent senders will not produce duplicate
         // PeerInfo entries.
         self.peers.entry(channel_id.to_string()).or_insert_with(|| {
-            info!(
+            debug!(
                 "send_on_channel: registering new channel {} on the fly",
                 channel_id
             );
@@ -1214,7 +1214,7 @@ impl TransportHandle {
 
         let raw_data_len = data.len();
         let message_data = self.create_protocol_message(protocol, data)?;
-        info!(
+        debug!(
             "Sending {} bytes to channel {} on protocol {} (raw data: {} bytes)",
             message_data.len(),
             channel_id,
@@ -1242,7 +1242,7 @@ impl TransportHandle {
             });
 
         if result.is_ok() {
-            info!(
+            debug!(
                 "Successfully sent {} bytes to channel {}",
                 message_data.len(),
                 channel_id


### PR DESCRIPTION
## Summary

The three highest-volume log emitters in the production network were all firing once
per outgoing message at INFO. Across the prod fleet that produced ~1 B docs/day in
Elasticsearch, dominated by ~99% INFO content from three modules:

- `transport_handle::send_on_channel`: `Sending N bytes …` and `Successfully sent N bytes …`,
  plus the `registering new channel … on the fly` line in `peers.entry().or_insert_with`.
- `dht_network_manager`: `[STEP 1] Sending request`, `[STEP 2] Message sent successfully`,
  and `[STEP 6] Got response`, on every DHT request.

Each of these is dropped from `info!` to `debug!`. Failure paths (`warn!` /
`[STEP X FAILED]`) are unchanged.

## Why

Sampled production logs showed 200 K log lines from a single hour split as 191 K INFO /
9 K WARN, with three modules accounting for 99.75% of the volume. ES daily index sizes
were 17 GB → 265 GB → 50 GB across three days. The per-message INFO content is an
operational debug aid rather than something an operator should see at the default
filter, so default-INFO production runs go silent for these emissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)