### PR TITLE
fix(dht): jitter the bucket-refresh interval to break startup-lockstep

### DIFF
--- a/docs/ROUTING_TABLE_DESIGN.md
+++ b/docs/ROUTING_TABLE_DESIGN.md
@@ -60,7 +60,7 @@ All parameters are configurable. Values below are a reference profile used for l
 | `EMA_ALPHA` | EMA smoothing factor — weight of each new observation (higher = faster response) | `0.3` |
 | `DECAY_LAMBDA` | Per-second exponential decay rate toward neutral (0.5) | `4.198e-6` |
 | `SELF_LOOKUP_INTERVAL` | Periodic self-lookup cadence (maintenance phase only; bootstrap self-lookups run back-to-back with no interval) | random in `[5 min, 10 min]` |
-| `BUCKET_REFRESH_INTERVAL` | Periodic refresh cadence for stale k-buckets | `10 min` |
+| `BUCKET_REFRESH_INTERVAL` | Periodic refresh cadence for stale k-buckets, randomised per cycle to break startup-lockstep across the network | random in `[7.5 min, 12.5 min]` |
 | `STALE_BUCKET_THRESHOLD` | Duration after which a bucket without activity is considered stale | `1 hour` |
 | `LIVE_THRESHOLD` | Duration of no contact after which a peer is considered stale for revalidation and loses trust protection | `15 min` |
 | `STALE_REVALIDATION_TIMEOUT` | Maximum time to wait for a stale peer's ping response during admission contention | `1s` |

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -150,8 +150,14 @@ const SELF_LOOKUP_INTERVAL_MIN: Duration = Duration::from_secs(300); // 5 minute
 /// Maximum self-lookup interval.
 const SELF_LOOKUP_INTERVAL_MAX: Duration = Duration::from_secs(600); // 10 minutes
 
-/// Periodic refresh cadence for stale k-buckets.
-const BUCKET_REFRESH_INTERVAL: Duration = Duration::from_secs(600); // 10 minutes
+/// Minimum periodic refresh cadence for stale k-buckets (randomized between
+/// min and max). Jittering this interval prevents 1000s of nodes that started
+/// in lockstep from all firing their bucket-refresh FIND_NODEs in the same
+/// second once their distant buckets cross [`STALE_BUCKET_THRESHOLD`].
+const BUCKET_REFRESH_INTERVAL_MIN: Duration = Duration::from_secs(450); // 7.5 minutes
+
+/// Maximum periodic refresh cadence for stale k-buckets.
+const BUCKET_REFRESH_INTERVAL_MAX: Duration = Duration::from_secs(750); // 12.5 minutes
 
 /// Routing table size below which automatic re-bootstrap is triggered.
 const AUTO_REBOOTSTRAP_THRESHOLD: usize = 3;
