### PR TITLE
chore(release): promote rc-2026.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,9 +260,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1528,6 +1528,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2258,9 +2288,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -2278,7 +2308,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -2398,7 +2428,28 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -2472,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.24.0"
+version = "0.24.1-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2621,7 +2672,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "rustls-post-quantum",
  "saorsa-pqc 0.4.2",
  "serde",
@@ -2811,6 +2862,22 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -3377,9 +3444,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3390,9 +3457,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3400,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3410,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3423,9 +3490,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -3466,9 +3533,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.24.1-rc.2"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.24.1-rc.1"
+version = "0.24.1-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "saorsa-core"
 # 0.22.0: MASQUE relay data plane, upgrade saorsa-transport to 0.31.0
 # 0.24.0-rc.1: release candidate for rc-2026.4.2
 # 0.24.0: upgrade saorsa-transport to 0.33.0
-version = "0.24.1-rc.1"
+version = "0.24.1-rc.2"
 edition = "2024"
 authors = ["Saorsa Labs Limited <david@saorsalabs.com>"]
 license = "AGPL-3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ name = "saorsa-core"
 # 0.20.0: simplify IP diversity, stale-peer fixes, cache atomicity improvements
 # 0.21.0: penalty-only trust model, distance-sorted lookup candidates, stale docs cleanup
 # 0.22.0: MASQUE relay data plane, upgrade saorsa-transport to 0.31.0
-# 0.24.0-rc.1: release candidate for rc-2026.4.2
 # 0.24.0: upgrade saorsa-transport to 0.33.0
-version = "0.24.1-rc.2"
+# 0.24.1: release candidate fixes
+version = "0.24.1"
 edition = "2024"
 authors = ["Saorsa Labs Limited <david@saorsalabs.com>"]
 license = "AGPL-3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "saorsa-core"
 # 0.22.0: MASQUE relay data plane, upgrade saorsa-transport to 0.31.0
 # 0.24.0-rc.1: release candidate for rc-2026.4.2
 # 0.24.0: upgrade saorsa-transport to 0.33.0
-version = "0.24.0"
+version = "0.24.1-rc.1"
 edition = "2024"
 authors = ["Saorsa Labs Limited <david@saorsalabs.com>"]
 license = "AGPL-3.0"

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -1598,7 +1598,7 @@ impl DhtNetworkManager {
         key: &Key,
         count: usize,
     ) -> Result<Vec<DHTNode>> {
-        const MAX_ITERATIONS: usize = 12;
+        const MAX_ITERATIONS: usize = 20;
         const ALPHA: usize = 3; // Parallel queries per iteration
 
         debug!(
@@ -3955,11 +3955,11 @@ const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 15;
 /// proceed. Once the first response is in, we have new candidates for the
 /// next iteration and can safely cap the wait on the stragglers.
 ///
-/// Sized at 2s: a peer with an already-open channel replies in well under
+/// Sized at 5s: a peer with an already-open channel replies in well under
 /// a second, so this leaves ample slack for legitimate stragglers while
 /// letting us abandon dial cascades that are almost certainly going to
 /// fail anyway.
-const ITERATION_GRACE_TIMEOUT_SECS: u64 = 2;
+const ITERATION_GRACE_TIMEOUT_SECS: u64 = 5;
 
 /// Default maximum concurrent DHT operations
 const DEFAULT_MAX_CONCURRENT_OPS: usize = 100;


### PR DESCRIPTION
Promotes `rc-2026.4.3` to release version 0.24.1.

- strips `-rc.*` from `[package].version`
- rewrites `saorsa-transport` git+branch dep to crates.io version pin (0.33.0)
- regenerates `Cargo.lock`

Once merged, the `v0.24.1` tag will be pushed to fire the publish workflow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release promotion bumps `saorsa-core` from `0.24.0` to `0.24.1`, pins `saorsa-transport` to the crates.io `0.33.0` release, and regenerates `Cargo.lock` with several transitive dependency updates (blake3, rustls, reqwest, wasm-bindgen). The only functional change carried over from the RC branch is DHT lookup tuning: `MAX_ITERATIONS` raised from 12 → 20 and `ITERATION_GRACE_TIMEOUT_SECS` raised from 2 → 5, neither of which is mentioned in the PR description.

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are a version bump, lock file refresh, and conservative DHT tuning with no correctness regressions.

Only P2 findings: a minor comment wording issue in Cargo.toml and a note about increased worst-case lookup latency that is unlikely to cause real problems given independent request timeouts elsewhere.

src/dht_network_manager.rs — confirm call-sites have outer timeouts to bound worst-case 100 s lookup duration.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Version bumped from 0.24.0 to 0.24.1; saorsa-transport dep already pinned to crates.io 0.33.0; minor changelog comment inaccuracy |
| Cargo.lock | Lock file regenerated; saorsa-core bumped to 0.24.1; several transitive deps updated (blake3, rustls, reqwest, wasm-bindgen); two versions of rustls-platform-verifier coexist (0.6.2 for saorsa-transport, 0.7.0 for reqwest 0.13.3) — expected and correct |
| src/dht_network_manager.rs | MAX_ITERATIONS increased 12→20 and ITERATION_GRACE_TIMEOUT_SECS increased 2→5; functional tuning changes not mentioned in PR description; worst-case lookup duration rises substantially |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[find_closest_nodes_network] --> B[Seed with local candidates]
    B --> C{Iteration ≤ MAX_ITERATIONS\nnow 20, was 12}
    C -- yes --> D[Pick up to ALPHA=3\nunqueried candidates]
    D --> E[Send parallel RPCs]
    E --> F{First response\narrived?}
    F -- yes --> G[Wait ITERATION_GRACE_TIMEOUT_SECS\nfor stragglers\nnow 5s, was 2s]
    G --> H[Merge new candidates\nUpdate subject_reports]
    H --> I{Converged?\nno closer nodes found}
    I -- no --> C
    I -- yes --> J[Return best K nodes]
    C -- no more iterations --> J
    F -- timeout --> J
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Cargo.toml:24
**Inaccurate version changelog comment**

The comment `# 0.24.1: release candidate fixes` describes this version as "release candidate fixes," but 0.24.1 is the final release being promoted from the RC. A more accurate description would reflect the actual changes shipped in this version (DHT iteration/timeout tuning), rather than characterising them as RC fixes.

### Issue 2 of 2
src/dht_network_manager.rs:1601-1602
**Worst-case lookup duration increases significantly**

With `MAX_ITERATIONS` raised to 20 and `ITERATION_GRACE_TIMEOUT_SECS` raised to 5, the upper-bound wait on a completely stalled lookup grows from ~24 s to ~100 s. In practice each iteration waits for `ALPHA = 3` parallel queries before the grace kicks in, so well-connected nodes won't be affected — but on a degraded or sparse network a caller awaiting `find_closest_nodes_network` could block for far longer than before. Worth confirming that call-sites have independent timeouts (e.g. `DEFAULT_REQUEST_TIMEOUT_SECS = 15`) that bound the overall operation, or that callers are prepared for the extended duration.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): promote rc-2026.4.3 to 0..."](https://github.com/saorsa-labs/saorsa-core/commit/fd60f8cb58b9df16709fd7b88ede27fd9cb64555) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30260380)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->