### PR TITLE
Revert #102: Kademlia lookup limit tightening

### DIFF
--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -1598,7 +1598,7 @@ impl DhtNetworkManager {
         key: &Key,
         count: usize,
     ) -> Result<Vec<DHTNode>> {
-        const MAX_ITERATIONS: usize = 12;
+        const MAX_ITERATIONS: usize = 20;
         const ALPHA: usize = 3; // Parallel queries per iteration
 
         debug!(
@@ -3955,11 +3955,11 @@ const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 15;
 /// proceed. Once the first response is in, we have new candidates for the
 /// next iteration and can safely cap the wait on the stragglers.
 ///
-/// Sized at 2s: a peer with an already-open channel replies in well under
+/// Sized at 5s: a peer with an already-open channel replies in well under
 /// a second, so this leaves ample slack for legitimate stragglers while
 /// letting us abandon dial cascades that are almost certainly going to
 /// fail anyway.
-const ITERATION_GRACE_TIMEOUT_SECS: u64 = 2;
+const ITERATION_GRACE_TIMEOUT_SECS: u64 = 5;
 
 /// Default maximum concurrent DHT operations
 const DEFAULT_MAX_CONCURRENT_OPS: usize = 100;


### PR DESCRIPTION
## Summary
- Reverts PR #102 (`tune/kademlia-iteration-limits`), which has shown negative effects in practice.
- Restores `MAX_ITERATIONS = 20` (from 12) and `ITERATION_GRACE_TIMEOUT_SECS = 5` (from 2) in `find_closest_nodes_network`.

The tighter caps were intended to abandon stalled dial cascades sooner, but in real-world conditions they reduced lookup convergence enough to be net-negative. Reverting to the previous, known-good values.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts the two Kademlia lookup-limit changes from PR #102: `MAX_ITERATIONS` is restored to 20 (from 12) and `ITERATION_GRACE_TIMEOUT_SECS` is restored to 5 (from 2). The doc comment for `ITERATION_GRACE_TIMEOUT_SECS` is correctly updated to reflect the restored 5s value. The revert is minimal, consistent, and well-motivated by observed real-world convergence regressions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a clean, minimal revert of two well-understood constants with no logic changes.

Only two constant values and one doc comment are changed. Both values are being restored to previously known-good settings, and the doc comment accurately describes the restored 5s grace timeout. No functional logic is introduced or removed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dht_network_manager.rs | Reverts MAX_ITERATIONS from 12→20 and ITERATION_GRACE_TIMEOUT_SECS from 2→5; updates the doc comment to match the restored 5s value. Clean revert with no other modifications. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant F as find_closest_nodes_network
    participant P as Peer (alpha=3 parallel)

    C->>F: find_closest_nodes_network(key, count)
    loop Up to MAX_ITERATIONS=20 (restored from 12)
        F->>P: Query alpha=3 candidates
        Note over F,P: Wait for first response, then grace period 5s (restored from 2s)
        P-->>F: FindNode responses
        F->>F: Merge candidates, check convergence
        alt Stagnation or No candidates
            F->>F: Break early
        end
    end
    F-->>C: top-K closest DHTNodes
```

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;Merge pull request #102 from sao..."](https://github.com/saorsa-labs/saorsa-core/commit/51f0c834530820b1b3eebe0395f8e7a9dfdb645e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30167698)</sub>

<!-- /greptile_comment -->