### PR TITLE
perf(network): client-mode bootstrap stops at 6 successful peers

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -158,6 +158,16 @@ const BOOTSTRAP_IDENTITY_TIMEOUT_SECS: u64 = 10;
 /// verification, and a cold-start node has no spare compute budget.
 const MAX_CONCURRENT_BOOTSTRAP_DIALS: usize = 4;
 
+/// Number of successful bootstrap connections after which a client-mode
+/// node stops dialing further candidates.
+///
+/// Clients only need enough peers to route their own lookups (α=3 parallel
+/// queries → 6 gives ~2× redundancy) and don't serve the DHT, so a fully
+/// populated close-group buys them nothing. Stopping early cuts cold-start
+/// latency by skipping the tail of slow / dead candidates. Nodes always
+/// dial every candidate so their routing table converges fully.
+const CLIENT_BOOTSTRAP_TARGET: usize = 6;
+
 /// Serde helper — returns `true`.
 const fn default_true() -> bool {
     true
@@ -2078,6 +2088,7 @@ impl P2PNode {
         let mut connected_peer_ids: Vec<PeerId> = Vec::new();
 
         // Phase A: serial close-group dials to preserve trust-priority ordering.
+        let client_mode = matches!(self.config.mode, NodeMode::Client);
         for addrs in &serial_addr_sets {
             if let Some(peer_id) = self
                 .dial_bootstrap_addr_set(addrs, used_cache, identity_timeout)
@@ -2085,23 +2096,41 @@ impl P2PNode {
             {
                 successful_connections += 1;
                 connected_peer_ids.push(peer_id);
+                if client_mode && successful_connections >= CLIENT_BOOTSTRAP_TARGET {
+                    debug!(
+                        "Client bootstrap target reached ({successful_connections} peers) — skipping remaining serial dials"
+                    );
+                    break;
+                }
             }
         }
 
         // Phase B: concurrent dials of CLI + cached bootstrap peers, bounded
         // by `MAX_CONCURRENT_BOOTSTRAP_DIALS` to cap simultaneous QUIC+PQC
-        // handshakes.
-        let mut parallel_stream =
-            futures::stream::iter(parallel_addr_sets.into_iter().map(|addrs| async move {
-                self.dial_bootstrap_addr_set(&addrs, used_cache, identity_timeout)
-                    .await
-            }))
-            .buffer_unordered(MAX_CONCURRENT_BOOTSTRAP_DIALS);
-        while let Some(result) = parallel_stream.next().await {
-            if let Some(peer_id) = result {
-                successful_connections += 1;
-                connected_peer_ids.push(peer_id);
+        // handshakes. Skipped entirely when a client has already hit its
+        // target during Phase A.
+        if !client_mode || successful_connections < CLIENT_BOOTSTRAP_TARGET {
+            let mut parallel_stream =
+                futures::stream::iter(parallel_addr_sets.into_iter().map(|addrs| async move {
+                    self.dial_bootstrap_addr_set(&addrs, used_cache, identity_timeout)
+                        .await
+                }))
+                .buffer_unordered(MAX_CONCURRENT_BOOTSTRAP_DIALS);
+            while let Some(result) = parallel_stream.next().await {
+                if let Some(peer_id) = result {
+                    successful_connections += 1;
+                    connected_peer_ids.push(peer_id);
+                    if client_mode && successful_connections >= CLIENT_BOOTSTRAP_TARGET {
+                        debug!(
+                            "Client bootstrap target reached ({successful_connections} peers) — cancelling pending dials"
+                        );
+                        break;
+                    }
+                }
             }
+            // `parallel_stream` is dropped here when the `if` block exits,
+            // cancelling any in-flight futures inside `buffer_unordered`
+            // before we proceed to the DHT discovery phase below.
         }
 
         if successful_connections == 0 {


### PR DESCRIPTION
## Summary
- Client-mode (`NodeMode::Client`) bootstrap now stops dialing once it has 6 successful identity-confirmed connections, instead of draining every candidate
- Phase A (serial close-group dials) breaks out of the loop when the threshold is hit
- Phase B (concurrent CLI + cached dials) is skipped entirely if Phase A already met the threshold; otherwise breaks out of the buffered stream on first success that reaches it. The stream drops at end-of-block so in-flight `buffer_unordered` futures are cancelled before DHT discovery starts
- Nodes (`NodeMode::Node`) keep current behaviour — dial every candidate so the routing table converges fully

## Why
Clients don't serve the DHT; they only need enough peers to route their own α-parallel lookups. Six gives ~2× redundancy over α=3 without paying for the long tail of slow / dead candidates. This sits alongside the existing client-mode shortcuts (skip relay-acquisition driver, skip post-bootstrap self-lookups).

Tradeoff: clients get less peer diversity and feed fewer outcomes into the bootstrap cache (the cancelled dials don't report success/failure). Acceptable for clients; would be wrong for nodes.

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --lib bootstrap` — 18 / 18 passing
- [ ] Devnet smoke: client cold-start latency vs. node cold-start latency, confirm client converges visibly faster when some bootstrap candidates are dead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an early-exit for `NodeMode::Client` bootstrap: once 6 identity-confirmed connections are established, both Phase A (serial close-group dials) and Phase B (concurrent CLI + cached dials) stop without draining remaining candidates. `NodeMode::Node` behaviour is entirely unchanged.

The implementation is correct — `client_mode` is computed once, the `>= CLIENT_BOOTSTRAP_TARGET` guard fires on exactly the 6th success in both phases, and dropping `parallel_stream` at the end of the Phase B `if`-block reliably cancels in-flight `buffer_unordered` futures before the DHT discovery stage. One acknowledged tradeoff (noted in the PR description) is that cancelled Phase B dials never report back to the bootstrap cache, which could marginally slow a client's second cold-start if most bootstrap candidates respond slowly; this is acceptable given the client-only scope.

<h3>Confidence Score: 4/5</h3>

Safe to merge — logic is correct, node behaviour is unaffected, and stream cancellation is properly scoped.

No P0 or P1 issues found. The only observations are P2-level tradeoffs already acknowledged in the PR description (bootstrap-cache miss for cancelled dials, hardcoded target). Ceiling for P2-only review is 4/5.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/network.rs | Adds CLIENT_BOOTSTRAP_TARGET=6 constant and wires it into both Phase A (serial, break on target) and Phase B (skip or break on target) of the bootstrap loop; Node-mode behaviour is unchanged. Logic is correct, stream-drop cancellation is properly scoped, and the mode check is computed once before both phases. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start bootstrap] --> B{serial_addr_sets empty\nAND parallel_addr_sets empty?}
    B -- Yes --> C[Return Ok - no peers]
    B -- No --> D[Compute client_mode\n= NodeMode::Client]
    D --> E[Phase A: serial dials\nclose-group priority order]
    E --> F{Dial succeeds?}
    F -- No --> G{More serial\ncandidates?}
    G -- Yes --> E
    G -- No --> H[Phase B check]
    F -- Yes --> I[successful_connections++]
    I --> J{client_mode AND\nsuccessful >= 6?}
    J -- Yes --> K[break]
    J -- No --> G
    K --> H
    H{client_mode AND\nsuccessful >= 6?}
    H -- Yes --> N[Skip Phase B entirely]
    H -- No --> L[Phase B: buffer_unordered\nMAX_CONCURRENT=4]
    L --> M{Next result?}
    M -- None --> N
    M -- Some-None --> M
    M -- Some-PeerId --> O[successful_connections++]
    O --> P{client_mode AND\nsuccessful >= 6?}
    P -- Yes --> Q[break — drop stream,\ncancel in-flight dials]
    P -- No --> M
    Q --> N
    N --> R{successful_connections == 0?}
    R -- Yes --> S[Wait 5s for inbound peers]
    R -- No --> T[DHT discovery phase]
    S --> U{Inbound peers?}
    U -- Yes --> T
    U -- No --> V[Return Ok - retry later]
```

<sub>Reviews (1): Last reviewed commit: ["perf(network): client-mode bootstrap sto..."](https://github.com/saorsa-labs/saorsa-core/commit/132e5ebc322744e2745ced7354ee4541dd93b46a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29875681)</sub>

<!-- /greptile_comment -->