@@ -1149,7 +1155,8 @@ impl DhtNetworkManager {
 
     /// Spawn the periodic bucket refresh background task.
     ///
-    /// Every [`BUCKET_REFRESH_INTERVAL`], finds stale buckets (not refreshed
+    /// At a randomised interval between [`BUCKET_REFRESH_INTERVAL_MIN`] and
+    /// [`BUCKET_REFRESH_INTERVAL_MAX`], finds stale buckets (not refreshed
     /// within [`STALE_BUCKET_THRESHOLD`]) and performs a FIND_NODE lookup for
     /// a random key in each stale bucket's range. This populates stale buckets
     /// with fresh peers.
@@ -1160,8 +1167,13 @@ impl DhtNetworkManager {
 
         let handle = tokio::spawn(async move {
             loop {
+                let interval = Self::randomised_interval(
+                    BUCKET_REFRESH_INTERVAL_MIN,
+                    BUCKET_REFRESH_INTERVAL_MAX,
+                );
+
                 tokio::select! {
-                    () = tokio::time::sleep(BUCKET_REFRESH_INTERVAL) => {}
+                    () = tokio::time::sleep(interval) => {}
                     () = shutdown.cancelled() => break,
                 }
 


### PR DESCRIPTION
## Summary

The periodic bucket-refresh task in `DhtNetworkManager` sleeps for a fixed `BUCKET_REFRESH_INTERVAL` (10 min, no jitter). Combined with `STALE_BUCKET_THRESHOLD` (60 min), a fleet started in lockstep has every node trip into bucket-staleness simultaneously and then fire FIND_NODE + dial-all-discovered-peers for every stale bucket in the same second.

This PR jitters the refresh sleep using the same `randomised_interval(MIN, MAX)` helper that `spawn_self_lookup_task` already uses (5 / 10 min). For bucket refresh it picks `[7.5 min, 12.5 min]` — preserves the 10-min mean cadence while giving a 5-min smear window, which is enough to break lockstep on a fleet of ~1000 nodes.

## Why this surfaced now

The 60-min synchronicity has existed since the routing-table-design landing on 2026-03-30 (`a36ac44`), but was masked because gossip ingestion was bumping `last_refreshed` on the receiving bucket, so `stale_bucket_indices` returned empty and the periodic timer fired no-ops.

[`311e197 fix(dht): gate routing-table liveness on identity-confirmed activity`](https://github.com/saorsa-labs/saorsa-core/commit/311e19758492fdbb916c3d25a75d4aaf752819a7) (2026-04-27) correctly stopped gossip from refreshing those signals — that commit is right and should stay. What it did was unblock the periodic refresh worker so it fires for real, which exposed the latent jitter bug.

## Observed effect on STG-01

- 900 ant-node services across 67 VMs, all with `ActiveEnterTimestamp = 2026-04-30 19:29:36 UTC`.
- DHT lookup activity (Iteration-0 logs in Elasticsearch) jumped from baseline ~7/sec to ~550/sec at exactly **20:29:30** (+59m54s after start).
- Connection-registration logs (`saorsa_transport::high_level::endpoint`) jumped 20× in the same window.
- Network never returned to baseline; ~10× elevated load thereafter.
- Downstream effect: ant clients on 4 GB upload VMs OOM-killed (exit 137) once `ant`'s anon-RSS exceeded available memory under the slower DHT.

## Test plan

- [ ] CI green
- [ ] Re-run a multi-VM testnet (~900 nodes) on a binary built from this branch and confirm no synchronous +60-min cliff in node log volume / DHT lookup rate
- [ ] Spot-check one node's bucket-refresh wake-up timestamps to confirm the inter-cycle interval varies in `[450, 750]` seconds

## Notes

This is the minimal fix. There are two further levers in the same task that may or may not be worth pursuing in follow-up PRs, depending on whether the storm fully subsides with jitter alone:
1. Per-bucket inner pacing (small sleep between iterating stale buckets within one cycle)
2. Skip the post-FIND_NODE `dial_addresses` call — let connections establish lazily on first use rather than warming them eagerly. Larger design call, not a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a thundering-herd problem in `DhtNetworkManager` where all nodes that started in lockstep would simultaneously fire bucket-refresh FIND_NODE lookups once their buckets crossed `STALE_BUCKET_THRESHOLD` (60 min). The fix replaces the fixed `BUCKET_REFRESH_INTERVAL` (10 min) with a jittered range `[7.5 min, 12.5 min]` using the existing `randomised_interval` helper that `spawn_self_lookup_task` already uses, and updates the documentation table accordingly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, targeted fix with no new logic paths or error conditions introduced.

The change is two new Duration constants and a one-line call to an already-exercised helper (randomised_interval), mirroring exactly what spawn_self_lookup_task does. No new failure modes, no changes to the refresh work itself, documentation updated correctly.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dht_network_manager.rs | Replaces fixed BUCKET_REFRESH_INTERVAL with MIN/MAX pair and applies existing randomised_interval helper in spawn_bucket_refresh_task; logic is correct and consistent with the self-lookup pattern. |
| docs/ROUTING_TABLE_DESIGN.md | Documentation table updated to reflect the new randomised range [7.5 min, 12.5 min] for BUCKET_REFRESH_INTERVAL; accurately describes the new behaviour. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Node as DhtNetworkManager
    participant Timer as tokio::time::sleep
    participant Shutdown as CancellationToken
    participant DHT as Routing Table

    Note over Node: spawn_bucket_refresh_task starts
    loop Each refresh cycle
        Node->>Node: randomised_interval(7.5min, 12.5min)
        Node->>Timer: sleep(random interval)
        alt Timer fires
            Timer-->>Node: wake up
            Node->>DHT: stale_bucket_indices()
            DHT-->>Node: [stale indices]
            loop For each stale bucket
                Node->>DHT: FIND_NODE(random key in bucket range)
                DHT-->>Node: discovered peers
                Node->>Node: dial discovered peers
            end
        else Shutdown signalled
            Shutdown-->>Node: cancelled()
            Note over Node: break loop
        end
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(dht): jitter the bucket-refresh inte..."](https://github.com/saorsa-labs/saorsa-core/commit/6abffa3abf503eb1bfe64f5d74dde93ff3aefdd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30418806)</sub>

<!-- /greptile_comment -->