### PR TITLE
feat(dht): tag LAN-scoped addresses and gate same-WAN sharing

### DIFF
--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -104,15 +104,16 @@ fn xor_distance_bytes(a: &[u8; 32], b: &[u8; 32]) -> [u8; 32] {
 /// Maximum addresses stored per node to prevent memory exhaustion.
 /// This cap is the last-line guard; in normal operation the per-IP-family
 /// cap ([`NodeInfo::enforce_per_ip_family_cap`]) holds each external peer
-/// to at most 2 IP addresses per family. Non-IP transports (Bluetooth,
-/// LoRa) are outside the per-family cap and rely on this bound.
+/// to at most 3 IP addresses per family: one LAN-scoped address, one relay,
+/// and one non-relay WAN address. Non-IP transports (Bluetooth, LoRa) are
+/// outside the per-family cap and rely on this bound.
 const MAX_ADDRESSES_PER_NODE: usize = 8;
 
 /// Address classification for priority ordering and staleness eviction.
 ///
-/// Priority: Relay > Direct > Unverified > NATted. The `merge_typed_address`
-/// method uses this for insertion ordering and the eviction of excess
-/// `NATted` / `Unverified` entries.
+/// Priority: LAN > Relay > Direct > Unverified > NATted. The
+/// `merge_typed_address` method uses this for insertion ordering and the
+/// eviction of excess `NATted` / `Unverified` entries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AddressType {
     /// Address through a MASQUE relay server (always reachable)
@@ -127,22 +128,28 @@ pub enum AddressType {
     Unverified,
     /// NATted address (ephemeral, typically unreachable from outside)
     NATted,
+    /// Private, link-local, or loopback address shared only with peers on
+    /// the same LAN/WAN. This is intentionally a separate slot from Direct /
+    /// Unverified / NATted so same-NAT peers can retain a local path without
+    /// evicting their WAN path.
+    Lan,
 }
 
 impl AddressType {
     /// Priority index for ordering addresses by type. Lower is preferred.
     ///
-    /// Relay (0) → Direct (1) → Unverified (2) → NATted (3).
+    /// LAN (0) → Relay (1) → Direct (2) → Unverified (3) → NATted (4).
     ///
     /// Used by [`NodeInfo::merge_typed_address`], [`KBucket::replace_node_addresses`],
     /// [`DHTNode::addresses_by_priority`], and [`DhtNetworkManager::dialable_addresses_typed`]
     /// to maintain a consistent ordering invariant.
     pub const fn priority(self) -> u8 {
         match self {
-            Self::Relay => 0,
-            Self::Direct => 1,
-            Self::Unverified => 2,
-            Self::NATted => 3,
+            Self::Lan => 0,
+            Self::Relay => 1,
+            Self::Direct => 2,
+            Self::Unverified => 3,
+            Self::NATted => 4,
         }
     }
 }
@@ -170,7 +177,7 @@ pub struct NodeInfo {
     pub addresses: Vec<MultiAddr>,
     /// Type tag for each address, parallel to `addresses` by index.
     /// Defaults to empty on deserialization (legacy nodes); callers treat
-    /// untagged addresses as `Direct`.
+    /// untagged addresses as `Unverified`.
     #[serde(default)]
     pub address_types: Vec<AddressType>,
     /// Monotonic timestamp of last successful interaction.
@@ -216,11 +223,11 @@ impl NodeInfo {
 
     /// Merge a new address with an explicit type tag.
     ///
-    /// Insertion position depends on type priority: Relay → Direct →
-    /// Unverified → NATted. Relay addresses always go to the front. After
+    /// Insertion position depends on type priority: LAN → Relay → Direct →
+    /// Unverified → NATted. LAN addresses always go to the front. After
     /// insertion, [`Self::enforce_per_ip_family_cap`] prunes the list so
-    /// the "at most 1 Relay + 1 non-Relay per IP family, Direct dominates
-    /// Unverified dominates NATted" invariant holds.
+    /// the "at most 1 LAN + 1 Relay + 1 non-Relay per IP family, Direct
+    /// dominates Unverified dominates NATted" invariant holds.
     pub fn merge_typed_address(&mut self, addr: MultiAddr, addr_type: AddressType) {
         // Ensure address_types is in sync with addresses (legacy compat).
         // Trailing untagged entries are padded with `Unverified` so we do not
@@ -239,20 +246,29 @@ impl NodeInfo {
         }
 
         // Insert based on type priority. Insertion order is what the cap
-        // uses to break "newest wins" ties: Relay / Direct / Unverified
-        // insert at the front of their tier so the newest sits at the
-        // lowest index among same-tier entries; NATted appends so the
-        // newest sits at the highest index.
+        // uses to break "newest wins" ties: LAN / Relay / Direct /
+        // Unverified insert at the front of their tier so the newest sits
+        // at the lowest index among same-tier entries; NATted appends so
+        // the newest sits at the highest index.
         match addr_type {
-            AddressType::Relay => {
+            AddressType::Lan => {
                 self.addresses.insert(0, addr);
-                self.address_types.insert(0, AddressType::Relay);
+                self.address_types.insert(0, AddressType::Lan);
+            }
+            AddressType::Relay => {
+                let pos = self
+                    .address_types
+                    .iter()
+                    .position(|t| *t != AddressType::Lan)
+                    .unwrap_or(self.addresses.len());
+                self.addresses.insert(pos, addr);
+                self.address_types.insert(pos, AddressType::Relay);
             }
             AddressType::Direct => {
                 let pos = self
                     .address_types
                     .iter()
-                    .position(|t| *t != AddressType::Relay)
+                    .position(|t| *t != AddressType::Lan && *t != AddressType::Relay)
                     .unwrap_or(self.addresses.len());
                 self.addresses.insert(pos, addr);
                 self.address_types.insert(pos, AddressType::Direct);
@@ -261,7 +277,11 @@ impl NodeInfo {
                 let pos = self
                     .address_types
                     .iter()
-                    .position(|t| *t != AddressType::Relay && *t != AddressType::Direct)
+                    .position(|t| {
+                        *t != AddressType::Lan
+                            && *t != AddressType::Relay
+                            && *t != AddressType::Direct
+                    })
                     .unwrap_or(self.addresses.len());
                 self.addresses.insert(pos, addr);
                 self.address_types.insert(pos, AddressType::Unverified);
@@ -295,25 +315,26 @@ impl NodeInfo {
     /// For each IP family (IPv4, IPv6 — IPv4-mapped IPv6 is canonicalised
     /// to IPv4 so it is counted against the IPv4 slot), keep at most:
     ///
+    /// - 1 [`AddressType::Lan`] (newest wins)
     /// - 1 [`AddressType::Relay`] (newest wins)
     /// - 1 of {[`AddressType::Direct`], [`AddressType::Unverified`],
     ///   [`AddressType::NATted`]} — the entry with the highest priority
     ///   tier present in that family wins, newer entries within a tier
     ///   win over older ones
     ///
-    /// That yields the invariant: at most 2 addresses per IP family, and
-    /// weaker tiers (Unverified, NATted) never coexist with a stronger
-    /// same-family tier (Direct) — they add no useful dial option once
+    /// That yields the invariant: at most 3 addresses per IP family, and
+    /// weaker WAN tiers (Unverified, NATted) never coexist with a stronger
+    /// same-family WAN tier (Direct) — they add no useful dial option once
     /// the stronger one is known. A dual-stack peer may therefore hold
-    /// up to 4 IP addresses (2 per family).
+    /// up to 6 IP addresses (3 per family).
     ///
     /// Non-IP transport addresses (Bluetooth, LoRa) are left alone — they
     /// have no IP family and are governed only by [`MAX_ADDRESSES_PER_NODE`].
     ///
     /// "Newest wins" is encoded by the insertion positions in
-    /// [`Self::merge_typed_address`]: Relay, Direct, and Unverified insert
-    /// at the front of their tier, so the newest entry has the lowest
-    /// index; NATted appends, so the newest has the highest index.
+    /// [`Self::merge_typed_address`]: LAN, Relay, Direct, and Unverified
+    /// insert at the front of their tier, so the newest entry has the
+    /// lowest index; NATted appends, so the newest has the highest index.
     ///
     /// This enforces the invariant for *external peers*. The routing
     /// table never stores `NodeInfo` for self (admission rejects
@@ -340,7 +361,15 @@ impl NodeInfo {
                 continue;
             }
 
-            // Slot 1: newest Relay for the family (lowest-index Relay).
+            // Slot 1: newest LAN-scoped address for the family.
+            if let Some(&i) = family
+                .iter()
+                .find(|&&i| self.address_types[i] == AddressType::Lan)
+            {
+                keep[i] = true;
+            }
+
+            // Slot 2: newest Relay for the family (lowest-index Relay).
             if let Some(&i) = family
                 .iter()
                 .find(|&&i| self.address_types[i] == AddressType::Relay)
@@ -348,9 +377,9 @@ impl NodeInfo {
                 keep[i] = true;
             }
 
-            // Slot 2: the single highest-priority non-Relay entry for the
-            // family. Precedence is Direct > Unverified > NATted. Within
-            // Direct/Unverified, newer is at the lowest index; within
+            // Slot 3: the single highest-priority non-local, non-relay entry
+            // for the family. Precedence is Direct > Unverified > NATted.
+            // Within Direct/Unverified, newer is at the lowest index; within
             // NATted, newer is at the highest (append ordering).
             let best_non_relay = [
                 AddressType::Direct,
@@ -507,7 +536,7 @@ impl KBucket {
                     .addresses
                     .iter()
                     .any(|a| a.ip().is_some_and(|ip| !canonicalize_ip(ip).is_loopback()));
-                if !(addr_is_loopback && node_has_non_loopback) {
+                if !(addr_is_loopback && node_has_non_loopback && addr_type != AddressType::Lan) {
                     self.nodes[pos].merge_typed_address(addr.clone(), addr_type);
                 }
             }
@@ -566,7 +595,7 @@ impl KBucket {
             .addresses
             .iter()
             .any(|a| a.ip().is_some_and(|ip| !canonicalize_ip(ip).is_loopback()));
-        if addr_is_loopback && node_has_non_loopback {
+        if addr_is_loopback && node_has_non_loopback && addr_type != AddressType::Lan {
             return false;
         }
         self.nodes[pos].merge_typed_address_upgrade_only(address.clone(), addr_type)
@@ -624,7 +653,7 @@ impl KBucket {
                         .addresses
                         .iter()
                         .any(|a| a.ip().is_some_and(|ip| !canonicalize_ip(ip).is_loopback()));
-                    addr_is_loopback && node_has_non_loopback
+                    addr_is_loopback && node_has_non_loopback && addr_type != AddressType::Lan
                 }
             }
         };
@@ -651,9 +680,10 @@ impl KBucket {
     /// drops any state the sender omits (e.g., a stale relay address after
     /// the relay session closes).
     ///
-    /// The new list is sorted by [`type_priority`] (Relay → Direct → NATted)
-    /// to preserve the same ordering invariant that [`NodeInfo::merge_typed_address`]
-    /// maintains, then truncated to [`MAX_ADDRESSES_PER_NODE`].
+    /// The new list is sorted by [`AddressType::priority`] (LAN → Relay →
+    /// Direct → Unverified → NATted) to preserve the same ordering invariant
+    /// that [`NodeInfo::merge_typed_address`] maintains, then truncated to
+    /// [`MAX_ADDRESSES_PER_NODE`].
     ///
     /// Returns `true` when the peer was found and its addresses replaced,
     /// `false` when the peer is not in this bucket.
@@ -1274,7 +1304,7 @@ impl DhtCoreEngine {
     /// Get a peer's addresses paired with their [`AddressType`] tags.
     ///
     /// Used by [`crate::dht_network_manager::DhtNetworkManager::peer_addresses_for_dial`]
-    /// to sort candidates by type priority (Relay first) per ADR-014.
+    /// to sort candidates by type priority (LAN first, when eligible) per ADR-014.
     pub async fn get_node_addresses_typed(
         &self,
         peer_id: &PeerId,
@@ -1472,13 +1502,14 @@ impl DhtCoreEngine {
         let allow_loopback = self.allow_loopback;
         let filtered: Vec<(MultiAddr, AddressType)> = typed_addresses
             .into_iter()
-            .filter(|(addr, _)| {
+            .filter(|(addr, addr_type)| {
                 if allow_loopback {
                     return true;
                 }
-                !addr
+                let is_loopback = addr
                     .ip()
-                    .is_some_and(|ip| canonicalize_ip(ip).is_loopback())
+                    .is_some_and(|ip| canonicalize_ip(ip).is_loopback());
+                !is_loopback || *addr_type == AddressType::Lan
             })
             .collect();
 
@@ -2449,7 +2480,7 @@ mod tests {
         let replaced = bucket.replace_node_addresses(&PeerId::from_bytes([1u8; 32]), typed);
         assert!(replaced);
         let node = bucket.find_node(&PeerId::from_bytes([1u8; 32])).unwrap();
-        // Relay is first, Direct second — matches NodeInfo::merge_typed_address ordering.
+        // With no LAN address present, Relay sorts before Direct.
         assert_eq!(node.addresses, vec![new_relay, new_direct]);
         assert_eq!(
             node.address_types,
@@ -4139,7 +4170,8 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn address_type_priority_is_relay_direct_unverified_natted() {
+    fn address_type_priority_is_lan_relay_direct_unverified_natted() {
+        assert!(AddressType::Lan.priority() < AddressType::Relay.priority());
         assert!(AddressType::Relay.priority() < AddressType::Direct.priority());
         assert!(AddressType::Direct.priority() < AddressType::Unverified.priority());
         assert!(AddressType::Unverified.priority() < AddressType::NATted.priority());
@@ -4222,6 +4254,21 @@ mod tests {
         ]);
         node.enforce_per_ip_family_cap();
         assert_eq!(node.addresses.len(), 4);
+    }
+
+    #[test]
+    fn cap_allows_lan_as_extra_same_family_slot() {
+        let mut node = node_with(vec![
+            ("/ip4/10.0.0.7/udp/9000/quic", AddressType::Lan),
+            ("/ip4/198.51.100.1/udp/9001/quic", AddressType::Relay),
+            ("/ip4/203.0.113.7/udp/9002/quic", AddressType::Direct),
+            ("/ip4/192.0.2.9/udp/9003/quic", AddressType::Unverified),
+        ]);
+        node.enforce_per_ip_family_cap();
+        assert_eq!(
+            node.address_types,
+            vec![AddressType::Lan, AddressType::Relay, AddressType::Direct]
+        );
     }
 
     #[test]

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -27,6 +27,7 @@ use crate::{
     dht::{AdmissionResult, DhtCoreEngine, DhtKey, Key, RoutingTableEvent},
     error::{DhtError, IdentityError, NetworkError},
     network::{NodeConfig, NodeMode},
+    security::canonicalize_ip,
 };
 use anyhow::Context as _;
 use dashmap::DashMap;
@@ -34,7 +35,7 @@ use dashmap::mapref::entry::Entry as DashEntry;
 use futures::stream::{FuturesUnordered, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::{RwLock, Semaphore, broadcast, oneshot};
@@ -171,6 +172,58 @@ const REBOOTSTRAP_COOLDOWN: Duration = Duration::from_secs(300); // 5 minutes
 /// stale Unverified/Direct entries published by NATed peers.
 const DIAL_FAILURE_CACHE_TTL: Duration = Duration::from_secs(30 * 60);
 
+pub(crate) fn is_lan_or_loopback_ip(ip: IpAddr) -> bool {
+    match canonicalize_ip(ip) {
+        IpAddr::V4(v4) => v4.is_private() || v4.is_loopback() || v4.is_link_local(),
+        IpAddr::V6(v6) => v6.is_loopback() || is_ipv6_unique_local(v6) || is_ipv6_link_local(v6),
+    }
+}
+
+/// IPv6 unique-local address range fc00::/7 (RFC 4193). The high 7 bits
+/// of the first octet are `0b1111110`, leaving the L bit free.
+fn is_ipv6_unique_local(v6: Ipv6Addr) -> bool {
+    const ULA_MASK: u8 = 0b1111_1110;
+    const ULA_PREFIX: u8 = 0b1111_1100;
+    (v6.octets()[0] & ULA_MASK) == ULA_PREFIX
+}
+
+/// IPv6 link-local address range fe80::/10 (RFC 4291). The high 10 bits
+/// are `1111111010`: full first octet `0xfe`, top 2 bits of the second
+/// octet `10`.
+fn is_ipv6_link_local(v6: Ipv6Addr) -> bool {
+    const LL_FIRST_OCTET: u8 = 0xfe;
+    const LL_SECOND_OCTET_MASK: u8 = 0b1100_0000;
+    const LL_SECOND_OCTET_PREFIX: u8 = 0b1000_0000;
+    let octets = v6.octets();
+    octets[0] == LL_FIRST_OCTET && (octets[1] & LL_SECOND_OCTET_MASK) == LL_SECOND_OCTET_PREFIX
+}
+
+pub(crate) fn is_lan_or_loopback_socket(addr: &SocketAddr) -> bool {
+    is_lan_or_loopback_ip(addr.ip())
+}
+
+pub(crate) fn is_wan_ip(ip: IpAddr) -> bool {
+    let ip = canonicalize_ip(ip);
+    if is_lan_or_loopback_ip(ip) || ip.is_unspecified() {
+        return false;
+    }
+    match ip {
+        IpAddr::V4(v4) => !v4.is_multicast(),
+        IpAddr::V6(v6) => !v6.is_multicast(),
+    }
+}
+
+pub(crate) fn socket_ip_in_set(addr: &SocketAddr, ips: &HashSet<IpAddr>) -> bool {
+    ips.contains(&canonicalize_ip(addr.ip()))
+}
+
+pub(crate) fn loopback_for_ip(ip: IpAddr) -> IpAddr {
+    match canonicalize_ip(ip) {
+        IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::LOCALHOST),
+        IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::LOCALHOST),
+    }
+}
+
 /// DHT node representation for network operations.
 ///
 /// The `addresses` field stores one or more typed [`MultiAddr`] values.
@@ -211,7 +264,7 @@ impl DHTNode {
     /// stand in for a verified `Direct` tag.
     ///
     /// The returned vec preserves the storage order from `addresses`;
-    /// callers that need Relay-first ordering should pass the result to
+    /// callers that need priority ordering should pass the result to
     /// [`DhtNetworkManager::dialable_addresses_typed`] or use
     /// [`Self::addresses_by_priority`] for a pre-sorted `Vec<MultiAddr>`.
     pub fn typed_addresses(&self) -> Vec<(MultiAddr, AddressType)> {
@@ -229,8 +282,8 @@ impl DHTNode {
             .collect()
     }
 
-    /// Addresses sorted by [`AddressType`] priority: Relay first, then
-    /// Direct, then NATted.  Within each tier the original insertion
+    /// Addresses sorted by [`AddressType`] priority: LAN first, then Relay,
+    /// Direct, Unverified, and NATted. Within each tier the original insertion
     /// order is preserved (stable sort).
     ///
     /// Use this instead of raw `addresses` whenever the caller needs to
@@ -895,7 +948,18 @@ impl DhtNetworkManager {
         );
 
         let candidate_nodes = self.find_closest_nodes_local(key, self.k_value()).await;
-        let closer_nodes = Self::filter_response_nodes(candidate_nodes, requester);
+        let own_wan_ips = self.own_direct_wan_ips();
+        let mut closer_nodes = Vec::new();
+        for mut node in Self::filter_response_nodes(candidate_nodes, requester) {
+            let filtered = self
+                .filter_address_set_for_peer_id(&node.typed_addresses(), requester, &own_wan_ips)
+                .await;
+            node.addresses = filtered.iter().map(|(addr, _)| addr.clone()).collect();
+            node.address_types = filtered.iter().map(|(_, ty)| *ty).collect();
+            if !node.addresses.is_empty() {
+                closer_nodes.push(node);
+            }
+        }
 
         // Log addresses being returned in FIND_NODE response
         for node in &closer_nodes {
@@ -1902,7 +1966,15 @@ impl DhtNetworkManager {
     /// closes the "NAT-through-NAT relay chain" failure mode where a
     /// node's observed-but-unverified ephemeral port would be treated as
     /// a dialable Direct candidate.
+    #[cfg(test)]
     pub(crate) fn first_direct_dialable(node: &DHTNode) -> Option<MultiAddr> {
+        Self::first_direct_dialable_excluding_wan(node, &HashSet::new())
+    }
+
+    pub(crate) fn first_direct_dialable_excluding_wan(
+        node: &DHTNode,
+        excluded_wan_ips: &HashSet<IpAddr>,
+    ) -> Option<MultiAddr> {
         for (i, addr) in node.addresses.iter().enumerate() {
             let addr_type = node
                 .address_types
@@ -1916,6 +1988,9 @@ impl DhtNetworkManager {
                 continue;
             };
             if sa.ip().is_unspecified() {
+                continue;
+            }
+            if socket_ip_in_set(&sa, excluded_wan_ips) {
                 continue;
             }
             return Some(addr.clone());
@@ -1944,6 +2019,312 @@ impl DhtNetworkManager {
             trace!("Accepting loopback address (local/test): {addr}");
         }
         true
+    }
+
+    pub(crate) fn own_direct_wan_ips_from_transport(
+        transport: &crate::transport_handle::TransportHandle,
+    ) -> HashSet<IpAddr> {
+        transport
+            .direct_external_addresses()
+            .into_iter()
+            .map(|addr| canonicalize_ip(addr.ip()))
+            .filter(|ip| is_wan_ip(*ip))
+            .collect()
+    }
+
+    fn own_direct_wan_ips(&self) -> HashSet<IpAddr> {
+        Self::own_direct_wan_ips_from_transport(&self.transport)
+    }
+
+    async fn own_lan_ips_from_transport(
+        transport: &crate::transport_handle::TransportHandle,
+    ) -> HashSet<IpAddr> {
+        transport
+            .listen_addrs()
+            .await
+            .into_iter()
+            .filter_map(|addr| addr.dialable_socket_addr())
+            .map(|addr| canonicalize_ip(addr.ip()))
+            .filter(|ip| is_lan_or_loopback_ip(*ip))
+            .collect()
+    }
+
+    pub(crate) async fn maybe_swap_same_lan_ip_to_loopback(
+        transport: &crate::transport_handle::TransportHandle,
+        addr: SocketAddr,
+    ) -> SocketAddr {
+        if !is_lan_or_loopback_socket(&addr) || addr.ip().is_loopback() {
+            return addr;
+        }
+
+        let local_ips = Self::own_lan_ips_from_transport(transport).await;
+        if local_ips.contains(&canonicalize_ip(addr.ip())) {
+            return SocketAddr::new(loopback_for_ip(addr.ip()), addr.port());
+        }
+
+        addr
+    }
+
+    fn collect_lan_ips<I>(addresses: I) -> impl Iterator<Item = IpAddr>
+    where
+        I: IntoIterator<Item = MultiAddr>,
+    {
+        addresses
+            .into_iter()
+            .filter_map(|addr| addr.dialable_socket_addr())
+            .filter(is_lan_or_loopback_socket)
+            .map(|addr| canonicalize_ip(addr.ip()))
+    }
+
+    async fn peer_lan_ips(&self, peer: &DHTNode) -> HashSet<IpAddr> {
+        let mut ips: HashSet<IpAddr> =
+            Self::collect_lan_ips(peer.addresses.iter().cloned()).collect();
+
+        if let Some(info) = self.transport.peer_info(&peer.peer_id).await {
+            ips.extend(Self::collect_lan_ips(info.addresses));
+        }
+
+        ips
+    }
+
+    async fn peer_id_lan_ips(&self, peer_id: &PeerId) -> HashSet<IpAddr> {
+        let mut ips = HashSet::new();
+
+        if let Some(info) = self.transport.peer_info(peer_id).await {
+            ips.extend(Self::collect_lan_ips(info.addresses));
+        }
+
+        let typed = self
+            .dht
+            .read()
+            .await
+            .get_node_addresses_typed(peer_id)
+            .await;
+        ips.extend(Self::collect_lan_ips(
+            typed.into_iter().map(|(addr, _)| addr),
+        ));
+
+        ips
+    }
+
+    /// True when the socket's IP is one of our own observed WAN IPs (and
+    /// is itself a public WAN address) — i.e., the peer is behind the
+    /// same NAT as us. Used as same-WAN evidence on routing-table records,
+    /// which may have been authored by us and so cannot count as LAN
+    /// evidence.
+    fn socket_is_same_wan(socket: &SocketAddr, own_wan_ips: &HashSet<IpAddr>) -> bool {
+        !own_wan_ips.is_empty() && is_wan_ip(socket.ip()) && socket_ip_in_set(socket, own_wan_ips)
+    }
+
+    /// True when the socket's IP shows the peer can receive LAN-scoped
+    /// addresses from us — either it is itself LAN/loopback, or it is on
+    /// our same WAN. Used on transport-level evidence (live connections),
+    /// where a LAN-scoped peer address is genuine.
+    fn socket_indicates_same_lan_or_wan(
+        socket: &SocketAddr,
+        own_wan_ips: &HashSet<IpAddr>,
+    ) -> bool {
+        is_lan_or_loopback_socket(socket) || Self::socket_is_same_wan(socket, own_wan_ips)
+    }
+
+    fn transport_addresses_indicate_same_lan_or_wan<I>(
+        addresses: I,
+        own_wan_ips: &HashSet<IpAddr>,
+    ) -> bool
+    where
+        I: IntoIterator<Item = MultiAddr>,
+    {
+        addresses
+            .into_iter()
+            .filter_map(|addr| addr.dialable_socket_addr())
+            .any(|socket| Self::socket_indicates_same_lan_or_wan(&socket, own_wan_ips))
+    }
+
+    fn routing_addresses_indicate_same_wan<I>(addresses: I, own_wan_ips: &HashSet<IpAddr>) -> bool
+    where
+        I: IntoIterator<Item = MultiAddr>,
+    {
+        addresses
+            .into_iter()
+            .filter_map(|addr| addr.dialable_socket_addr())
+            .any(|socket| Self::socket_is_same_wan(&socket, own_wan_ips))
+    }
+
+    async fn peer_can_receive_lan_addresses(
+        &self,
+        peer: &DHTNode,
+        own_wan_ips: &HashSet<IpAddr>,
+    ) -> bool {
+        if Self::routing_addresses_indicate_same_wan(peer.addresses.iter().cloned(), own_wan_ips) {
+            return true;
+        }
+
+        if let Some(info) = self.transport.peer_info(&peer.peer_id).await
+            && Self::transport_addresses_indicate_same_lan_or_wan(info.addresses, own_wan_ips)
+        {
+            return true;
+        }
+
+        false
+    }
+
+    async fn peer_id_can_receive_lan_addresses(
+        &self,
+        peer_id: &PeerId,
+        own_wan_ips: &HashSet<IpAddr>,
+    ) -> bool {
+        if let Some(info) = self.transport.peer_info(peer_id).await
+            && Self::transport_addresses_indicate_same_lan_or_wan(info.addresses, own_wan_ips)
+        {
+            return true;
+        }
+
+        let typed = self
+            .dht
+            .read()
+            .await
+            .get_node_addresses_typed(peer_id)
+            .await;
+        Self::routing_addresses_indicate_same_wan(
+            typed.into_iter().map(|(addr, _)| addr),
+            own_wan_ips,
+        )
+    }
+
+    fn address_set_has_same_wan_non_relay(
+        addresses: &[(MultiAddr, AddressType)],
+        own_wan_ips: &HashSet<IpAddr>,
+    ) -> bool {
+        !own_wan_ips.is_empty()
+            && addresses.iter().any(|(addr, addr_type)| {
+                *addr_type != AddressType::Relay
+                    && addr.dialable_socket_addr().is_some_and(|socket| {
+                        is_wan_ip(socket.ip()) && socket_ip_in_set(&socket, own_wan_ips)
+                    })
+            })
+    }
+
+    async fn filter_address_set_for_local_use(
+        &self,
+        peer_id: &PeerId,
+        addresses: &[(MultiAddr, AddressType)],
+        own_wan_ips: &HashSet<IpAddr>,
+    ) -> Vec<(MultiAddr, AddressType)> {
+        let allow_lan = Self::address_set_has_same_wan_non_relay(addresses, own_wan_ips)
+            || self
+                .peer_id_can_receive_lan_addresses(peer_id, own_wan_ips)
+                .await;
+
+        let mut out = Vec::with_capacity(addresses.len());
+        for (addr, addr_type) in addresses {
+            let Some(socket) = addr.dialable_socket_addr() else {
+                out.push((addr.clone(), *addr_type));
+                continue;
+            };
+
+            if (*addr_type == AddressType::Lan || is_lan_or_loopback_socket(&socket)) && !allow_lan
+            {
+                continue;
+            }
+
+            if *addr_type == AddressType::Relay && socket_ip_in_set(&socket, own_wan_ips) {
+                continue;
+            }
+
+            let socket = if *addr_type == AddressType::Lan {
+                Self::maybe_swap_same_lan_ip_to_loopback(&self.transport, socket).await
+            } else {
+                socket
+            };
+
+            out.push((MultiAddr::quic(socket), *addr_type));
+        }
+
+        out
+    }
+
+    async fn filter_address_set_for_peer(
+        &self,
+        addresses: &[(MultiAddr, AddressType)],
+        peer: &DHTNode,
+        own_wan_ips: &HashSet<IpAddr>,
+    ) -> Vec<(MultiAddr, AddressType)> {
+        let allow_lan = self.peer_can_receive_lan_addresses(peer, own_wan_ips).await;
+        let peer_lan_ips = if allow_lan {
+            self.peer_lan_ips(peer).await
+        } else {
+            HashSet::new()
+        };
+
+        Self::filter_address_set_for_receiver(addresses, allow_lan, &peer_lan_ips, own_wan_ips)
+    }
+
+    async fn filter_address_set_for_peer_id(
+        &self,
+        addresses: &[(MultiAddr, AddressType)],
+        peer_id: &PeerId,
+        own_wan_ips: &HashSet<IpAddr>,
+    ) -> Vec<(MultiAddr, AddressType)> {
+        let allow_lan = self
+            .peer_id_can_receive_lan_addresses(peer_id, own_wan_ips)
+            .await;
+        let peer_lan_ips = if allow_lan {
+            self.peer_id_lan_ips(peer_id).await
+        } else {
+            HashSet::new()
+        };
+
+        Self::filter_address_set_for_receiver(addresses, allow_lan, &peer_lan_ips, own_wan_ips)
+    }
+
+    fn filter_address_set_for_receiver(
+        addresses: &[(MultiAddr, AddressType)],
+        allow_lan: bool,
+        peer_lan_ips: &HashSet<IpAddr>,
+        own_wan_ips: &HashSet<IpAddr>,
+    ) -> Vec<(MultiAddr, AddressType)> {
+        addresses
+            .iter()
+            .filter_map(|(addr, addr_type)| {
+                let socket = addr.dialable_socket_addr();
+                let local_scoped = socket.as_ref().is_some_and(is_lan_or_loopback_socket);
+                if (*addr_type == AddressType::Lan || local_scoped) && !allow_lan {
+                    return None;
+                }
+
+                if *addr_type == AddressType::Relay
+                    && socket
+                        .as_ref()
+                        .is_some_and(|socket| socket_ip_in_set(socket, own_wan_ips))
+                {
+                    return None;
+                }
+
+                let mut out = addr.clone();
+                if *addr_type == AddressType::Lan
+                    && let Some(socket) = socket
+                    && !socket.ip().is_loopback()
+                    && peer_lan_ips.contains(&canonicalize_ip(socket.ip()))
+                {
+                    out = MultiAddr::quic(SocketAddr::new(
+                        loopback_for_ip(socket.ip()),
+                        socket.port(),
+                    ));
+                }
+
+                Some((out, *addr_type))
+            })
+            .collect()
+    }
+
+    async fn filter_published_address_set_from_sender(
+        &self,
+        sender: &PeerId,
+        addresses: &[(MultiAddr, AddressType)],
+    ) -> Vec<(MultiAddr, AddressType)> {
+        let own_wan_ips = self.own_direct_wan_ips();
+        self.filter_address_set_for_local_use(sender, addresses, &own_wan_ips)
+            .await
     }
 
     /// Try dialing at most two addresses from `typed_addresses`, chosen by
@@ -1979,7 +2360,11 @@ impl DhtNetworkManager {
             );
             return None;
         }
-        let plan = Self::select_dial_candidates(typed_addresses);
+        let own_wan_ips = self.own_direct_wan_ips();
+        let filtered = self
+            .filter_address_set_for_local_use(peer_id, typed_addresses, &own_wan_ips)
+            .await;
+        let plan = Self::select_dial_candidates_with_own_wan(&filtered, &own_wan_ips);
         if plan.is_empty() {
             debug!(
                 "dial_addresses: no dialable addresses for {}",
@@ -2499,7 +2884,7 @@ impl DhtNetworkManager {
     /// Thin wrapper over [`Self::peer_addresses_for_dial_typed`] for
     /// callers that don't need the per-address type tag (e.g.,
     /// `network.rs::first_dialable_peer_address`). Internally always
-    /// goes through the typed path so the Relay-first sort invariant
+    /// goes through the typed path so the address-priority invariant
     /// holds for both consumer styles.
     pub(crate) async fn peer_addresses_for_dial(&self, peer_id: &PeerId) -> Vec<MultiAddr> {
         self.peer_addresses_for_dial_typed(peer_id)
@@ -2516,23 +2901,28 @@ impl DhtNetworkManager {
     /// peers. Returns an empty vec when the peer is unknown or has no
     /// dialable addresses.
     ///
-    /// Result is sorted by [`AddressType`] priority — Relay first
-    /// (known-good relay endpoint), then Direct, then NATted — so the
-    /// dialer tries the fastest path first.
+    /// Result is filtered for the local node's LAN/WAN relationship with the
+    /// peer, then sorted by [`AddressType`] priority — LAN first when
+    /// eligible, then Relay, Direct, Unverified, and NATted — so the dialer
+    /// tries the fastest safe path first.
     pub(crate) async fn peer_addresses_for_dial_typed(
         &self,
         peer_id: &PeerId,
     ) -> Vec<(MultiAddr, AddressType)> {
-        // 1. Routing table — filter to dialable QUIC addresses and sort
-        //    by AddressType priority (Relay first).
+        // 1. Routing table — filter to safe dialable QUIC addresses and sort
+        //    by AddressType priority.
         let typed = self
             .dht
             .read()
             .await
             .get_node_addresses_typed(peer_id)
             .await;
+        let own_wan_ips = self.own_direct_wan_ips();
         if !typed.is_empty() {
-            return Self::dialable_addresses_typed(&typed);
+            let filtered = self
+                .filter_address_set_for_local_use(peer_id, &typed, &own_wan_ips)
+                .await;
+            return Self::dialable_addresses_typed(&filtered);
         }
 
         // 2. Transport layer — for connected peers not yet in the
@@ -2557,9 +2947,9 @@ impl DhtNetworkManager {
 
     /// Filter and sort typed addresses by [`AddressType::priority`].
     ///
-    /// Relay first, Direct second, NATted last. Stable sort within each
-    /// tier preserves the input order, so callers that hand in addresses
-    /// in a meaningful sub-order (e.g., IPv6 before IPv4) keep that
+    /// LAN first, then Relay, Direct, Unverified, and NATted. Stable sort
+    /// within each tier preserves the input order, so callers that hand in
+    /// addresses in a meaningful sub-order (e.g., IPv6 before IPv4) keep that
     /// order within the type tier.
     fn dialable_addresses_typed(
         typed: &[(MultiAddr, AddressType)],
@@ -2579,10 +2969,12 @@ impl DhtNetworkManager {
     /// cold-start policy documented on [`Self::dial_addresses`].
     ///
     /// Rules:
-    /// - If a Relay is published, dial the Relay and (when present) one
-    ///   Direct address. Relay paths are the reliable fallback, so we do
-    ///   not burn a second attempt on an Unverified guess.
-    /// - If no Relay is published but a Direct is, dial the Direct and
+    /// - If a LAN address is usable, dial it first and skip Relay; same-LAN
+    ///   peers should not hairpin through a relay.
+    /// - If a Relay is published and not on our own WAN IP, dial the Relay and
+    ///   (when present) one Direct address. Relay paths are the reliable
+    ///   fallback, so we do not burn a second attempt on an Unverified guess.
+    /// - If no usable Relay is published but a Direct is, dial the Direct and
     ///   (when present) a single Unverified/NATted address as backup.
     /// - If only Unverified/NATted addresses exist, dial one of them and
     ///   stop. A second attempt from the same bucket is rarely more
@@ -2594,16 +2986,33 @@ impl DhtNetworkManager {
     /// when the top choice is unreachable. Capping at two keeps the
     /// worst case to a single retry while still covering the expected
     /// relay→direct and direct→unverified handoffs.
+    #[cfg(test)]
     fn select_dial_candidates(typed: &[(MultiAddr, AddressType)]) -> Vec<(MultiAddr, AddressType)> {
+        Self::select_dial_candidates_with_own_wan(typed, &HashSet::new())
+    }
+
+    fn select_dial_candidates_with_own_wan(
+        typed: &[(MultiAddr, AddressType)],
+        own_wan_ips: &HashSet<IpAddr>,
+    ) -> Vec<(MultiAddr, AddressType)> {
         let dialable: Vec<(MultiAddr, AddressType)> = typed
             .iter()
             .filter(|pair| Self::is_dialable(&pair.0))
             .cloned()
             .collect();
 
+        let lan = dialable
+            .iter()
+            .find(|(_, t)| *t == AddressType::Lan)
+            .cloned();
         let relay = dialable
             .iter()
-            .find(|(_, t)| *t == AddressType::Relay)
+            .find(|(addr, t)| {
+                *t == AddressType::Relay
+                    && addr
+                        .dialable_socket_addr()
+                        .is_none_or(|socket| !socket_ip_in_set(&socket, own_wan_ips))
+            })
             .cloned();
         let direct = dialable
             .iter()
@@ -2611,17 +3020,25 @@ impl DhtNetworkManager {
             .cloned();
         let other = dialable
             .iter()
-            .filter(|(_, t)| !matches!(*t, AddressType::Relay | AddressType::Direct))
+            .filter(|(_, t)| {
+                !matches!(
+                    *t,
+                    AddressType::Lan | AddressType::Relay | AddressType::Direct
+                )
+            })
             .min_by_key(|(_, t)| t.priority())
             .cloned();
 
-        match (relay, direct, other) {
-            (Some(r), Some(d), _) => vec![r, d],
-            (Some(r), None, _) => vec![r],
-            (None, Some(d), Some(o)) => vec![d, o],
-            (None, Some(d), None) => vec![d],
-            (None, None, Some(o)) => vec![o],
-            (None, None, None) => Vec::new(),
+        match (lan, relay, direct, other) {
+            (Some(l), _, Some(d), _) => vec![l, d],
+            (Some(l), _, None, Some(o)) => vec![l, o],
+            (Some(l), _, None, None) => vec![l],
+            (None, Some(r), Some(d), _) => vec![r, d],
+            (None, Some(r), None, _) => vec![r],
+            (None, None, Some(d), Some(o)) => vec![d, o],
+            (None, None, Some(d), None) => vec![d],
+            (None, None, None, Some(o)) => vec![o],
+            (None, None, None, None) => Vec::new(),
         }
     }
 
@@ -2782,8 +3199,18 @@ impl DhtNetworkManager {
                     seq,
                     addresses.len()
                 );
+                let filtered = self
+                    .filter_published_address_set_from_sender(authenticated_sender, addresses)
+                    .await;
+                if filtered.is_empty() {
+                    debug!(
+                        "Ignoring PUBLISH_ADDRESS_SET from {} after address filtering",
+                        authenticated_sender
+                    );
+                    return Ok(DhtNetworkResult::PublishAddressAck);
+                }
                 let dht = self.dht.read().await;
-                dht.replace_node_addresses(authenticated_sender, addresses.clone(), *seq)
+                dht.replace_node_addresses(authenticated_sender, filtered, *seq)
                     .await;
                 Ok(DhtNetworkResult::PublishAddressAck)
             }
@@ -3561,8 +3988,12 @@ impl DhtNetworkManager {
     /// nodes whose identity exchange always times out) as long as some
     /// authenticated neighbour keeps mentioning them.
     pub async fn merge_gossiped_typed_addresses(&self, node: &DHTNode) {
+        let own_wan_ips = self.own_direct_wan_ips();
+        let filtered = self
+            .filter_address_set_for_local_use(&node.peer_id, &node.typed_addresses(), &own_wan_ips)
+            .await;
         let dht = self.dht.read().await;
-        for (addr, ty) in node.typed_addresses() {
+        for (addr, ty) in filtered {
             dht.merge_typed_address_upgrade_only(&node.peer_id, &addr, ty)
                 .await;
         }
@@ -3660,14 +4091,24 @@ impl DhtNetworkManager {
         peers: &[DHTNode],
     ) {
         let seq = Self::next_publish_seq();
-        let op = DhtNetworkOperation::PublishAddressSet {
-            seq,
-            addresses: typed_addresses.clone(),
-        };
+        let own_wan_ips = self.own_direct_wan_ips();
         for peer in peers {
             if peer.peer_id == self.config.peer_id {
                 continue; // Skip self
             }
+            let addresses = self
+                .filter_address_set_for_peer(&typed_addresses, peer, &own_wan_ips)
+                .await;
+            if addresses.is_empty() {
+                debug!(
+                    peer = %peer.peer_id.to_hex(),
+                    seq,
+                    "skipping address-set publish after per-peer address filtering",
+                );
+                continue;
+            }
+            let address_count = addresses.len();
+            let op = DhtNetworkOperation::PublishAddressSet { seq, addresses };
             // Pass the peer's typed addresses through directly so
             // send_dht_request avoids a redundant routing-table read for
             // a peer we already have in hand.
@@ -3679,7 +4120,7 @@ impl DhtNetworkManager {
                 Ok(_) => {
                     debug!(
                         peer = %peer.peer_id.to_hex(),
-                        addrs = typed_addresses.len(),
+                        addrs = address_count,
                         seq,
                         "published address set to peer",
                     );
@@ -4321,6 +4762,145 @@ mod tests {
         assert_eq!(picks.len(), 2);
         assert_eq!(picks[0].1, AddressType::Direct);
         assert_eq!(picks[1].1, AddressType::Unverified);
+    }
+
+    #[test]
+    fn select_dial_candidates_prefers_lan_and_skips_relay() {
+        let addrs = typed(vec![
+            ("/ip4/198.51.100.1/udp/9000/quic", AddressType::Relay),
+            ("/ip4/10.0.0.7/udp/9001/quic", AddressType::Lan),
+            ("/ip4/203.0.113.7/udp/9002/quic", AddressType::Direct),
+        ]);
+        let picks = DhtNetworkManager::select_dial_candidates(&addrs);
+        assert_eq!(picks.len(), 2);
+        assert_eq!(picks[0].1, AddressType::Lan);
+        assert_eq!(picks[1].1, AddressType::Direct);
+    }
+
+    #[test]
+    fn select_dial_candidates_lan_plus_unverified_does_not_duplicate_lan() {
+        let addrs = typed(vec![
+            ("/ip4/10.0.0.7/udp/9001/quic", AddressType::Lan),
+            ("/ip4/192.0.2.9/udp/9002/quic", AddressType::Unverified),
+        ]);
+        let picks = DhtNetworkManager::select_dial_candidates(&addrs);
+        assert_eq!(picks.len(), 2);
+        assert_eq!(picks[0].1, AddressType::Lan);
+        assert_eq!(picks[1].1, AddressType::Unverified);
+    }
+
+    #[test]
+    fn select_dial_candidates_skips_relay_on_our_wan_ip() {
+        let addrs = typed(vec![
+            ("/ip4/82.151.167.27/udp/9000/quic", AddressType::Relay),
+            ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
+            ("/ip4/192.0.2.9/udp/9002/quic", AddressType::Unverified),
+        ]);
+        let own_wan_ips = HashSet::from([IpAddr::V4(Ipv4Addr::new(82, 151, 167, 27))]);
+        let picks = DhtNetworkManager::select_dial_candidates_with_own_wan(&addrs, &own_wan_ips);
+        assert_eq!(picks.len(), 2);
+        assert_eq!(picks[0].1, AddressType::Direct);
+        assert_eq!(picks[1].1, AddressType::Unverified);
+    }
+
+    #[test]
+    fn filter_address_set_drops_lan_when_receiver_is_not_same_wan() {
+        let addrs = typed(vec![
+            ("/ip4/10.0.0.7/udp/9000/quic", AddressType::Lan),
+            ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
+        ]);
+        let filtered = DhtNetworkManager::filter_address_set_for_receiver(
+            &addrs,
+            false,
+            &HashSet::new(),
+            &HashSet::new(),
+        );
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].1, AddressType::Direct);
+    }
+
+    #[test]
+    fn same_wan_evidence_ignores_lan_and_relay_addresses() {
+        let own_wan_ips = HashSet::from([IpAddr::V4(Ipv4Addr::new(82, 151, 167, 27))]);
+        let lan_only = typed(vec![("/ip4/10.0.0.7/udp/9000/quic", AddressType::Lan)]);
+        let same_wan_relay = typed(vec![(
+            "/ip4/82.151.167.27/udp/9000/quic",
+            AddressType::Relay,
+        )]);
+        let same_wan_direct = typed(vec![(
+            "/ip4/82.151.167.27/udp/9001/quic",
+            AddressType::Direct,
+        )]);
+
+        assert!(!DhtNetworkManager::address_set_has_same_wan_non_relay(
+            &lan_only,
+            &own_wan_ips
+        ));
+        assert!(!DhtNetworkManager::address_set_has_same_wan_non_relay(
+            &same_wan_relay,
+            &own_wan_ips
+        ));
+        assert!(DhtNetworkManager::address_set_has_same_wan_non_relay(
+            &same_wan_direct,
+            &own_wan_ips
+        ));
+    }
+
+    #[test]
+    fn filter_address_set_drops_relay_on_our_wan_ip() {
+        let addrs = typed(vec![
+            ("/ip4/82.151.167.27/udp/9000/quic", AddressType::Relay),
+            ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
+        ]);
+        let own_wan_ips = HashSet::from([IpAddr::V4(Ipv4Addr::new(82, 151, 167, 27))]);
+        let filtered = DhtNetworkManager::filter_address_set_for_receiver(
+            &addrs,
+            true,
+            &HashSet::new(),
+            &own_wan_ips,
+        );
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].1, AddressType::Direct);
+    }
+
+    #[test]
+    fn filter_address_set_swaps_same_lan_ip_to_loopback_for_receiver() {
+        let addrs = typed(vec![("/ip4/10.0.0.7/udp/9000/quic", AddressType::Lan)]);
+        let peer_lan_ips = HashSet::from([IpAddr::V4(Ipv4Addr::new(10, 0, 0, 7))]);
+        let filtered = DhtNetworkManager::filter_address_set_for_receiver(
+            &addrs,
+            true,
+            &peer_lan_ips,
+            &HashSet::new(),
+        );
+
+        assert_eq!(
+            filtered[0].0,
+            "/ip4/127.0.0.1/udp/9000/quic".parse::<MultiAddr>().unwrap()
+        );
+        assert_eq!(filtered[0].1, AddressType::Lan);
+    }
+
+    #[test]
+    fn first_direct_dialable_excluding_wan_skips_same_wan_candidate() {
+        let node = dht_node(
+            1,
+            vec![
+                ("/ip4/82.151.167.27/udp/9000/quic", AddressType::Direct),
+                ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
+            ],
+        );
+        let own_wan_ips = HashSet::from([IpAddr::V4(Ipv4Addr::new(82, 151, 167, 27))]);
+        let picked =
+            DhtNetworkManager::first_direct_dialable_excluding_wan(&node, &own_wan_ips).unwrap();
+        assert_eq!(
+            picked,
+            "/ip4/203.0.113.7/udp/9001/quic"
+                .parse::<MultiAddr>()
+                .unwrap()
+        );
     }
 
     fn sock(s: &str) -> SocketAddr {

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -2191,6 +2191,14 @@ impl DhtNetworkManager {
         )
     }
 
+    async fn peer_supports_lan_address_type(&self, peer_id: &PeerId) -> bool {
+        self.transport
+            .peer_user_agent(peer_id)
+            .await
+            .as_deref()
+            .is_some_and(crate::network::supports_lan_address_type)
+    }
+
     fn address_set_has_same_wan_non_relay(
         addresses: &[(MultiAddr, AddressType)],
         own_wan_ips: &HashSet<IpAddr>,
@@ -2250,13 +2258,20 @@ impl DhtNetworkManager {
         own_wan_ips: &HashSet<IpAddr>,
     ) -> Vec<(MultiAddr, AddressType)> {
         let allow_lan = self.peer_can_receive_lan_addresses(peer, own_wan_ips).await;
+        let supports_lan_wire = self.peer_supports_lan_address_type(&peer.peer_id).await;
         let peer_lan_ips = if allow_lan {
             self.peer_lan_ips(peer).await
         } else {
             HashSet::new()
         };
 
-        Self::filter_address_set_for_receiver(addresses, allow_lan, &peer_lan_ips, own_wan_ips)
+        Self::filter_address_set_for_receiver(
+            addresses,
+            allow_lan,
+            supports_lan_wire,
+            &peer_lan_ips,
+            own_wan_ips,
+        )
     }
 
     async fn filter_address_set_for_peer_id(
@@ -2265,6 +2280,7 @@ impl DhtNetworkManager {
         peer_id: &PeerId,
         own_wan_ips: &HashSet<IpAddr>,
     ) -> Vec<(MultiAddr, AddressType)> {
+        let supports_lan_wire = self.peer_supports_lan_address_type(peer_id).await;
         let allow_lan = self
             .peer_id_can_receive_lan_addresses(peer_id, own_wan_ips)
             .await;
@@ -2274,12 +2290,19 @@ impl DhtNetworkManager {
             HashSet::new()
         };
 
-        Self::filter_address_set_for_receiver(addresses, allow_lan, &peer_lan_ips, own_wan_ips)
+        Self::filter_address_set_for_receiver(
+            addresses,
+            allow_lan,
+            supports_lan_wire,
+            &peer_lan_ips,
+            own_wan_ips,
+        )
     }
 
     fn filter_address_set_for_receiver(
         addresses: &[(MultiAddr, AddressType)],
         allow_lan: bool,
+        supports_lan_wire: bool,
         peer_lan_ips: &HashSet<IpAddr>,
         own_wan_ips: &HashSet<IpAddr>,
     ) -> Vec<(MultiAddr, AddressType)> {
@@ -2288,7 +2311,9 @@ impl DhtNetworkManager {
             .filter_map(|(addr, addr_type)| {
                 let socket = addr.dialable_socket_addr();
                 let local_scoped = socket.as_ref().is_some_and(is_lan_or_loopback_socket);
-                if (*addr_type == AddressType::Lan || local_scoped) && !allow_lan {
+                if (*addr_type == AddressType::Lan || local_scoped)
+                    && (!allow_lan || !supports_lan_wire)
+                {
                     return None;
                 }
 
@@ -2312,9 +2337,76 @@ impl DhtNetworkManager {
                     ));
                 }
 
-                Some((out, *addr_type))
+                let out_type = if local_scoped {
+                    AddressType::Lan
+                } else {
+                    *addr_type
+                };
+
+                Some((out, out_type))
             })
             .collect()
+    }
+
+    fn strip_lan_wire_addresses_for_legacy(
+        addresses: Vec<(MultiAddr, AddressType)>,
+    ) -> Vec<(MultiAddr, AddressType)> {
+        // TODO(0.26): remove this backwards-compatible legacy stripping once
+        // all supported peers can deserialize `AddressType::Lan`.
+        addresses
+            .into_iter()
+            .filter(|(addr, addr_type)| {
+                *addr_type != AddressType::Lan
+                    && !addr
+                        .dialable_socket_addr()
+                        .is_some_and(|socket| is_lan_or_loopback_socket(&socket))
+            })
+            .collect()
+    }
+
+    fn strip_lan_node_for_legacy(node: &mut DHTNode) {
+        let filtered = Self::strip_lan_wire_addresses_for_legacy(node.typed_addresses());
+        node.addresses = filtered.iter().map(|(addr, _)| addr.clone()).collect();
+        node.address_types = filtered.iter().map(|(_, ty)| *ty).collect();
+    }
+
+    fn strip_lan_result_for_legacy(result: DhtNetworkResult) -> DhtNetworkResult {
+        match result {
+            DhtNetworkResult::NodesFound { key, mut nodes } => {
+                for node in &mut nodes {
+                    Self::strip_lan_node_for_legacy(node);
+                }
+                nodes.retain(|node| !node.addresses.is_empty());
+                DhtNetworkResult::NodesFound { key, nodes }
+            }
+            other => other,
+        }
+    }
+
+    fn strip_lan_operation_for_legacy(operation: DhtNetworkOperation) -> DhtNetworkOperation {
+        match operation {
+            DhtNetworkOperation::PublishAddressSet { seq, addresses } => {
+                DhtNetworkOperation::PublishAddressSet {
+                    seq,
+                    addresses: Self::strip_lan_wire_addresses_for_legacy(addresses),
+                }
+            }
+            other => other,
+        }
+    }
+
+    async fn sanitize_operation_for_peer(
+        &self,
+        peer_id: &PeerId,
+        operation: DhtNetworkOperation,
+    ) -> DhtNetworkOperation {
+        // TODO(0.26): remove this compatibility branch and send the operation
+        // unchanged once live 0.24.0 nodes are no longer supported.
+        if self.peer_supports_lan_address_type(peer_id).await {
+            operation
+        } else {
+            Self::strip_lan_operation_for_legacy(operation)
+        }
     }
 
     async fn filter_published_address_set_from_sender(
@@ -2659,6 +2751,7 @@ impl DhtNetworkManager {
         self.sweep_expired_operations();
 
         let message_id = Uuid::new_v4().to_string();
+        let operation = self.sanitize_operation_for_peer(peer_id, operation).await;
 
         let message = DhtNetworkMessage {
             message_id: message_id.clone(),
@@ -3127,7 +3220,9 @@ impl DhtNetworkManager {
                     sender,
                     message.message_id
                 );
-                let response = self.create_response_message(&message, result)?;
+                let response = self
+                    .create_response_message(&message, result, sender)
+                    .await?;
                 Ok(Some(postcard::to_stdvec(&response).map_err(|e| {
                     P2PError::Serialization(e.to_string().into())
                 })?))
@@ -3330,14 +3425,22 @@ impl DhtNetworkManager {
     }
 
     /// Create response message
-    fn create_response_message(
+    async fn create_response_message(
         &self,
         request: &DhtNetworkMessage,
         result: DhtNetworkResult,
+        response_peer: &PeerId,
     ) -> Result<DhtNetworkMessage> {
+        let supports_lan_wire = self.peer_supports_lan_address_type(response_peer).await;
+        let result = if supports_lan_wire {
+            result
+        } else {
+            Self::strip_lan_result_for_legacy(result)
+        };
+
         // Create a minimal payload that echoes the original operation type
         // Each variant explicitly extracts its key to avoid silent fallbacks
-        let payload = match &result {
+        let mut payload = match &result {
             DhtNetworkResult::NodesFound { key, .. } => DhtNetworkOperation::FindNode { key: *key },
             DhtNetworkResult::PongReceived { .. } => DhtNetworkOperation::Ping,
             DhtNetworkResult::JoinSuccess { .. } => DhtNetworkOperation::Join,
@@ -3352,6 +3455,9 @@ impl DhtNetworkManager {
                 )));
             }
         };
+        if !supports_lan_wire {
+            payload = Self::strip_lan_operation_for_legacy(payload);
+        }
 
         Ok(DhtNetworkMessage {
             message_id: request.message_id.clone(),
@@ -4649,6 +4755,99 @@ mod tests {
             .collect()
     }
 
+    #[allow(dead_code)]
+    #[derive(Debug, serde::Deserialize)]
+    enum LegacyAddressType {
+        Relay,
+        Direct,
+        Unverified,
+        NATted,
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, serde::Deserialize)]
+    struct LegacyDhtNode {
+        peer_id: PeerId,
+        addresses: Vec<MultiAddr>,
+        address_types: Vec<LegacyAddressType>,
+        distance: Option<Vec<u8>>,
+        reliability: f64,
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, serde::Deserialize)]
+    enum LegacyDhtNetworkOperation {
+        FindNode {
+            key: Key,
+        },
+        Ping,
+        Join,
+        Leave,
+        PublishAddressSet {
+            seq: u64,
+            addresses: Vec<(MultiAddr, LegacyAddressType)>,
+        },
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, serde::Deserialize)]
+    enum LegacyDhtNetworkResult {
+        NodesFound {
+            key: Key,
+            nodes: Vec<LegacyDhtNode>,
+        },
+        PongReceived {
+            responder: PeerId,
+            latency: Duration,
+        },
+        JoinSuccess {
+            assigned_key: Key,
+            bootstrap_peers: usize,
+        },
+        LeaveSuccess,
+        PeerRejected,
+        PublishAddressAck,
+        Error {
+            operation: String,
+            error: String,
+        },
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, serde::Deserialize)]
+    struct LegacyDhtNetworkMessage {
+        message_id: String,
+        source: PeerId,
+        target: Option<PeerId>,
+        message_type: DhtMessageType,
+        payload: LegacyDhtNetworkOperation,
+        result: Option<LegacyDhtNetworkResult>,
+        timestamp: u64,
+        ttl: u8,
+        hop_count: u8,
+    }
+
+    fn test_wire_message(
+        payload: DhtNetworkOperation,
+        result: Option<DhtNetworkResult>,
+    ) -> DhtNetworkMessage {
+        DhtNetworkMessage {
+            message_id: "compat-test".to_string(),
+            source: PeerId::from_bytes([1u8; 32]),
+            target: Some(PeerId::from_bytes([2u8; 32])),
+            message_type: if result.is_some() {
+                DhtMessageType::Response
+            } else {
+                DhtMessageType::Request
+            },
+            payload,
+            result,
+            timestamp: 1,
+            ttl: 10,
+            hop_count: 0,
+        }
+    }
+
     #[test]
     fn select_dial_candidates_returns_empty_for_empty_input() {
         let picks = DhtNetworkManager::select_dial_candidates(&[]);
@@ -4812,6 +5011,7 @@ mod tests {
         let filtered = DhtNetworkManager::filter_address_set_for_receiver(
             &addrs,
             false,
+            true,
             &HashSet::new(),
             &HashSet::new(),
         );
@@ -4857,6 +5057,7 @@ mod tests {
         let filtered = DhtNetworkManager::filter_address_set_for_receiver(
             &addrs,
             true,
+            true,
             &HashSet::new(),
             &own_wan_ips,
         );
@@ -4872,6 +5073,7 @@ mod tests {
         let filtered = DhtNetworkManager::filter_address_set_for_receiver(
             &addrs,
             true,
+            true,
             &peer_lan_ips,
             &HashSet::new(),
         );
@@ -4881,6 +5083,117 @@ mod tests {
             "/ip4/127.0.0.1/udp/9000/quic".parse::<MultiAddr>().unwrap()
         );
         assert_eq!(filtered[0].1, AddressType::Lan);
+    }
+
+    #[test]
+    fn filter_address_set_drops_lan_when_receiver_is_legacy() {
+        let addrs = typed(vec![
+            ("/ip4/10.0.0.7/udp/9000/quic", AddressType::Lan),
+            ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
+        ]);
+        let peer_lan_ips = HashSet::from([IpAddr::V4(Ipv4Addr::new(10, 0, 0, 7))]);
+        let filtered = DhtNetworkManager::filter_address_set_for_receiver(
+            &addrs,
+            true,
+            false,
+            &peer_lan_ips,
+            &HashSet::new(),
+        );
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].1, AddressType::Direct);
+    }
+
+    #[test]
+    fn strip_lan_wire_addresses_for_legacy_removes_lan_and_local_scoped() {
+        let addrs = typed(vec![
+            ("/ip4/10.0.0.7/udp/9000/quic", AddressType::Lan),
+            ("/ip4/127.0.0.1/udp/9001/quic", AddressType::Unverified),
+            ("/ip4/203.0.113.7/udp/9002/quic", AddressType::Direct),
+        ]);
+
+        let filtered = DhtNetworkManager::strip_lan_wire_addresses_for_legacy(addrs);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].1, AddressType::Direct);
+    }
+
+    #[test]
+    fn legacy_wire_decoder_rejects_unsanitized_lan_publish_address_set() {
+        let message = test_wire_message(
+            DhtNetworkOperation::PublishAddressSet {
+                seq: 1,
+                addresses: typed(vec![("/ip4/10.0.0.7/udp/9000/quic", AddressType::Lan)]),
+            },
+            None,
+        );
+        let bytes = postcard::to_stdvec(&message).expect("serialize current wire message");
+
+        let legacy = postcard::from_bytes::<LegacyDhtNetworkMessage>(&bytes);
+
+        assert!(
+            legacy.is_err(),
+            "legacy 0.24.0-shaped decoder must reject unsanitized AddressType::Lan"
+        );
+    }
+
+    #[test]
+    fn legacy_wire_decoder_accepts_sanitized_publish_address_set() {
+        let payload = DhtNetworkManager::strip_lan_operation_for_legacy(
+            DhtNetworkOperation::PublishAddressSet {
+                seq: 1,
+                addresses: typed(vec![
+                    ("/ip4/10.0.0.7/udp/9000/quic", AddressType::Lan),
+                    ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
+                ]),
+            },
+        );
+        let message = test_wire_message(payload, None);
+        let bytes = postcard::to_stdvec(&message).expect("serialize sanitized wire message");
+
+        let legacy =
+            postcard::from_bytes::<LegacyDhtNetworkMessage>(&bytes).expect("legacy decode");
+
+        match legacy.payload {
+            LegacyDhtNetworkOperation::PublishAddressSet { addresses, .. } => {
+                assert_eq!(addresses.len(), 1);
+                assert!(matches!(addresses[0].1, LegacyAddressType::Direct));
+            }
+            other => panic!("expected legacy PublishAddressSet, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn legacy_wire_decoder_accepts_sanitized_nodes_found_response() {
+        let key = [9u8; 32];
+        let mut result = DhtNetworkResult::NodesFound {
+            key,
+            nodes: vec![dht_node(
+                7,
+                vec![
+                    ("/ip4/10.0.0.7/udp/9000/quic", AddressType::Lan),
+                    ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
+                ],
+            )],
+        };
+        result = DhtNetworkManager::strip_lan_result_for_legacy(result);
+        let message = test_wire_message(DhtNetworkOperation::FindNode { key }, Some(result));
+        let bytes = postcard::to_stdvec(&message).expect("serialize sanitized response");
+
+        let legacy =
+            postcard::from_bytes::<LegacyDhtNetworkMessage>(&bytes).expect("legacy decode");
+
+        match legacy.result {
+            Some(LegacyDhtNetworkResult::NodesFound { nodes, .. }) => {
+                assert_eq!(nodes.len(), 1);
+                assert_eq!(nodes[0].addresses.len(), 1);
+                assert!(matches!(
+                    nodes[0].address_types[0],
+                    LegacyAddressType::Direct
+                ));
+            }
+            other => panic!("expected legacy NodesFound result, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/network.rs
+++ b/src/network.rs
@@ -21,7 +21,11 @@ use crate::adaptive::trust::{TrustRecord, TrustSnapshot};
 use crate::adaptive::{AdaptiveDHT, AdaptiveDhtConfig, TrustEngine, TrustEvent};
 use crate::bootstrap::cache::{CachedCloseGroupPeer, CloseGroupCache};
 use crate::bootstrap::{BootstrapConfig, BootstrapManager};
-use crate::dht_network_manager::{DhtNetworkConfig, DhtNetworkEvent, DhtNetworkManager};
+use crate::dht::AddressType;
+use crate::dht_network_manager::{
+    DhtNetworkConfig, DhtNetworkEvent, DhtNetworkManager, is_lan_or_loopback_socket,
+    socket_ip_in_set,
+};
 use crate::error::{IdentityError, NetworkError, P2PError, P2pResult as Result};
 use crate::reachability::spawn_acquisition_driver;
 
@@ -1267,13 +1271,6 @@ impl P2PNode {
                                 advertised_addr,
                                 peer_addr.ip() == advertised_addr.ip()
                             );
-                            // Only update DHT when the advertised IP differs
-                            // from the peer's connection IP. Same-IP updates
-                            // are just different NATted ports (useless for
-                            // symmetric NAT); different-IP means a relay.
-                            if peer_addr.ip() == advertised_addr.ip() {
-                                continue;
-                            }
                             // Look up peer ID by address (tries both IPv4 and
                             // IPv4-mapped IPv6 forms via dual_stack_alternate).
                             // For symmetric NAT, this may fail because the
@@ -1281,15 +1278,68 @@ impl P2PNode {
                             if let Some(peer_id) = transport.peer_id_for_addr(&peer_addr).await {
                                 let normalized_adv =
                                     saorsa_transport::shared::normalize_socket_addr(advertised_addr);
-                                let multi_addr = crate::MultiAddr::quic(normalized_adv);
+                                let own_wan_ips =
+                                    DhtNetworkManager::own_direct_wan_ips_from_transport(&transport);
+                                let advertised_is_lan = is_lan_or_loopback_socket(&normalized_adv);
+                                let peer_is_lan = is_lan_or_loopback_socket(&peer_addr);
+                                let peer_same_wan = socket_ip_in_set(&peer_addr, &own_wan_ips);
+
+                                if advertised_is_lan {
+                                    if !(peer_is_lan || peer_same_wan) {
+                                        debug!(
+                                            "Ignoring LAN address {} from peer {} over different WAN {}",
+                                            normalized_adv, peer_id, peer_addr
+                                        );
+                                        continue;
+                                    }
+
+                                    let lan_addr =
+                                        DhtNetworkManager::maybe_swap_same_lan_ip_to_loopback(
+                                            &transport,
+                                            normalized_adv,
+                                        )
+                                        .await;
+                                    let multi_addr = MultiAddr::quic(lan_addr);
+                                    info!(
+                                        "Updating DHT: peer {} LAN address {} (connection was {})",
+                                        peer_id, lan_addr, peer_addr
+                                    );
+                                    dht.touch_node_typed(
+                                        &peer_id,
+                                        Some(&multi_addr),
+                                        AddressType::Lan,
+                                    )
+                                    .await;
+                                    continue;
+                                }
+
+                                // Same-IP non-LAN updates are just different
+                                // NATted ports (useless for symmetric NAT).
+                                if peer_addr.ip() == normalized_adv.ip() {
+                                    continue;
+                                }
+
+                                // A relay address on our own observed WAN IP is
+                                // a same-NAT hairpin candidate. Keep it out of
+                                // the routing record so dialers try the peer's
+                                // direct or unverified path instead.
+                                if socket_ip_in_set(&normalized_adv, &own_wan_ips) {
+                                    debug!(
+                                        "Ignoring relay address {} for peer {} because it is on our WAN",
+                                        normalized_adv, peer_id
+                                    );
+                                    continue;
+                                }
+
+                                let multi_addr = MultiAddr::quic(normalized_adv);
                                 info!(
                                     "Updating DHT: peer {} relay address {} (connection was {})",
-                                    peer_id, advertised_addr, peer_addr
+                                    peer_id, normalized_adv, peer_addr
                                 );
                                 dht.touch_node_typed(
                                     &peer_id,
                                     Some(&multi_addr),
-                                    crate::dht::AddressType::Relay,
+                                    AddressType::Relay,
                                 )
                                 .await;
                             }

--- a/src/network.rs
+++ b/src/network.rs
@@ -62,8 +62,9 @@ pub(crate) struct WireMessage {
     pub(crate) timestamp: u64,
     /// User agent string identifying the sender's software.
     ///
-    /// Convention: `"node/<version>"` for full DHT participants,
-    /// `"client/<version>"` or `"<app>/<version>"` for ephemeral clients.
+    /// Convention: `"node/<version> [capability...]"` for full DHT
+    /// participants, `"client/<version> [capability...]"` or
+    /// `"<app>/<version> [capability...]"` for ephemeral clients.
     /// Included in the signed bytes — tamper-proof.
     #[serde(default)]
     pub(crate) user_agent: String,
@@ -98,21 +99,43 @@ enum ListenMode {
     Local,
 }
 
+/// User-agent capability token for peers that can deserialize
+/// `AddressType::Lan`.
+///
+/// Nodes that do not advertise this token must not receive `AddressType::Lan`,
+/// because older 0.24.0 binaries cannot deserialize that enum variant.
+/// TODO(0.26): remove this backwards-compatibility capability gate once all
+/// supported live nodes can decode `AddressType::Lan`.
+pub const LAN_ADDRESS_CAPABILITY: &str = "lanaddr/1";
+
 /// Returns the default user agent string for the given mode.
 ///
-/// - `Node` → `"node/<saorsa-core-version>"`
-/// - `Client` → `"client/<saorsa-core-version>"`
+/// - `Node` → `"node/<saorsa-core-version> lanaddr/1"`
+/// - `Client` → `"client/<saorsa-core-version> lanaddr/1"`
 pub fn user_agent_for_mode(mode: NodeMode) -> String {
     let prefix = match mode {
         NodeMode::Node => "node",
         NodeMode::Client => "client",
     };
-    format!("{prefix}/{}", env!("CARGO_PKG_VERSION"))
+    format!(
+        "{prefix}/{} {}",
+        env!("CARGO_PKG_VERSION"),
+        LAN_ADDRESS_CAPABILITY
+    )
 }
 
 /// Returns `true` if the user agent identifies a full DHT participant (prefix `"node/"`).
 pub fn is_dht_participant(user_agent: &str) -> bool {
     user_agent.starts_with("node/")
+}
+
+/// Returns `true` when a peer explicitly supports the LAN address wire
+/// variant. Old live nodes advertise `node/0.24.0` without this token, so they
+/// are treated as legacy even if they are on the same NAT.
+pub fn supports_lan_address_type(user_agent: &str) -> bool {
+    user_agent
+        .split(|c: char| c.is_whitespace() || c == ',' || c == ';')
+        .any(|token| token == LAN_ADDRESS_CAPABILITY)
 }
 
 /// Capacity of the internal channel used by the message receiving system.
@@ -227,8 +250,8 @@ pub struct NodeConfig {
     /// Operating mode of this node.
     ///
     /// Determines the default user agent and DHT participation:
-    /// - `Node` → user agent `"node/<version>"`, added to DHT routing tables.
-    /// - `Client` → user agent `"client/<version>"`, treated as ephemeral.
+    /// - `Node` → user agent `"node/<version> lanaddr/1"`, added to DHT routing tables.
+    /// - `Client` → user agent `"client/<version> lanaddr/1"`, treated as ephemeral.
     #[serde(default)]
     pub mode: NodeMode,
 
@@ -698,7 +721,8 @@ pub enum P2PEvent {
         data: Vec<u8>,
     },
     /// An authenticated peer has connected (first signed message verified on any channel).
-    /// The `user_agent` identifies the remote software (e.g. `"node/0.12.1"`, `"client/1.0"`).
+    /// The `user_agent` identifies the remote software and capabilities
+    /// (e.g. `"node/0.24.1 lanaddr/1"`, `"client/1.0"`).
     PeerConnected(PeerId, String),
     /// An authenticated peer has fully disconnected (all channels closed).
     PeerDisconnected(PeerId),
@@ -2464,6 +2488,20 @@ mod tests {
         assert_eq!(config.k_value, 20);
         assert_eq!(config.alpha_value, 3);
         assert_eq!(config.refresh_interval, Duration::from_secs(600));
+    }
+
+    #[test]
+    fn default_user_agent_advertises_lan_address_capability() {
+        let user_agent = user_agent_for_mode(NodeMode::Node);
+
+        assert!(user_agent.starts_with("node/"));
+        assert!(supports_lan_address_type(&user_agent));
+    }
+
+    #[test]
+    fn old_live_user_agent_is_legacy_for_lan_address_wire_type() {
+        assert!(!supports_lan_address_type("node/0.24.0"));
+        assert!(supports_lan_address_type("node/0.24.0 lanaddr/1"));
     }
 
     #[test]

--- a/src/reachability/driver.rs
+++ b/src/reachability/driver.rs
@@ -59,7 +59,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace, warn};
 
 use crate::dht::AddressType;
-use crate::dht_network_manager::{DhtNetworkEvent, DhtNetworkManager};
+use crate::dht_network_manager::{DhtNetworkEvent, DhtNetworkManager, is_lan_or_loopback_socket};
 use crate::reachability::session::{RelayAcquisitionOutcome, run_relay_acquisition};
 use crate::transport_handle::TransportHandle;
 use crate::{MultiAddr, PeerId};
@@ -220,32 +220,45 @@ impl AcquisitionDriver {
         // different representations.
         let mut seen: HashSet<SocketAddr> = HashSet::new();
 
-        if let Some(tag) = direct_tag {
-            // Prefer observed (post-NAT) addresses for the direct tier since
-            // those are what peers actually see from the outside. Fall back
-            // to locally-bound listen addresses when no observations exist.
-            if !observed.is_empty() {
-                for sa in observed {
-                    if sa.ip().is_unspecified() {
-                        continue;
-                    }
-                    let normalized = saorsa_transport::shared::normalize_socket_addr(sa);
-                    if seen.insert(normalized) {
-                        typed.push((MultiAddr::quic(normalized), tag));
-                    }
-                }
-            }
-            for addr in listen {
-                let Some(sa) = addr.dialable_socket_addr() else {
-                    continue;
-                };
+        // Prefer observed (post-NAT) addresses for the direct tier since
+        // those are what peers actually see from the outside. LAN-scoped
+        // observations and listen sockets are tagged separately and only
+        // published to peers on the same WAN by `publish_address_set_to_peers`.
+        if !observed.is_empty() {
+            for sa in observed {
                 if sa.ip().is_unspecified() {
                     continue;
                 }
                 let normalized = saorsa_transport::shared::normalize_socket_addr(sa);
-                if seen.insert(normalized) {
+                let addr_type = if is_lan_or_loopback_socket(&normalized) {
+                    Some(AddressType::Lan)
+                } else {
+                    direct_tag
+                };
+                if let Some(tag) = addr_type
+                    && seen.insert(normalized)
+                {
                     typed.push((MultiAddr::quic(normalized), tag));
                 }
+            }
+        }
+        for addr in listen {
+            let Some(sa) = addr.dialable_socket_addr() else {
+                continue;
+            };
+            if sa.ip().is_unspecified() {
+                continue;
+            }
+            let normalized = saorsa_transport::shared::normalize_socket_addr(sa);
+            let addr_type = if is_lan_or_loopback_socket(&normalized) {
+                Some(AddressType::Lan)
+            } else {
+                direct_tag
+            };
+            if let Some(tag) = addr_type
+                && seen.insert(normalized)
+            {
+                typed.push((MultiAddr::quic(normalized), tag));
             }
         }
 

--- a/src/reachability/session.rs
+++ b/src/reachability/session.rs
@@ -94,11 +94,13 @@ pub(crate) async fn run_relay_acquisition(
 
     let own_key = *dht.peer_id().to_bytes();
     let closest = dht.find_closest_nodes_local(&own_key, dht.k_value()).await;
+    let own_wan_ips = DhtNetworkManager::own_direct_wan_ips_from_transport(transport);
 
     let candidates: Vec<RelayCandidate> = closest
         .iter()
         .filter_map(|node| {
-            let direct = DhtNetworkManager::first_direct_dialable(node)?;
+            let direct =
+                DhtNetworkManager::first_direct_dialable_excluding_wan(node, &own_wan_ips)?;
             Some(RelayCandidate::new(node.peer_id, direct))
         })
         .collect();


### PR DESCRIPTION
## Summary
- Adds `AddressType::Lan` as a new highest-priority address slot so same-LAN peers retain a fast local path alongside their relay/direct/unverified/NATted entries (one extra slot per IP family, capped at 3).
- Filters LAN-tagged entries on publish, gossip-merge, find-node response, and dial selection so they only reach receivers we believe share our LAN/WAN; rewrites our own LAN IP to loopback for the receiver where appropriate.
- Drops relay candidates that resolve to our own observed WAN IP (same-NAT hairpin) so dialers fall through to the peer's direct/unverified path.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` (379 passed)
- [ ] Validate same-LAN dial path on a real two-node setup
- [ ] Validate same-NAT hairpin avoidance on a real two-node setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)