### PR TITLE
perf(dht): tighten bootstrap identity timeout, dedupe reconnect budget, client-mode early-exit

### DIFF
--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -64,16 +64,19 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const SELF_RELIABILITY_SCORE: f64 = 1.0;
 
 /// Maximum time to wait for the identity-exchange handshake after dialling
-/// a peer. The actual timeout is `min(request_timeout, this)`.
+/// a known peer. The actual timeout is `min(request_timeout, this)`.
 ///
 /// Identity exchange is two RTTs over a freshly-handshaken QUIC connection
 /// plus an ML-DSA-65 signature verification. Covers a reasonable range of
 /// loopback and WAN links — LAN completes in <1 s, a congested
-/// cross-region link fits in the 5 s budget with retransmits. Kept in
-/// lockstep with `BOOTSTRAP_IDENTITY_TIMEOUT_SECS` in `network.rs` — both
-/// budgets exist to absorb the same slow-link failure mode (the bootstrap
-/// variant covers the initial join, this one covers every subsequent peer
-/// dial via `send_dht_request`).
+/// cross-region link fits in the 5 s budget with retransmits.
+///
+/// Used for every post-bootstrap dial: `send_dht_request` against a peer
+/// the routing table already knows about, and the reconnect-on-send path
+/// in `network.rs::wait_for_peer_identity`. Bootstrap dials use a tighter
+/// budget (`BOOTSTRAP_IDENTITY_TIMEOUT_SECS`) on the assumption that the
+/// peer is unverified and should not be allowed to head-of-line block
+/// convergence.
 ///
 /// Tightened from 15 s to 5 s: the old budget let dead channels hold
 /// up bootstrap convergence for 15 s each. On a devnet with serialised
@@ -81,7 +84,7 @@ const SELF_RELIABILITY_SCORE: f64 = 1.0;
 /// `wait_for_peer_identity` additionally short-circuits on channel
 /// close so most failures surface in microseconds regardless of the
 /// timeout.
-const IDENTITY_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const IDENTITY_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Maximum time to wait for a stale peer's ping response during admission contention.
 const STALE_REVALIDATION_TIMEOUT: Duration = Duration::from_secs(1);

--- a/src/network.rs
+++ b/src/network.rs
@@ -21,7 +21,9 @@ use crate::adaptive::trust::{TrustRecord, TrustSnapshot};
 use crate::adaptive::{AdaptiveDHT, AdaptiveDhtConfig, TrustEngine, TrustEvent};
 use crate::bootstrap::cache::{CachedCloseGroupPeer, CloseGroupCache};
 use crate::bootstrap::{BootstrapConfig, BootstrapManager};
-use crate::dht_network_manager::{DhtNetworkConfig, DhtNetworkEvent, DhtNetworkManager};
+use crate::dht_network_manager::{
+    DhtNetworkConfig, DhtNetworkEvent, DhtNetworkManager, IDENTITY_EXCHANGE_TIMEOUT,
+};
 use crate::error::{IdentityError, NetworkError, P2PError, P2pResult as Result};
 use crate::reachability::spawn_acquisition_driver;
 
@@ -138,17 +140,18 @@ const BOOTSTRAP_PEER_BATCH_SIZE: usize = 20;
 
 /// Timeout in seconds for waiting on a bootstrap peer's identity exchange.
 ///
-/// Identity exchange is two RTTs over a freshly-handshaken QUIC connection
-/// plus an ML-DSA-65 signature verification. 5 s covers loopback (<100 ms
-/// in practice) and reasonable WAN paths (~2 s with one handshake retry),
-/// while keeping dead-channel detection fast enough that bootstrap
-/// convergence does not serialise on a single stuck peer. Kept in lockstep
-/// with `IDENTITY_EXCHANGE_TIMEOUT` in `dht_network_manager.rs`, which
-/// covers the same exchange for every subsequent dial.
+/// Tighter than the post-bootstrap budget (`IDENTITY_EXCHANGE_TIMEOUT`,
+/// 5 s) on purpose: bootstrap candidates are unverified and a stuck one
+/// must not be allowed to head-of-line block convergence. 3 s covers
+/// loopback (<100 ms) and direct WAN paths (~1–2 s with one handshake
+/// retry); a relay-tunnelled path with congested ML-DSA verification
+/// can exceed this and will fail identity exchange, but the bootstrap
+/// manager simply moves on to other candidates rather than retrying the
+/// same one.
 ///
 /// `wait_for_peer_identity` short-circuits on channel close, so most dead
 /// channels surface in microseconds regardless of this budget.
