### PR TITLE
fix(dht): gate routing-table liveness on identity-confirmed activity

### DIFF
--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -520,25 +520,40 @@ impl KBucket {
         }
     }
 
-    /// Upgrade-only variant of [`Self::touch_node_typed`]: merge `address`
-    /// with `addr_type` into the peer's `NodeInfo`, but never demote a
-    /// higher-priority tag already on the same address.
+    /// Merge `address` (with `addr_type`) into the peer's `NodeInfo` using
+    /// upgrade-only semantics: never demote a higher-priority tag already
+    /// on the same address.
+    ///
+    /// **Pure address-set update.** Does NOT bump the peer's `last_seen`,
+    /// does NOT reorder the bucket (no MRU promotion), and does NOT bump
+    /// the bucket's `last_refreshed` timestamp. Intended for FIND_NODE
+    /// gossip ingestion, where a responder's typed view of a *third*
+    /// peer is trusted enough to widen our known address set or promote
+    /// `Unverified` → `Direct`/`Relay`, but is **not** evidence of:
+    ///
+    /// * peer-level liveness (covered by `last_seen` — bumping it from
+    ///   gossip would let peers we cannot authenticate with ourselves
+    ///   stay perpetually "fresh", indefinitely deferring the
+    ///   [`DhtCoreEngine::stale_k_closest`] eviction worker), or
+    /// * bucket-level discovery activity (covered by `last_refreshed` —
+    ///   the bucket-refresh task uses it to decide when to run a
+    ///   FIND_NODE for a random key in this bucket's range, which is how
+    ///   we discover *new* peers. Gossip about peers we already know is
+    ///   not discovery; bumping `last_refreshed` from gossip would mask
+    ///   genuinely-stale buckets and silently suppress discovery as long
+    ///   as some neighbour kept gossiping about a peer in that range).
     ///
     /// Returns `true` when the peer is in this bucket (regardless of
     /// whether the merge changed state); `false` when the peer is absent.
     /// The loopback-injection guard from [`Self::touch_node_typed`] applies
     /// equally.
