### PR TITLE
perf(dht): tighten Kademlia lookup limits to fail faster

### DIFF
--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -1421,7 +1421,7 @@ impl DhtNetworkManager {
         key: &Key,
         count: usize,
     ) -> Result<Vec<DHTNode>> {
-        const MAX_ITERATIONS: usize = 20;
+        const MAX_ITERATIONS: usize = 10;
         const ALPHA: usize = 3; // Parallel queries per iteration
 
         debug!(
@@ -3681,11 +3681,11 @@ const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 15;
 /// proceed. Once the first response is in, we have new candidates for the
 /// next iteration and can safely cap the wait on the stragglers.
 ///
-/// Sized at 5s: a peer with an already-open channel replies in well under
+/// Sized at 2s: a peer with an already-open channel replies in well under
 /// a second, so this leaves ample slack for legitimate stragglers while
 /// letting us abandon dial cascades that are almost certainly going to
 /// fail anyway.
-const ITERATION_GRACE_TIMEOUT_SECS: u64 = 5;
+const ITERATION_GRACE_TIMEOUT_SECS: u64 = 2;
 
 /// Default maximum concurrent DHT operations
 const DEFAULT_MAX_CONCURRENT_OPS: usize = 100;

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -1421,7 +1421,7 @@ impl DhtNetworkManager {
         key: &Key,
         count: usize,
     ) -> Result<Vec<DHTNode>> {
-        const MAX_ITERATIONS: usize = 10;
+        const MAX_ITERATIONS: usize = 12;
         const ALPHA: usize = 3; // Parallel queries per iteration
 
         debug!(


### PR DESCRIPTION
## Summary
- Reduce `MAX_ITERATIONS` in `find_closest_nodes_network` from 20 → 12.
- Reduce `ITERATION_GRACE_TIMEOUT_SECS` from 5 → 2 (and update the doc comment).

Both knobs gate how long a single Kademlia lookup can keep waiting on
slow/dead peers. Tighter caps let us abandon stalled dial cascades sooner
while still benefiting from the α=3 parallel fan-out per iteration. 12
keeps a little more headroom than the original 10 in this PR for
pathological cases where stagnation never fires, while still well under
the previous 20.

## Test plan
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --lib`
- [ ] Smoke test against bootstrap nodes (`saorsa-2`, `saorsa-3`) to confirm lookups still converge under realistic NAT/relay conditions, including cold-start cases (flushed connection pools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)