-const BOOTSTRAP_IDENTITY_TIMEOUT_SECS: u64 = 10;
+const BOOTSTRAP_IDENTITY_TIMEOUT_SECS: u64 = 3;
 
 /// Maximum number of bootstrap peers dialed concurrently in Phase B.
 ///
@@ -735,9 +738,6 @@ pub(crate) struct PendingRequest {
     /// The peer we expect the response from (for origin validation).
     pub(crate) expected_peer: PeerId,
 }
-
-/// Maximum time to wait for identity exchange during a reconnect-on-send dial.
-const RECONNECT_IDENTITY_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Short grace period after closing stale QUIC connections before re-dialing.
 ///
@@ -1580,7 +1580,7 @@ impl P2PNode {
         let channel_id = self.transport.connect_peer(&address).await?;
         let authenticated = match self
             .transport
-            .wait_for_peer_identity(&channel_id, RECONNECT_IDENTITY_TIMEOUT)
+            .wait_for_peer_identity(&channel_id, IDENTITY_EXCHANGE_TIMEOUT)
             .await
         {
             Ok(peer) => peer,

--- a/src/network.rs
+++ b/src/network.rs
@@ -161,6 +161,16 @@ const BOOTSTRAP_IDENTITY_TIMEOUT_SECS: u64 = 3;
 /// verification, and a cold-start node has no spare compute budget.
 const MAX_CONCURRENT_BOOTSTRAP_DIALS: usize = 4;
 
+/// Number of successful bootstrap connections after which a client-mode
+/// node stops dialing further candidates.
+///
+/// Clients only need enough peers to route their own lookups (α=3 parallel
+/// queries → 6 gives ~2× redundancy) and don't serve the DHT, so a fully
+/// populated close-group buys them nothing. Stopping early cuts cold-start
+/// latency by skipping the tail of slow / dead candidates. Nodes always
+/// dial every candidate so their routing table converges fully.
+const CLIENT_BOOTSTRAP_TARGET: usize = 6;
+
 /// Serde helper — returns `true`.
 const fn default_true() -> bool {
     true
@@ -2078,6 +2088,7 @@ impl P2PNode {
         let mut connected_peer_ids: Vec<PeerId> = Vec::new();
 
         // Phase A: serial close-group dials to preserve trust-priority ordering.
+        let client_mode = matches!(self.config.mode, NodeMode::Client);
         for addrs in &serial_addr_sets {
             if let Some(peer_id) = self
                 .dial_bootstrap_addr_set(addrs, used_cache, identity_timeout)
@@ -2085,23 +2096,41 @@ impl P2PNode {
             {
                 successful_connections += 1;
                 connected_peer_ids.push(peer_id);
+                if client_mode && successful_connections >= CLIENT_BOOTSTRAP_TARGET {
+                    debug!(
+                        "Client bootstrap target reached ({successful_connections} peers) — skipping remaining serial dials"
+                    );
+                    break;
+                }
             }
         }
 
         // Phase B: concurrent dials of CLI + cached bootstrap peers, bounded
         // by `MAX_CONCURRENT_BOOTSTRAP_DIALS` to cap simultaneous QUIC+PQC
-        // handshakes.
-        let mut parallel_stream =
-            futures::stream::iter(parallel_addr_sets.into_iter().map(|addrs| async move {
-                self.dial_bootstrap_addr_set(&addrs, used_cache, identity_timeout)
-                    .await
-            }))
-            .buffer_unordered(MAX_CONCURRENT_BOOTSTRAP_DIALS);
-        while let Some(result) = parallel_stream.next().await {
-            if let Some(peer_id) = result {
-                successful_connections += 1;
-                connected_peer_ids.push(peer_id);
+        // handshakes. Skipped entirely when a client has already hit its
+        // target during Phase A.
+        if !client_mode || successful_connections < CLIENT_BOOTSTRAP_TARGET {
+            let mut parallel_stream =
+                futures::stream::iter(parallel_addr_sets.into_iter().map(|addrs| async move {
+                    self.dial_bootstrap_addr_set(&addrs, used_cache, identity_timeout)
+                        .await
+                }))
+                .buffer_unordered(MAX_CONCURRENT_BOOTSTRAP_DIALS);
+            while let Some(result) = parallel_stream.next().await {
+                if let Some(peer_id) = result {
+                    successful_connections += 1;
+                    connected_peer_ids.push(peer_id);
+                    if client_mode && successful_connections >= CLIENT_BOOTSTRAP_TARGET {
+                        debug!(
+                            "Client bootstrap target reached ({successful_connections} peers) — cancelling pending dials"
+                        );
+                        break;
+                    }
+                }
             }
+            // `parallel_stream` is dropped here when the `if` block exits,
+            // cancelling any in-flight futures inside `buffer_unordered`
+            // before we proceed to the DHT discovery phase below.
         }
 
         if successful_connections == 0 {


### PR DESCRIPTION
## Summary
Three related bootstrap-convergence tweaks:

1. **Bootstrap identity-exchange budget tightened from 10 s → 3 s.** Bootstrap candidates are unverified, so a stuck one must not head-of-line block convergence. `wait_for_peer_identity` already short-circuits on channel close, so dead channels still surface in microseconds — the timeout only governs the genuine slow-link case, where 3 s is enough for loopback (<100 ms) and direct WAN paths (~1–2 s).
2. **Reconnect-on-send path now reuses `IDENTITY_EXCHANGE_TIMEOUT` (5 s).** The duplicate `RECONNECT_IDENTITY_TIMEOUT` (10 s) constant was a leftover; consolidating onto `IDENTITY_EXCHANGE_TIMEOUT` keeps the two semantically equivalent paths in sync going forward.
3. **Client-mode bootstrap stops at 6 successful peers.** Clients only need enough peers to route their own α-parallel lookups (α=3, so 6 gives ~2× redundancy) and don't serve the DHT, so a fully populated close-group buys them nothing. Phase A (serial close-group) breaks early when the threshold is hit; Phase B (concurrent CLI + cached) is skipped entirely if Phase A already met it, otherwise breaks on first qualifying success and the buffered stream drops at end-of-block so in-flight futures are cancelled before DHT discovery starts. Nodes (`NodeMode::Node`) keep current behaviour — dial every candidate so the routing table converges fully.

Doc comments updated to reflect that the bootstrap and post-bootstrap budgets are intentionally different (bootstrap = unverified/tight, post-bootstrap = known-good/generous), not "in lockstep" as previously documented.

## Why
On a devnet with serialised bootstrap dials, the old 10 s bootstrap budget could stall convergence behind a single dead channel. Combined with the client-mode early-exit, this sits alongside existing client-mode shortcuts (skip relay-acquisition driver, skip post-bootstrap self-lookups) to make client cold-start meaningfully faster when some bootstrap candidates are slow or dead.

Tradeoff for the early-exit: clients get less peer diversity and feed fewer outcomes into the bootstrap cache (the cancelled dials don't report success/failure). Acceptable for clients; would be wrong for nodes.

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --lib bootstrap` — 18 / 18 passing
- [ ] Devnet smoke: bootstrap convergence with one stuck candidate
- [ ] Devnet smoke: client cold-start latency vs. node cold-start latency, confirm client converges visibly faster when some bootstrap candidates are dead

🤖 Generated with [Claude Code](https://claude.com/claude-code)