-    ///
-    /// Intended for FIND_NODE gossip ingestion — see
-    /// [`NodeInfo::merge_typed_address_upgrade_only`].
-    fn touch_node_typed_upgrade_only(
+    fn merge_typed_address_upgrade_only(
         &mut self,
         node_id: &PeerId,
         address: Option<&MultiAddr>,
         addr_type: AddressType,
     ) -> bool {
         if let Some(pos) = self.nodes.iter().position(|n| &n.id == node_id) {
-            self.nodes[pos].last_seen.store_now();
             if let Some(addr) = address {
                 let addr_is_loopback = addr
                     .ip()
@@ -551,9 +566,6 @@ impl KBucket {
                     self.nodes[pos].merge_typed_address_upgrade_only(addr.clone(), addr_type);
                 }
             }
-            let node = self.nodes.remove(pos);
-            self.nodes.push(node);
-            self.last_refreshed = Instant::now();
             true
         } else {
             false
@@ -773,10 +785,13 @@ impl KademliaRoutingTable {
         }
     }
 
-    /// Upgrade-only variant of [`Self::touch_node`]: the merge never
-    /// demotes an existing higher-priority tag on the same address. See
-    /// [`KBucket::touch_node_typed_upgrade_only`].
-    fn touch_node_upgrade_only(
+    /// Pure address-set merge for an existing routing-table entry.
+    ///
+    /// Like [`Self::touch_node`] but never demotes a higher-priority tag
+    /// on the same address, and does NOT bump `last_seen` or reorder the
+    /// bucket — see [`KBucket::merge_typed_address_upgrade_only`] for the
+    /// rationale (gossip ingestion must not refresh peer liveness).
+    fn merge_typed_address_upgrade_only(
         &mut self,
         node_id: &PeerId,
         address: Option<&MultiAddr>,
@@ -784,7 +799,7 @@ impl KademliaRoutingTable {
     ) -> bool {
         match self.get_bucket_index(node_id) {
             Some(bucket_index) => self.buckets[bucket_index]
-                .touch_node_typed_upgrade_only(node_id, address, addr_type),
+                .merge_typed_address_upgrade_only(node_id, address, addr_type),
             None => false,
         }
     }
@@ -1380,20 +1395,29 @@ impl DhtCoreEngine {
         routing.touch_node(node_id, address, addr_type)
     }
 
-    /// Upgrade-only variant of [`Self::touch_node_typed`]: merge `address`
-    /// with `addr_type` into the peer's record, but never demote a
-    /// higher-priority tag already on the same address.
+    /// Merge `address` (with `addr_type`) into an existing peer's record
+    /// using upgrade-only semantics: never demote a higher-priority tag
+    /// already on the same address.
     ///
-    /// Returns `true` when the peer is in the routing table (regardless of
-    /// whether the merge changed state); `false` otherwise.
+    /// **Pure address-set update.** Does NOT bump `last_seen` and does
+    /// NOT reorder the bucket. Intended for FIND_NODE gossip ingestion:
+    /// a responder's typed view is trusted enough to widen our record
+    /// (new addresses) or promote a cold-start `Unverified` to
+    /// `Direct`/`Relay`, but it is **not** evidence that the subject
+    /// peer is alive from *our* point of view — only direct authenticated
+    /// activity (handled by [`Self::touch_node_typed`] via
+    /// [`crate::dht_network_manager::DhtNetworkManager::handle_dht_message`])
+    /// refreshes liveness.
     ///
-    /// Intended for FIND_NODE gossip ingestion: a responder's typed set is
-    /// trusted enough to widen our record (new addresses) or promote a
-    /// cold-start `Unverified` to `Direct`/`Relay`, but not trusted enough
-    /// to overwrite an authoritative higher-priority tag — which typically
-    /// came from the peer's own `PublishAddressSet` (full-replace) or from
-    /// our own classifier.
-    pub async fn touch_node_typed_upgrade_only(
+    /// Without this gating, a chatty network would defer
+    /// [`Self::stale_k_closest`] eviction indefinitely for every peer
+    /// some authenticated neighbour happens to mention — including
+    /// peers we cannot authenticate with ourselves (e.g., older
+    /// protocol versions whose identity exchange always times out).
+    ///
+    /// Returns `true` when the peer is in the routing table (regardless
+    /// of whether the merge changed state); `false` otherwise.
+    pub async fn merge_typed_address_upgrade_only(
         &self,
         node_id: &PeerId,
         address: Option<&MultiAddr>,
@@ -1405,7 +1429,7 @@ impl DhtCoreEngine {
         // tag, which must happen under the write lock to avoid a TOCTOU
         // race with a concurrent PublishAddressSet replace.
         let mut routing = self.routing_table.write().await;
-        routing.touch_node_upgrade_only(node_id, address, addr_type)
+        routing.merge_typed_address_upgrade_only(node_id, address, addr_type)
     }
 
     /// Replace a peer's advertised address list with `typed_addresses`, under
@@ -2224,6 +2248,162 @@ mod tests {
             AddressType::Direct,
         );
         assert!(!found);
+    }
+
+    // -----------------------------------------------------------------------
+    // KBucket::merge_typed_address_upgrade_only tests
+    //
+    // The gossip-ingestion path: merges a third party's view of an existing
+    // peer's addresses without claiming the peer is alive from our point of
+    // view. Liveness (`last_seen`) and bucket-MRU position must be preserved
+    // — see the rationale on `KBucket::merge_typed_address_upgrade_only`.
+    // -----------------------------------------------------------------------
+
+    /// Offset used when pinning `last_seen` to a past instant in
+    /// gossip-merge tests. Chosen well above [`LIVE_THRESHOLD`] (15 min)
+    /// so that a leaked `last_seen` refresh would be unmistakable
+    /// regardless of test scheduling jitter.
+    const GOSSIP_LAST_SEEN_PIN_OFFSET: Duration = Duration::from_secs(3600);
+
+    #[test]
+    fn gossip_merge_does_not_bump_last_seen() {
+        let k = 8;
+        let mut bucket = KBucket::new(k);
+        bucket
+            .add_node(make_node(1, "/ip4/1.1.1.1/udp/9000/quic"))
+            .unwrap();
+
+        // Pin `last_seen` to a known past instant so we can detect any
+        // refresh. The offset (see `GOSSIP_LAST_SEEN_PIN_OFFSET`) far
+        // exceeds LIVE_THRESHOLD, so a leaked refresh would be obvious.
+        let pinned = Instant::now()
+            .checked_sub(GOSSIP_LAST_SEEN_PIN_OFFSET)
+            .expect("monotonic clock supports the configured pin offset");
+        bucket.nodes[0].last_seen.store(pinned);
+
+        // Gossip ingestion: another peer reports a new Relay address for
+        // peer 1. Should merge the address but leave liveness alone.
+        let gossiped: MultiAddr = "/ip4/9.9.9.9/udp/9000/quic".parse().unwrap();
+        let found = bucket.merge_typed_address_upgrade_only(
+            &PeerId::from_bytes([1u8; 32]),
+            Some(&gossiped),
+            AddressType::Relay,
+        );
+        assert!(found, "peer 1 should be in the bucket");
+        assert_eq!(
+            bucket.nodes[0].last_seen.load(),
+            pinned,
+            "gossip ingestion must not refresh last_seen"
+        );
+    }
+
+    #[test]
+    fn gossip_merge_does_not_reorder_bucket() {
+        let k = 8;
+        let mut bucket = KBucket::new(k);
+        bucket
+            .add_node(make_node(1, "/ip4/1.1.1.1/udp/9000/quic"))
+            .unwrap();
+        bucket
+            .add_node(make_node(2, "/ip4/2.2.2.2/udp/9000/quic"))
+            .unwrap();
+        bucket
+            .add_node(make_node(3, "/ip4/3.3.3.3/udp/9000/quic"))
+            .unwrap();
+
+        // Insertion order (head = LRU, tail = MRU): [1, 2, 3].
+        // touch_node_typed would move peer 1 to the tail. Gossip-merge must
+        // NOT, otherwise unauthenticated gossip could shield bad peers from
+        // LRU-driven eviction.
+        let gossiped: MultiAddr = "/ip4/8.8.8.8/udp/9000/quic".parse().unwrap();
+        bucket.merge_typed_address_upgrade_only(
+            &PeerId::from_bytes([1u8; 32]),
+            Some(&gossiped),
+            AddressType::Relay,
+        );
+
+        let ids: Vec<u8> = bucket
+            .get_nodes()
+            .iter()
+            .map(|n| n.id.to_bytes()[0])
+            .collect();
+        assert_eq!(
+            ids,
+            vec![1, 2, 3],
+            "gossip ingestion must preserve bucket order"
+        );
+    }
+
+    #[test]
+    fn gossip_merge_adds_new_address() {
+        let k = 8;
+        let mut bucket = KBucket::new(k);
+        bucket
+            .add_node(make_node(1, "/ip4/1.1.1.1/udp/9000/quic"))
+            .unwrap();
+
+        // A previously unseen Direct address from gossip. Should be added.
+        let gossiped: MultiAddr = "/ip4/7.7.7.7/udp/9000/quic".parse().unwrap();
+        let found = bucket.merge_typed_address_upgrade_only(
+            &PeerId::from_bytes([1u8; 32]),
+            Some(&gossiped),
+            AddressType::Direct,
+        );
+        assert!(found);
+        assert!(
+            bucket.nodes[0].addresses.iter().any(|a| a == &gossiped),
+            "gossip ingestion must merge a previously-unseen address"
+        );
+    }
+
+    #[test]
+    fn gossip_merge_returns_false_for_missing_peer() {
+        let k = 8;
+        let mut bucket = KBucket::new(k);
+        bucket
+            .add_node(make_node(1, "/ip4/1.1.1.1/udp/9000/quic"))
+            .unwrap();
+
+        let gossiped: MultiAddr = "/ip4/9.9.9.9/udp/9000/quic".parse().unwrap();
+        let found = bucket.merge_typed_address_upgrade_only(
+            &PeerId::from_bytes([42u8; 32]),
+            Some(&gossiped),
+            AddressType::Direct,
+        );
+        assert!(
+            !found,
+            "missing peer should return false (gossip never inserts new identities)"
+        );
+    }
+
+    #[test]
+    fn gossip_merge_does_not_bump_last_refreshed() {
+        let k = 8;
+        let mut bucket = KBucket::new(k);
+        bucket
+            .add_node(make_node(1, "/ip4/1.1.1.1/udp/9000/quic"))
+            .unwrap();
+
+        // Pin `last_refreshed` to a known past instant. The same offset
+        // used for last_seen tests is well above STALE_BUCKET_THRESHOLD
+        // (1 hour), so a leak would unmistakably appear as a fresh
+        // timestamp.
+        let pinned = Instant::now()
+            .checked_sub(GOSSIP_LAST_SEEN_PIN_OFFSET)
+            .expect("monotonic clock supports the configured pin offset");
+        bucket.last_refreshed = pinned;
+
+        let gossiped: MultiAddr = "/ip4/8.8.8.8/udp/9000/quic".parse().unwrap();
+        let found = bucket.merge_typed_address_upgrade_only(
+            &PeerId::from_bytes([1u8; 32]),
+            Some(&gossiped),
+            AddressType::Relay,
+        );
+        assert!(found);
+        assert_eq!(
+            bucket.last_refreshed, pinned,
+            "gossip ingestion is not bucket-level discovery — last_refreshed must not advance"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -553,16 +553,13 @@ impl KBucket {
     fn merge_typed_address_upgrade_only(
         &mut self,
         node_id: &PeerId,
-        address: Option<&MultiAddr>,
+        address: &MultiAddr,
         addr_type: AddressType,
     ) -> bool {
         let Some(pos) = self.nodes.iter().position(|n| &n.id == node_id) else {
             return false;
         };
-        let Some(addr) = address else {
-            return false;
-        };
-        let addr_is_loopback = addr
+        let addr_is_loopback = address
             .ip()
             .is_some_and(|ip| canonicalize_ip(ip).is_loopback());
         let node_has_non_loopback = self.nodes[pos]
@@ -572,7 +569,7 @@ impl KBucket {
         if addr_is_loopback && node_has_non_loopback {
             return false;
         }
-        self.nodes[pos].merge_typed_address_upgrade_only(addr.clone(), addr_type)
+        self.nodes[pos].merge_typed_address_upgrade_only(address.clone(), addr_type)
     }
 
     /// Fast path: if `node_id` is in this bucket AND the optional address
@@ -800,7 +797,7 @@ impl KademliaRoutingTable {
     fn merge_typed_address_upgrade_only(
         &mut self,
         node_id: &PeerId,
-        address: Option<&MultiAddr>,
+        address: &MultiAddr,
         addr_type: AddressType,
     ) -> bool {
         match self.get_bucket_index(node_id) {
@@ -1430,7 +1427,7 @@ impl DhtCoreEngine {
     pub async fn merge_typed_address_upgrade_only(
         &self,
         node_id: &PeerId,
-        address: Option<&MultiAddr>,
+        address: &MultiAddr,
         addr_type: AddressType,
     ) -> bool {
         // No fast path: the read-locked fast path is only valid when the
@@ -2288,7 +2285,7 @@ mod tests {
         let gossiped: MultiAddr = "/ip4/9.9.9.9/udp/9000/quic".parse().unwrap();
         let changed = bucket.merge_typed_address_upgrade_only(
             &PeerId::from_bytes([1u8; 32]),
-            Some(&gossiped),
+            &gossiped,
             AddressType::Relay,
         );
         assert!(changed, "merge of new address should report a state change");
@@ -2320,7 +2317,7 @@ mod tests {
         let gossiped: MultiAddr = "/ip4/8.8.8.8/udp/9000/quic".parse().unwrap();
         bucket.merge_typed_address_upgrade_only(
             &PeerId::from_bytes([1u8; 32]),
-            Some(&gossiped),
+            &gossiped,
             AddressType::Relay,
         );
 
@@ -2349,7 +2346,7 @@ mod tests {
         let gossiped: MultiAddr = "/ip4/7.7.7.7/udp/9000/quic".parse().unwrap();
         let changed = bucket.merge_typed_address_upgrade_only(
             &PeerId::from_bytes([1u8; 32]),
-            Some(&gossiped),
+            &gossiped,
             AddressType::Direct,
         );
         assert!(changed);
@@ -2370,7 +2367,7 @@ mod tests {
         let gossiped: MultiAddr = "/ip4/9.9.9.9/udp/9000/quic".parse().unwrap();
         let changed = bucket.merge_typed_address_upgrade_only(
             &PeerId::from_bytes([42u8; 32]),
-            Some(&gossiped),
+            &gossiped,
             AddressType::Direct,
         );
         assert!(
@@ -2399,7 +2396,7 @@ mod tests {
 
         let changed = bucket.merge_typed_address_upgrade_only(
             &PeerId::from_bytes([1u8; 32]),
-            Some(&known),
+            &known,
             AddressType::Direct,
         );
         assert!(
@@ -2421,7 +2418,7 @@ mod tests {
         let gossiped: MultiAddr = "/ip4/8.8.8.8/udp/9000/quic".parse().unwrap();
         let changed = bucket.merge_typed_address_upgrade_only(
             &PeerId::from_bytes([1u8; 32]),
-            Some(&gossiped),
+            &gossiped,
             AddressType::Relay,
         );
         assert!(changed);

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -543,33 +543,36 @@ impl KBucket {
     ///   genuinely-stale buckets and silently suppress discovery as long
     ///   as some neighbour kept gossiping about a peer in that range).
     ///
-    /// Returns `true` when the peer is in this bucket (regardless of
-    /// whether the merge changed state); `false` when the peer is absent.
-    /// The loopback-injection guard from [`Self::touch_node_typed`] applies
-    /// equally.
+    /// Returns `true` when the merge changed the peer's address record
+    /// (a new address was appended, or an existing tag was promoted to a
+    /// higher-priority tier); `false` when the peer is absent, the
+    /// loopback-injection guard skipped the merge, or the merge was a
+    /// no-op (address already present with an equal-or-higher-priority
+    /// tag). The loopback-injection guard from [`Self::touch_node_typed`]
+    /// applies equally.
     fn merge_typed_address_upgrade_only(
         &mut self,
         node_id: &PeerId,
         address: Option<&MultiAddr>,
         addr_type: AddressType,
     ) -> bool {
-        if let Some(pos) = self.nodes.iter().position(|n| &n.id == node_id) {
-            if let Some(addr) = address {
-                let addr_is_loopback = addr
-                    .ip()
-                    .is_some_and(|ip| canonicalize_ip(ip).is_loopback());
-                let node_has_non_loopback = self.nodes[pos]
-                    .addresses
-                    .iter()
-                    .any(|a| a.ip().is_some_and(|ip| !canonicalize_ip(ip).is_loopback()));
-                if !(addr_is_loopback && node_has_non_loopback) {
-                    self.nodes[pos].merge_typed_address_upgrade_only(addr.clone(), addr_type);
-                }
-            }
-            true
-        } else {
-            false
+        let Some(pos) = self.nodes.iter().position(|n| &n.id == node_id) else {
+            return false;
+        };
+        let Some(addr) = address else {
+            return false;
+        };
+        let addr_is_loopback = addr
+            .ip()
+            .is_some_and(|ip| canonicalize_ip(ip).is_loopback());
+        let node_has_non_loopback = self.nodes[pos]
+            .addresses
+            .iter()
+            .any(|a| a.ip().is_some_and(|ip| !canonicalize_ip(ip).is_loopback()));
+        if addr_is_loopback && node_has_non_loopback {
+            return false;
         }
+        self.nodes[pos].merge_typed_address_upgrade_only(addr.clone(), addr_type)
     }
 
     /// Fast path: if `node_id` is in this bucket AND the optional address
@@ -791,6 +794,9 @@ impl KademliaRoutingTable {
     /// on the same address, and does NOT bump `last_seen` or reorder the
     /// bucket — see [`KBucket::merge_typed_address_upgrade_only`] for the
     /// rationale (gossip ingestion must not refresh peer liveness).
+    ///
+    /// Returns `true` when the merge changed the peer's address record;
+    /// `false` for missing peer, no-op merge, or loopback-skip.
     fn merge_typed_address_upgrade_only(
         &mut self,
         node_id: &PeerId,
@@ -1415,8 +1421,12 @@ impl DhtCoreEngine {
     /// peers we cannot authenticate with ourselves (e.g., older
     /// protocol versions whose identity exchange always times out).
     ///
-    /// Returns `true` when the peer is in the routing table (regardless
-    /// of whether the merge changed state); `false` otherwise.
+    /// Returns `true` when the merge changed the peer's address record
+    /// (a new address was appended, or an existing tag was promoted to
+    /// a higher-priority tier); `false` for missing peer, no-op merge,
+    /// or loopback-skip — see
+    /// [`KBucket::merge_typed_address_upgrade_only`] for the full
+    /// classification.
     pub async fn merge_typed_address_upgrade_only(
         &self,
         node_id: &PeerId,
@@ -2257,13 +2267,13 @@ mod tests {
     // peer's addresses without claiming the peer is alive from our point of
     // view. Liveness (`last_seen`) and bucket-MRU position must be preserved
     // — see the rationale on `KBucket::merge_typed_address_upgrade_only`.
+    //
+    // The robust pattern here is capture-before-merge / compare-after-merge:
+    // any leaked `store_now()` would write a strictly later `Instant` than
+    // the captured snapshot (the merge does a Vec scan, mutex unlock, and
+    // assertion code in between), so exact-equality detects refresh leaks
+    // without depending on system uptime or clock granularity.
     // -----------------------------------------------------------------------
-
-    /// Offset used when pinning `last_seen` to a past instant in
-    /// gossip-merge tests. Chosen well above [`LIVE_THRESHOLD`] (15 min)
-    /// so that a leaked `last_seen` refresh would be unmistakable
-    /// regardless of test scheduling jitter.
-    const GOSSIP_LAST_SEEN_PIN_OFFSET: Duration = Duration::from_secs(3600);
 
     #[test]
     fn gossip_merge_does_not_bump_last_seen() {
@@ -2273,26 +2283,18 @@ mod tests {
             .add_node(make_node(1, "/ip4/1.1.1.1/udp/9000/quic"))
             .unwrap();
 
-        // Pin `last_seen` to a known past instant so we can detect any
-        // refresh. The offset (see `GOSSIP_LAST_SEEN_PIN_OFFSET`) far
-        // exceeds LIVE_THRESHOLD, so a leaked refresh would be obvious.
-        let pinned = Instant::now()
-            .checked_sub(GOSSIP_LAST_SEEN_PIN_OFFSET)
-            .expect("monotonic clock supports the configured pin offset");
-        bucket.nodes[0].last_seen.store(pinned);
+        let before = bucket.nodes[0].last_seen.load();
 
-        // Gossip ingestion: another peer reports a new Relay address for
-        // peer 1. Should merge the address but leave liveness alone.
         let gossiped: MultiAddr = "/ip4/9.9.9.9/udp/9000/quic".parse().unwrap();
-        let found = bucket.merge_typed_address_upgrade_only(
+        let changed = bucket.merge_typed_address_upgrade_only(
             &PeerId::from_bytes([1u8; 32]),
             Some(&gossiped),
             AddressType::Relay,
         );
-        assert!(found, "peer 1 should be in the bucket");
+        assert!(changed, "merge of new address should report a state change");
         assert_eq!(
             bucket.nodes[0].last_seen.load(),
-            pinned,
+            before,
             "gossip ingestion must not refresh last_seen"
         );
     }
@@ -2342,14 +2344,15 @@ mod tests {
             .add_node(make_node(1, "/ip4/1.1.1.1/udp/9000/quic"))
             .unwrap();
 
-        // A previously unseen Direct address from gossip. Should be added.
+        // A previously unseen Direct address from gossip. Should be added
+        // and the merge should report a state change.
         let gossiped: MultiAddr = "/ip4/7.7.7.7/udp/9000/quic".parse().unwrap();
-        let found = bucket.merge_typed_address_upgrade_only(
+        let changed = bucket.merge_typed_address_upgrade_only(
             &PeerId::from_bytes([1u8; 32]),
             Some(&gossiped),
             AddressType::Direct,
         );
-        assert!(found);
+        assert!(changed);
         assert!(
             bucket.nodes[0].addresses.iter().any(|a| a == &gossiped),
             "gossip ingestion must merge a previously-unseen address"
@@ -2365,14 +2368,43 @@ mod tests {
             .unwrap();
 
         let gossiped: MultiAddr = "/ip4/9.9.9.9/udp/9000/quic".parse().unwrap();
-        let found = bucket.merge_typed_address_upgrade_only(
+        let changed = bucket.merge_typed_address_upgrade_only(
             &PeerId::from_bytes([42u8; 32]),
             Some(&gossiped),
             AddressType::Direct,
         );
         assert!(
-            !found,
+            !changed,
             "missing peer should return false (gossip never inserts new identities)"
+        );
+    }
+
+    #[test]
+    fn gossip_merge_returns_false_when_already_known_with_same_tag() {
+        // The return value signals "did the merge change anything",
+        // not "is the peer in the bucket". When gossip reports an
+        // already-known address with the same tag classification, the
+        // merge is a no-op and must report `false` so a future caller
+        // can gate downstream work (logging, event emission, etc.) on
+        // genuine record changes.
+        let k = 8;
+        let mut bucket = KBucket::new(k);
+        let addr_str = "/ip4/1.1.1.1/udp/9000/quic";
+        bucket.add_node(make_node(1, addr_str)).unwrap();
+
+        // Promote the existing address to `Direct` so the redundant
+        // gossip below cannot upgrade it from the default `Unverified`.
+        let known: MultiAddr = addr_str.parse().unwrap();
+        bucket.nodes[0].merge_typed_address_upgrade_only(known.clone(), AddressType::Direct);
+
+        let changed = bucket.merge_typed_address_upgrade_only(
+            &PeerId::from_bytes([1u8; 32]),
+            Some(&known),
+            AddressType::Direct,
+        );
+        assert!(
+            !changed,
+            "no-op merge (same address, same tag) must report false"
         );
     }
 
@@ -2384,24 +2416,17 @@ mod tests {
             .add_node(make_node(1, "/ip4/1.1.1.1/udp/9000/quic"))
             .unwrap();
 
-        // Pin `last_refreshed` to a known past instant. The same offset
-        // used for last_seen tests is well above STALE_BUCKET_THRESHOLD
-        // (1 hour), so a leak would unmistakably appear as a fresh
-        // timestamp.
-        let pinned = Instant::now()
-            .checked_sub(GOSSIP_LAST_SEEN_PIN_OFFSET)
-            .expect("monotonic clock supports the configured pin offset");
-        bucket.last_refreshed = pinned;
+        let before = bucket.last_refreshed;
 
         let gossiped: MultiAddr = "/ip4/8.8.8.8/udp/9000/quic".parse().unwrap();
-        let found = bucket.merge_typed_address_upgrade_only(
+        let changed = bucket.merge_typed_address_upgrade_only(
             &PeerId::from_bytes([1u8; 32]),
             Some(&gossiped),
             AddressType::Relay,
         );
-        assert!(found);
+        assert!(changed);
         assert_eq!(
-            bucket.last_refreshed, pinned,
+            bucket.last_refreshed, before,
             "gossip ingestion is not bucket-level discovery — last_refreshed must not advance"
         );
     }

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -3558,7 +3558,7 @@ impl DhtNetworkManager {
     pub async fn merge_gossiped_typed_addresses(&self, node: &DHTNode) {
         let dht = self.dht.read().await;
         for (addr, ty) in node.typed_addresses() {
-            dht.merge_typed_address_upgrade_only(&node.peer_id, Some(&addr), ty)
+            dht.merge_typed_address_upgrade_only(&node.peer_id, &addr, ty)
                 .await;
         }
     }

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -83,8 +83,40 @@ const SELF_RELIABILITY_SCORE: f64 = 1.0;
 /// timeout.
 const IDENTITY_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Maximum time to wait for a stale peer's ping response during admission contention.
-const STALE_REVALIDATION_TIMEOUT: Duration = Duration::from_secs(1);
+/// Wall-clock budget for a single stale-peer revalidation probe.
+///
+/// The probe is `ping_peer`, which will dial and run identity exchange
+/// from cold when no authenticated channel is currently open — the
+/// common case for a peer that has been silent for `LIVE_THRESHOLD`
+/// (15 min) and may have lost its transport channel to a NAT rebind,
+/// idle timeout, or transient network blip. We must therefore budget
+/// for the full identity-exchange handshake before the ping reply is
+/// even possible:
+///
+/// ```text
+///   IDENTITY_EXCHANGE_TIMEOUT  (up to 5 s)   — fresh handshake from cold
+/// + STALE_REVALIDATION_PING_RTT (1 s)        — ping round-trip over the
+///                                              freshly-authenticated channel
+/// = STALE_REVALIDATION_BUDGET   (6 s)
+/// ```
+///
+/// Capping at 1 s — the original budget — silently false-evicted
+/// healthy peers whose channel had to be re-established, because the
+/// outer timeout fired mid-handshake. The strict identity-confirmation
+/// check in [`DhtNetworkManager::ping_with_identity_confirmation`]
+/// makes that especially harmful: even if the wire ping somehow
+/// succeeded, `is_known_app_peer_id` would still be `false` until
+/// identity exchange completed.
+///
+/// `wait_for_peer_identity` short-circuits on transport-level channel
+/// close, so genuinely-broken peers (the case that motivated the
+/// strict check) usually surface their failure in microseconds and
+/// don't pay the full 6 s. The budget is the worst-case ceiling, not
+/// the typical path.
+const STALE_REVALIDATION_PING_RTT: Duration = Duration::from_secs(1);
+const STALE_REVALIDATION_BUDGET: Duration = Duration::from_secs(
+    IDENTITY_EXCHANGE_TIMEOUT.as_secs() + STALE_REVALIDATION_PING_RTT.as_secs(),
+);
 
 /// Buffer size for the broadcast channel that
 /// [`DhtNetworkManager::ensure_peer_channel`] uses to fan a single
@@ -3287,17 +3319,14 @@ impl DhtNetworkManager {
 
         // --- Ping stale peers concurrently with DHT write lock released ---
         // Process in chunks to bound concurrent pings while still parallelising
-        // within each chunk (total wall time: chunks * STALE_REVALIDATION_TIMEOUT
-        // instead of stale_peers.len() * STALE_REVALIDATION_TIMEOUT).
+        // within each chunk (worst-case wall time: chunks * STALE_REVALIDATION_BUDGET
+        // instead of stale_peers.len() * STALE_REVALIDATION_BUDGET).
         let mut evicted_peers = Vec::new();
         let mut retained_peers = Vec::new();
 
         for chunk in stale_peers.chunks(MAX_CONCURRENT_REVALIDATION_PINGS) {
             let results = futures::future::join_all(chunk.iter().map(|(peer_id, _)| async {
-                let responded =
-                    tokio::time::timeout(STALE_REVALIDATION_TIMEOUT, self.ping_peer(peer_id))
-                        .await
-                        .is_ok_and(|r| r.is_ok());
+                let responded = self.ping_with_identity_confirmation(peer_id).await;
                 (*peer_id, responded)
             }))
             .await;
@@ -3351,6 +3380,42 @@ impl DhtNetworkManager {
             .context("ping failed")
     }
 
+    /// Liveness probe used by the stale-peer eviction paths.
+    ///
+    /// A peer counts as alive only when **both** conditions hold:
+    /// 1. [`Self::ping_peer`] completes successfully within
+    ///    [`STALE_REVALIDATION_BUDGET`]. The budget covers a fresh
+    ///    identity exchange ([`IDENTITY_EXCHANGE_TIMEOUT`]) plus the
+    ///    ping round-trip on the resulting channel — see the constant's
+    ///    docs for the breakdown. A stale peer's transport channel is
+    ///    routinely gone (NAT rebind, idle timeout) by the time we
+    ///    revalidate, and a 1 s budget would cancel the dial mid-handshake
+    ///    and false-evict an otherwise-healthy peer.
+    /// 2. The peer is in the authenticated app-level set
+    ///    ([`TransportHandle::is_known_app_peer_id`]) at the moment of the
+    ///    check.
+    ///
+    /// Condition (1) catches dead-on-the-wire peers (no QUIC reachability,
+    /// or no DHT response). Condition (2) is the load-bearing identity
+    /// gate: it rejects peers that respond at the transport layer but
+    /// have never completed (or have lost) the saorsa-core identity
+    /// exchange — the exact failure mode of older-protocol nodes whose
+    /// QUIC handshake succeeds but whose identity exchange always times
+    /// out. Without (2), such peers could be retained because some
+    /// other path opened a half-authenticated transport channel.
+    ///
+    /// Used by [`Self::revalidate_and_retry_admission`] and
+    /// [`Self::revalidate_stale_k_closest`] in place of a bare
+    /// `ping_peer().is_ok()` so the routing-table invariant ("every
+    /// retained peer is currently identity-confirmed") is enforced
+    /// exactly where eviction decisions are made.
+    async fn ping_with_identity_confirmation(&self, peer_id: &PeerId) -> bool {
+        let ping_ok = tokio::time::timeout(STALE_REVALIDATION_BUDGET, self.ping_peer(peer_id))
+            .await
+            .is_ok_and(|r| r.is_ok());
+        ping_ok && self.transport.is_known_app_peer_id(peer_id).await
+    }
+
     /// Revalidate stale K-closest peers by pinging them and evicting non-responders.
     ///
     /// Piggybacked on the periodic self-lookup to avoid a dedicated background
@@ -3374,10 +3439,7 @@ impl DhtNetworkManager {
 
         for chunk in stale_peers.chunks(MAX_CONCURRENT_REVALIDATION_PINGS) {
             let results = futures::future::join_all(chunk.iter().map(|peer_id| async {
-                let responded =
-                    tokio::time::timeout(STALE_REVALIDATION_TIMEOUT, self.ping_peer(peer_id))
-                        .await
-                        .is_ok_and(|r| r.is_ok());
+                let responded = self.ping_with_identity_confirmation(peer_id).await;
                 (*peer_id, responded)
             }))
             .await;
@@ -3480,10 +3542,20 @@ impl DhtNetworkManager {
     /// fan-out — without gossip ingestion it stayed starved of `Direct`
     /// addresses and failed relay acquisition with "no direct-addressable
     /// candidates in routing table" despite having 17 peers in its RT.
+    ///
+    /// Crucially, this path does NOT refresh `last_seen` for the subject
+    /// peer: we ingest *address* information from gossip, but liveness
+    /// claims from a third party are not evidence the subject is alive
+    /// from our point of view. Letting gossip refresh `last_seen` would
+    /// indefinitely defer
+    /// [`crate::dht::core_engine::DhtCoreEngine::stale_k_closest`]
+    /// eviction for peers we cannot authenticate with (e.g., old-protocol
+    /// nodes whose identity exchange always times out) as long as some
+    /// authenticated neighbour keeps mentioning them.
     pub async fn merge_gossiped_typed_addresses(&self, node: &DHTNode) {
         let dht = self.dht.read().await;
         for (addr, ty) in node.typed_addresses() {
-            dht.touch_node_typed_upgrade_only(&node.peer_id, Some(&addr), ty)
+            dht.merge_typed_address_upgrade_only(&node.peer_id, Some(&addr), ty)
                 .await;
         }
     }

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -114,9 +114,14 @@ const IDENTITY_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(5);
 /// don't pay the full 6 s. The budget is the worst-case ceiling, not
 /// the typical path.
 const STALE_REVALIDATION_PING_RTT: Duration = Duration::from_secs(1);
-const STALE_REVALIDATION_BUDGET: Duration = Duration::from_secs(
-    IDENTITY_EXCHANGE_TIMEOUT.as_secs() + STALE_REVALIDATION_PING_RTT.as_secs(),
-);
+// Use `saturating_add` rather than re-deriving from `as_secs()`: the latter
+// truncates any sub-second component, so a future tweak that adds millis or
+// nanos to either input would silently shrink the budget below the documented
+// "identity exchange + ping RTT" invariant. `saturating_add` is `const fn`,
+// preserves every nanosecond, and only saturates at `Duration::MAX` (~584 Gyr)
+// — well outside any realistic input range here.
+const STALE_REVALIDATION_BUDGET: Duration =
+    IDENTITY_EXCHANGE_TIMEOUT.saturating_add(STALE_REVALIDATION_PING_RTT);
 
 /// Buffer size for the broadcast channel that
 /// [`DhtNetworkManager::ensure_peer_channel`] uses to fan a single

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -3413,24 +3413,10 @@ impl DhtNetworkManager {
         let ping_ok = tokio::time::timeout(STALE_REVALIDATION_BUDGET, self.ping_peer(peer_id))
             .await
             .is_ok_and(|r| r.is_ok());
-        let identity_ok = self.transport.is_known_app_peer_id(peer_id).await;
-        Self::is_revalidation_alive(ping_ok, identity_ok)
-    }
-
-    /// Combine the two stale-peer revalidation signals.
-    ///
-    /// A peer counts as alive only when **both** `ping_ok` (wire-level
-    /// reachability proven by a successful ping within
-    /// [`STALE_REVALIDATION_BUDGET`]) and `identity_ok` (membership in
-    /// the authenticated app-level peer set per
-    /// [`crate::transport_handle::TransportHandle::is_known_app_peer_id`])
-    /// hold. Either condition failing causes eviction.
-    ///
-    /// Extracted as a pure const fn so the AND invariant is unit-testable
-    /// without spinning up a transport — see the truth-table tests in
-    /// this module's `#[cfg(test)] mod tests` block.
-    const fn is_revalidation_alive(ping_ok: bool, identity_ok: bool) -> bool {
-        ping_ok && identity_ok
+        if !ping_ok {
+            return false;
+        }
+        self.transport.is_known_app_peer_id(peer_id).await
     }
 
     /// Revalidate stale K-closest peers by pinging them and evicting non-responders.
@@ -3800,48 +3786,6 @@ mod tests {
     fn is_dialable_accepts_quic_with_routable_ip() {
         let quic = MultiAddr::quic("203.0.113.7:9000".parse().unwrap());
         assert!(DhtNetworkManager::is_dialable(&quic));
-    }
-
-    // -----------------------------------------------------------------------
-    // Stale-peer revalidation invariants
-    //
-    // `ping_with_identity_confirmation` is the routing-table eviction gate.
-    // The full path requires a real transport (constructing a
-    // `DhtNetworkManager` is non-trivial in a sync test), but the load-bearing
-    // *logic* — the AND combinator and the budget arithmetic — is extracted
-    // so refactoring regressions surface here, fast and deterministically.
-    //
-    // Invariants locked in:
-    //   - AND, not OR: failing either signal causes eviction.
-    //   - Budget covers a full identity exchange + ping RTT, so cold-channel
-    //     revalidation does not false-evict healthy peers.
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn revalidation_alive_only_when_both_signals_pass() {
-        assert!(DhtNetworkManager::is_revalidation_alive(true, true));
-    }
-
-    #[test]
-    fn revalidation_dead_when_ping_fails_even_with_identity() {
-        // A peer that is in the authenticated set but does not answer
-        // pings within the budget is dead-on-the-wire and must be evicted.
-        assert!(!DhtNetworkManager::is_revalidation_alive(false, true));
-    }
-
-    #[test]
-    fn revalidation_dead_when_identity_missing_even_with_ping() {
-        // The load-bearing case from the bug fix: a peer that responds at
-        // the transport layer but is not in the authenticated app-level
-        // set (e.g. older-protocol nodes whose identity exchange always
-        // times out) must be evicted regardless of ping success. Catches
-        // any refactor that drops the identity check or weakens AND to OR.
-        assert!(!DhtNetworkManager::is_revalidation_alive(true, false));
-    }
-
-    #[test]
-    fn revalidation_dead_when_both_signals_fail() {
-        assert!(!DhtNetworkManager::is_revalidation_alive(false, false));
     }
 
     #[test]

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -3413,7 +3413,24 @@ impl DhtNetworkManager {
         let ping_ok = tokio::time::timeout(STALE_REVALIDATION_BUDGET, self.ping_peer(peer_id))
             .await
             .is_ok_and(|r| r.is_ok());
-        ping_ok && self.transport.is_known_app_peer_id(peer_id).await
+        let identity_ok = self.transport.is_known_app_peer_id(peer_id).await;
+        Self::is_revalidation_alive(ping_ok, identity_ok)
+    }
+
+    /// Combine the two stale-peer revalidation signals.
+    ///
+    /// A peer counts as alive only when **both** `ping_ok` (wire-level
+    /// reachability proven by a successful ping within
+    /// [`STALE_REVALIDATION_BUDGET`]) and `identity_ok` (membership in
+    /// the authenticated app-level peer set per
+    /// [`crate::transport_handle::TransportHandle::is_known_app_peer_id`])
+    /// hold. Either condition failing causes eviction.
+    ///
+    /// Extracted as a pure const fn so the AND invariant is unit-testable
+    /// without spinning up a transport — see the truth-table tests in
+    /// this module's `#[cfg(test)] mod tests` block.
+    const fn is_revalidation_alive(ping_ok: bool, identity_ok: bool) -> bool {
+        ping_ok && identity_ok
     }
 
     /// Revalidate stale K-closest peers by pinging them and evicting non-responders.
@@ -3783,6 +3800,62 @@ mod tests {
     fn is_dialable_accepts_quic_with_routable_ip() {
         let quic = MultiAddr::quic("203.0.113.7:9000".parse().unwrap());
         assert!(DhtNetworkManager::is_dialable(&quic));
+    }
+
+    // -----------------------------------------------------------------------
+    // Stale-peer revalidation invariants
+    //
+    // `ping_with_identity_confirmation` is the routing-table eviction gate.
+    // The full path requires a real transport (constructing a
+    // `DhtNetworkManager` is non-trivial in a sync test), but the load-bearing
+    // *logic* — the AND combinator and the budget arithmetic — is extracted
+    // so refactoring regressions surface here, fast and deterministically.
+    //
+    // Invariants locked in:
+    //   - AND, not OR: failing either signal causes eviction.
+    //   - Budget covers a full identity exchange + ping RTT, so cold-channel
+    //     revalidation does not false-evict healthy peers.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn revalidation_alive_only_when_both_signals_pass() {
+        assert!(DhtNetworkManager::is_revalidation_alive(true, true));
+    }
+
+    #[test]
+    fn revalidation_dead_when_ping_fails_even_with_identity() {
+        // A peer that is in the authenticated set but does not answer
+        // pings within the budget is dead-on-the-wire and must be evicted.
+        assert!(!DhtNetworkManager::is_revalidation_alive(false, true));
+    }
+
+    #[test]
+    fn revalidation_dead_when_identity_missing_even_with_ping() {
+        // The load-bearing case from the bug fix: a peer that responds at
+        // the transport layer but is not in the authenticated app-level
+        // set (e.g. older-protocol nodes whose identity exchange always
+        // times out) must be evicted regardless of ping success. Catches
+        // any refactor that drops the identity check or weakens AND to OR.
+        assert!(!DhtNetworkManager::is_revalidation_alive(true, false));
+    }
+
+    #[test]
+    fn revalidation_dead_when_both_signals_fail() {
+        assert!(!DhtNetworkManager::is_revalidation_alive(false, false));
+    }
+
+    #[test]
+    fn stale_revalidation_budget_covers_identity_exchange_plus_ping_rtt() {
+        // Cold-channel revalidation must survive a fresh identity exchange
+        // (≤ IDENTITY_EXCHANGE_TIMEOUT) followed by a ping round-trip on
+        // the resulting authenticated channel. Capping below this is the
+        // exact regression the constant was introduced to close — guard
+        // the arithmetic so a future tweak to either input is mirrored
+        // here intentionally.
+        assert_eq!(
+            STALE_REVALIDATION_BUDGET,
+            IDENTITY_EXCHANGE_TIMEOUT + STALE_REVALIDATION_PING_RTT,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a routing-table eviction gap where peers whose identity exchange
always times out (e.g. older-protocol nodes accepting QUIC but never
returning a valid identity announce) were never evicted. Close-group
lookups kept paying the 5 s identity timeout against the same dead
peers across many requests.

Two leaks let unauthenticated information refresh routing-table
liveness signals:

- **Gossip ingestion** (`merge_gossiped_typed_addresses` → the
  upgrade-only bucket touch) refreshed both the per-peer `last_seen`
  and the bucket's `last_refreshed`, and reordered the bucket to
  MRU. Gossip from peer A about peer B is not evidence we have
  authenticated with B, nor that we have done genuine discovery in
  B's bucket; bumping these signals indefinitely deferred
  `stale_k_closest` peer eviction and the periodic bucket-refresh
  FIND_NODE.
- **Stale-peer revalidation** treated any successful ping as proof
  of life, even when no fresh identity exchange had happened. The
  1 s timeout would also have cancelled a fresh handshake mid-flight
  on the cold-channel path.

### Changes

- `KBucket::touch_node_typed_upgrade_only` →
  `KBucket::merge_typed_address_upgrade_only` (with mirroring rename
  through `KademliaRoutingTable` and `DhtCoreEngine`). Now a pure
  address-set merge: no `last_seen` bump, no MRU reorder, no
  `last_refreshed` bump. Doc-comments on every layer spell out why
  each is intentionally omitted.
- New `DhtNetworkManager::ping_with_identity_confirmation`. A stale
  peer is retained only when **both** the ping round-trips and
  `is_known_app_peer_id` is true at the moment of the check. Both
  revalidation sites (`revalidate_and_retry_admission`,
  `revalidate_stale_k_closest`) use this helper.
- `STALE_REVALIDATION_TIMEOUT` (1 s) → `STALE_REVALIDATION_BUDGET`
  (6 s = `IDENTITY_EXCHANGE_TIMEOUT` + 1 s ping RTT). Closes a
  pre-existing false-eviction window for healthy peers whose
  channel was gone (NAT rebind, idle timeout) and needed up to 5 s
  for a fresh handshake. Worst-case admission-contention
  revalidation goes from `chunks × 1 s` to `chunks × 6 s`;
  `wait_for_peer_identity` short-circuits on transport-level
  channel close so genuinely-broken peers usually surface in
  microseconds.

### Effect

Bad peers age out of the routing table within
`LIVE_THRESHOLD + SELF_LOOKUP_INTERVAL_MAX` (~15–25 minutes after
the last successful identity exchange) instead of indefinitely.

This does not help inside a single short session — for that you
would need a short-TTL identity-failure deny-list consulted by
`find_closest_nodes`. Worth a follow-up if needed.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` — 368 passed (was 367; +1 new test)
- [x] Five new unit tests on `KBucket::merge_typed_address_upgrade_only`:
  - [x] `gossip_merge_does_not_bump_last_seen`
  - [x] `gossip_merge_does_not_reorder_bucket`
  - [x] `gossip_merge_does_not_bump_last_refreshed`
  - [x] `gossip_merge_adds_new_address`
  - [x] `gossip_merge_returns_false_for_missing_peer`
- [ ] Soak test against the live network: download a file, observe
  whether bad peers (older-protocol nodes failing identity exchange)
  are still being retried 5+ times per close-group lookup. Expected
  improvement is across-session — within a single session bad peers
  remain in the close group until 15–25 min elapses without
  authenticated activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a routing-table liveness leak where unauthenticated gossip activity (`merge_gossiped_typed_addresses`) and overly permissive ping-only revalidation kept peers with failing identity exchanges perpetually "fresh", preventing `stale_k_closest` eviction. The fix has two parts: stripping all liveness side-effects from gossip ingestion (now a pure address-set merge) and gating stale-peer retention on `is_known_app_peer_id` with a correctly-sized 6 s budget that covers a cold-channel identity exchange.

<h3>Confidence Score: 4/5</h3>

Safe to merge; logic is correct and well-tested with only a minor async short-circuit inefficiency remaining.

No P0 or P1 issues found. The single P2 finding (unconditional `is_known_app_peer_id` call when `ping_ok` is already false) is a performance micro-optimisation with no effect on correctness. All four truth-table cases are covered by the new unit tests, and the six `KBucket` gossip-merge tests pin the three liveness-non-refresh invariants robustly.

src/dht_network_manager.rs — `ping_with_identity_confirmation` short-circuit (P2 only)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dht/core_engine.rs | Renames `touch_node_typed_upgrade_only` → `merge_typed_address_upgrade_only` and strips the three liveness side-effects (last_seen bump, MRU reorder, last_refreshed bump) from gossip ingestion; adds 6 well-targeted unit tests covering the invariants. |
| src/dht_network_manager.rs | Introduces `ping_with_identity_confirmation`, widens `STALE_REVALIDATION_TIMEOUT` to `STALE_REVALIDATION_BUDGET` (6 s), and applies the new probe to both eviction sites; minor inefficiency: `is_known_app_peer_id` is awaited unconditionally even when the ping already failed. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GI as Gossip Ingestion<br/>(merge_gossiped_typed_addresses)
    participant RT as KademliaRoutingTable
    participant KB as KBucket
    participant RV as Revalidation<br/>(ping_with_identity_confirmation)
    participant TP as Transport<br/>(is_known_app_peer_id)

    Note over GI,KB: Gossip path — address-set merge only
    GI->>RT: merge_typed_address_upgrade_only(peer, addr, type)
    RT->>KB: merge_typed_address_upgrade_only(peer, addr, type)
    KB-->>RT: true/false (state changed?)
    Note over KB: ✗ last_seen NOT bumped<br/>✗ MRU reorder NOT done<br/>✗ last_refreshed NOT bumped

    Note over RV,TP: Stale-peer eviction path (both revalidation sites)
    RV->>RV: timeout(6s, ping_peer(peer))
    alt ping succeeds within budget
        RV->>TP: is_known_app_peer_id(peer)
        TP-->>RV: true / false
        RV-->>RT: retain if both true (AND gate)
    else ping times out / fails
        RV-->>RT: evict peer
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/dht_network_manager.rs
Line: 3412-3418

Comment:
**Unnecessary async call when ping already failed**

`is_known_app_peer_id` is awaited unconditionally, even when `ping_ok` is `false` — at which point `is_revalidation_alive` will return `false` regardless. For peers that are dead-on-the-wire (the common revalidation case), this adds an extra async round-trip to the transport layer on every eviction decision. An explicit short-circuit avoids the redundant call:

```suggestion
    async fn ping_with_identity_confirmation(&self, peer_id: &PeerId) -> bool {
        let ping_ok = tokio::time::timeout(STALE_REVALIDATION_BUDGET, self.ping_peer(peer_id))
            .await
            .is_ok_and(|r| r.is_ok());
        if !ping_ok {
            return false;
        }
        self.transport.is_known_app_peer_id(peer_id).await
    }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(dht): tighten gossip-merge tests an..."](https://github.com/saorsa-labs/saorsa-core/commit/6918c7a4fc2cad6ab31eac4b512f217a0360474f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29838616)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->