### PR TITLE
transport: per-address reachability proofs + dial/send hardening

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'rc-*' ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'rc-*' ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'rc-*' ]
   workflow_dispatch:
 
 concurrency:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.34.0"
-source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.4#4d0c4a868f208c288323c7b9a2c0d44c2f55173e"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.4#e0f7bcd2c7011f298a112f242656b2d3269aef43"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2637,9 +2637,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df373519d88540825f435bf3c5c6e300377871b28f16cdd461db3c3f4bb5323"
+version = "0.34.0"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.4#4d0c4a868f208c288323c7b9a2c0d44c2f55173e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3128,9 +3127,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ once_cell = "1.21"
 dashmap = "6"
 
 # Networking
-saorsa-transport = "0.33.0"
+saorsa-transport = { git = "https://github.com/saorsa-labs/saorsa-transport.git", branch = "rc-2026.4.4" }
 
 # Core-specific dependencies
 dirs = "6.0"

--- a/src/adaptive/dht.rs
+++ b/src/adaptive/dht.rs
@@ -21,6 +21,7 @@
 //! trust signals through [`AdaptiveDHT::report_trust_event`].
 
 use crate::adaptive::trust::{NodeStatisticsUpdate, TrustEngine};
+use crate::dht::core_engine::AddressType;
 use crate::dht_network_manager::{DhtNetworkConfig, DhtNetworkManager};
 use crate::{MultiAddr, PeerId};
 
@@ -247,13 +248,20 @@ impl AdaptiveDHT {
         self.dht_manager.trigger_self_lookup().await
     }
 
-    /// Look up connectable addresses for a peer.
+    /// Look up connectable typed addresses for a peer.
     ///
-    /// Checks the DHT routing table first, then falls back to the transport
-    /// layer. Returns an empty vec when the peer is unknown or has no dialable
-    /// addresses.
-    pub(crate) async fn peer_addresses_for_dial(&self, peer_id: &PeerId) -> Vec<MultiAddr> {
-        self.dht_manager.peer_addresses_for_dial(peer_id).await
+    /// Checks the DHT routing table first, then falls back to the
+    /// transport layer. Returns an empty vec when the peer is unknown
+    /// or has no dialable addresses. The per-address [`AddressType`]
+    /// tag is preserved so the dial path can log the kind on
+    /// success/failure.
+    pub(crate) async fn peer_addresses_for_dial_typed(
+        &self,
+        peer_id: &PeerId,
+    ) -> Vec<(MultiAddr, AddressType)> {
+        self.dht_manager
+            .peer_addresses_for_dial_typed(peer_id)
+            .await
     }
 }
 

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -1273,7 +1273,7 @@ impl DhtCoreEngine {
 
     /// Get a peer's addresses paired with their [`AddressType`] tags.
     ///
-    /// Used by [`crate::dht_network_manager::DhtNetworkManager::peer_addresses_for_dial`]
+    /// Used by [`crate::dht_network_manager::DhtNetworkManager::peer_addresses_for_dial_typed`]
     /// to sort candidates by type priority (Relay first) per ADR-014.
     pub async fn get_node_addresses_typed(
         &self,

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -2141,7 +2141,7 @@ impl DhtNetworkManager {
         }
         let mut attempted = 0usize;
         let mut skipped_cached = 0usize;
-        for (addr, _ty) in &plan {
+        for (addr, ty) in &plan {
             attempted += 1;
             let Some(socket_addr) = addr.dialable_socket_addr() else {
                 continue;
@@ -2149,13 +2149,14 @@ impl DhtNetworkManager {
             if self.dial_failure_cache.is_failed(&socket_addr) {
                 skipped_cached += 1;
                 trace!(
-                    "dial_addresses: skipping recently failed address {} for {}",
+                    "dial_addresses: skipping recently failed address {} ({:?}) for {}",
                     addr,
+                    ty,
                     peer_id.to_hex()
                 );
                 continue;
             }
-            match self.dial_candidate(peer_id, addr).await {
+            match self.dial_candidate(peer_id, addr, *ty).await {
                 Some(channel_id) => {
                     self.dial_failure_cache.clear(&socket_addr);
                     return Some(channel_id);
@@ -2659,14 +2660,19 @@ impl DhtNetworkManager {
     /// [`TransportHandle::wait_for_peer_identity`] before sending, because
     /// the app-level `peer_to_channel` mapping is only populated after the
     /// asynchronous identity-exchange handshake completes.
-    async fn dial_candidate(&self, peer_id: &PeerId, address: &MultiAddr) -> Option<String> {
+    async fn dial_candidate(
+        &self,
+        peer_id: &PeerId,
+        address: &MultiAddr,
+        kind: AddressType,
+    ) -> Option<String> {
         let peer_hex = peer_id.to_hex();
 
         // Reject unspecified addresses before attempting the connection.
         if address.ip().is_some_and(|ip| ip.is_unspecified()) {
             debug!(
-                "dial_candidate: rejecting unspecified address for {}: {}",
-                peer_hex, address
+                "dial_candidate: rejecting unspecified address for {}: {} ({:?})",
+                peer_hex, address, kind
             );
             return None;
         }
@@ -2675,44 +2681,34 @@ impl DhtNetworkManager {
             .transport
             .connection_timeout()
             .min(self.config.request_timeout);
-        match tokio::time::timeout(dial_timeout, self.transport.connect_peer(address)).await {
+        match tokio::time::timeout(
+            dial_timeout,
+            self.transport.connect_peer_typed(address, kind),
+        )
+        .await
+        {
             Ok(Ok(channel_id)) => {
                 debug!(
-                    "dial_candidate: connected to {} at {} (channel {})",
-                    peer_hex, address, channel_id
+                    "dial_candidate: connected to {} at {} ({:?}) (channel {})",
+                    peer_hex, address, kind, channel_id
                 );
                 Some(channel_id)
             }
             Ok(Err(e)) => {
                 debug!(
-                    "dial_candidate: failed to connect to {} at {}: {}",
-                    peer_hex, address, e
+                    "dial_candidate: failed to connect to {} at {} ({:?}): {}",
+                    peer_hex, address, kind, e
                 );
                 None
             }
             Err(_) => {
                 debug!(
-                    "dial_candidate: timeout connecting to {} at {} (>{:?})",
-                    peer_hex, address, dial_timeout
+                    "dial_candidate: timeout connecting to {} at {} ({:?}) (>{:?})",
+                    peer_hex, address, kind, dial_timeout
                 );
                 None
             }
         }
-    }
-
-    /// Look up connectable addresses for `peer_id` as bare `MultiAddr`s.
-    ///
-    /// Thin wrapper over [`Self::peer_addresses_for_dial_typed`] for
-    /// callers that don't need the per-address type tag (e.g.,
-    /// `network.rs::first_dialable_peer_address`). Internally always
-    /// goes through the typed path so the Relay-first sort invariant
-    /// holds for both consumer styles.
-    pub(crate) async fn peer_addresses_for_dial(&self, peer_id: &PeerId) -> Vec<MultiAddr> {
-        self.peer_addresses_for_dial_typed(peer_id)
-            .await
-            .into_iter()
-            .map(|(addr, _ty)| addr)
-            .collect()
     }
 
     /// Look up connectable typed addresses for `peer_id`.

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -3325,7 +3325,7 @@ impl DhtNetworkManager {
                     }
                 }
                 Err(e) => {
-                    warn!(
+                    debug!(
                         "Failed to add peer {} to DHT routing table: {}",
                         app_peer_id_hex, e
                     );

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -1995,13 +1995,17 @@ impl DhtNetworkManager {
     async fn local_dht_node(&self) -> DHTNode {
         let mut addresses: Vec<MultiAddr> = Vec::new();
 
-        // 1. Pinned direct external addresses — the post-NAT addresses
-        //    peers observed from QUIC OBSERVED_ADDRESS frames during
-        //    bootstrap. Empty until at least one peer has observed us.
-        //    Uses `direct_external_addresses()` (not `observed_external_addresses()`)
-        //    because the relay address is published via the typed-set path
-        //    in the relay driver, not here.
-        for observed in self.transport.direct_external_addresses() {
+        // 1. Non-relay external addresses — pinned Direct (post-NAT
+        //    addresses peers observed via QUIC OBSERVED_ADDRESS during
+        //    bootstrap, quorum-cleared by the source-disjoint classifier)
+        //    plus single-peer Unverified candidates retained as a
+        //    fallback. Mirrors what the typed-publish path advertises so
+        //    a node behind NAT remains reachable via the OBSERVED_ADDRESS
+        //    hint before it crosses the Direct proof threshold. Empty
+        //    until at least one peer has observed us. Excludes the relay
+        //    address, which is advertised via the typed-set path in the
+        //    relay driver.
+        for observed in self.transport.non_relay_external_addresses() {
             let resolved = MultiAddr::quic(observed);
             if !addresses.contains(&resolved) {
                 addresses.push(resolved);

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -176,9 +176,15 @@ const REBOOTSTRAP_COOLDOWN: Duration = Duration::from_secs(300); // 5 minutes
 /// causes of transient direct-dial failure (short-lived NAT rebinds,
 /// bootstrap hiccups, routing churn) without permanently banning an
 /// address that was temporarily unreachable. Combined with the
-/// per-peer two-address dial cap, this prevents retry storms against
-/// stale Unverified/Direct entries published by NATed peers.
+/// per-peer bounded dial cap, this prevents retry storms against stale
+/// Unverified/Direct entries published by NATed peers.
 const DIAL_FAILURE_CACHE_TTL: Duration = Duration::from_secs(30 * 60);
+
+/// Worst-case number of addresses [`DhtNetworkManager::select_dial_candidates`]
+/// returns for a single peer: one Relay plus at most one best non-Relay
+/// address per IP family (V4 and V6). Used to size the result vector so the
+/// hot path does not reallocate.
+const MAX_DIAL_PLAN_SIZE: usize = 3;
 
 /// Duration an identity-exchange *timeout* is remembered before the
 /// peer may be re-dialed. Used for the `IdentityFailed` outcome —
@@ -2098,7 +2104,7 @@ impl DhtNetworkManager {
         true
     }
 
-    /// Try dialing at most two addresses from `typed_addresses`, chosen by
+    /// Try dialing the bounded per-family plan chosen by
     /// [`Self::select_dial_candidates`]. Returns the transport channel ID on
     /// the first success, `None` if every attempted dial failed.
     ///
@@ -2110,7 +2116,7 @@ impl DhtNetworkManager {
     ///
     /// Addresses that failed a dial within the last
     /// [`DIAL_FAILURE_CACHE_TTL`] are **not re-dialed**, but they still
-    /// consume one of the two plan slots — a fully cached plan therefore
+    /// consume one of the plan slots — a fully cached plan therefore
     /// returns `None` without trying anything further down the priority
     /// list. This stops a peer that republishes the same broken Direct /
     /// Unverified pair on every DHT query from causing a dial retry
@@ -2719,8 +2725,8 @@ impl DhtNetworkManager {
     /// dialable addresses.
     ///
     /// Result is sorted by [`AddressType`] priority — Relay first
-    /// (known-good relay endpoint), then Direct, then NATted — so the
-    /// dialer tries the fastest path first.
+    /// (known-good relay endpoint), then Direct, Unverified, and NATted
+    /// — so the dialer tries the fastest path first.
     pub(crate) async fn peer_addresses_for_dial_typed(
         &self,
         peer_id: &PeerId,
@@ -2759,10 +2765,10 @@ impl DhtNetworkManager {
 
     /// Filter and sort typed addresses by [`AddressType::priority`].
     ///
-    /// Relay first, Direct second, NATted last. Stable sort within each
-    /// tier preserves the input order, so callers that hand in addresses
-    /// in a meaningful sub-order (e.g., IPv6 before IPv4) keep that
-    /// order within the type tier.
+    /// Relay first, Direct second, Unverified third, NATted last. Stable
+    /// sort within each tier preserves the input order, so callers that
+    /// hand in addresses in a meaningful sub-order (e.g., IPv6 before
+    /// IPv4) keep that order within the type tier.
     fn dialable_addresses_typed(
         typed: &[(MultiAddr, AddressType)],
     ) -> Vec<(MultiAddr, AddressType)> {
@@ -2777,54 +2783,62 @@ impl DhtNetworkManager {
         candidates
     }
 
-    /// Pick at most two addresses to dial for a single peer, applying the
-    /// cold-start policy documented on [`Self::dial_addresses`].
+    /// Pick a bounded per-family address plan for a single peer, applying
+    /// the cold-start policy documented on [`Self::dial_addresses`].
     ///
     /// Rules:
-    /// - If a Relay is published, dial the Relay and (when present) one
-    ///   Direct address. Relay paths are the reliable fallback, so we do
-    ///   not burn a second attempt on an Unverified guess.
-    /// - If no Relay is published but a Direct is, dial the Direct and
-    ///   (when present) a single Unverified/NATted address as backup.
-    /// - If only Unverified/NATted addresses exist, dial one of them and
-    ///   stop. A second attempt from the same bucket is rarely more
-    ///   likely to succeed and just extends cold-start latency.
+    /// - If a Relay is published, dial the Relay first.
+    /// - Then dial at most one best non-Relay address per IP family. Direct
+    ///   wins over Unverified, which wins over NATted.
+    /// - If there is no Relay, dial the same per-family non-Relay plan.
     ///
-    /// Peers routinely publish several addresses (IPv4+IPv6, plus one or
-    /// more observed externals). Dialing all of them costs a full
-    /// connect-timeout per failure, which dominates first-contact latency
-    /// when the top choice is unreachable. Capping at two keeps the
-    /// worst case to a single retry while still covering the expected
-    /// relay→direct and direct→unverified handoffs.
+    /// Peers can publish a relay plus one V4 and one V6 non-Relay address.
+    /// Preserving both families avoids making the caller's first-contact
+    /// path depend on whichever family happened to appear first, while still
+    /// capping the worst case at three attempts.
     fn select_dial_candidates(typed: &[(MultiAddr, AddressType)]) -> Vec<(MultiAddr, AddressType)> {
-        let dialable: Vec<(MultiAddr, AddressType)> = typed
-            .iter()
-            .filter(|pair| Self::is_dialable(&pair.0))
-            .cloned()
-            .collect();
+        let mut relay: Option<(MultiAddr, AddressType)> = None;
+        let mut non_relay_v4: Option<(usize, MultiAddr, AddressType)> = None;
+        let mut non_relay_v6: Option<(usize, MultiAddr, AddressType)> = None;
 
-        let relay = dialable
-            .iter()
-            .find(|(_, t)| *t == AddressType::Relay)
-            .cloned();
-        let direct = dialable
-            .iter()
-            .find(|(_, t)| *t == AddressType::Direct)
-            .cloned();
-        let other = dialable
-            .iter()
-            .filter(|(_, t)| !matches!(*t, AddressType::Relay | AddressType::Direct))
-            .min_by_key(|(_, t)| t.priority())
-            .cloned();
+        for (index, (addr, ty)) in typed.iter().enumerate() {
+            if !Self::is_dialable(addr) {
+                continue;
+            }
+            if *ty == AddressType::Relay {
+                if relay.is_none() {
+                    relay = Some((addr.clone(), *ty));
+                }
+                continue;
+            }
 
-        match (relay, direct, other) {
-            (Some(r), Some(d), _) => vec![r, d],
-            (Some(r), None, _) => vec![r],
-            (None, Some(d), Some(o)) => vec![d, o],
-            (None, Some(d), None) => vec![d],
-            (None, None, Some(o)) => vec![o],
-            (None, None, None) => Vec::new(),
+            let Some(socket_addr) = addr.dialable_socket_addr() else {
+                continue;
+            };
+            let normalized = saorsa_transport::shared::normalize_socket_addr(socket_addr);
+            let slot = if normalized.ip().is_ipv4() {
+                &mut non_relay_v4
+            } else {
+                &mut non_relay_v6
+            };
+            let should_replace = slot
+                .as_ref()
+                .map(|(_, _, existing_ty)| ty.priority() < existing_ty.priority())
+                .unwrap_or(true);
+            if should_replace {
+                *slot = Some((index, addr.clone(), *ty));
+            }
         }
+
+        let mut out = Vec::with_capacity(MAX_DIAL_PLAN_SIZE);
+        if let Some(relay) = relay {
+            out.push(relay);
+        }
+
+        let mut non_relay: Vec<_> = [non_relay_v4, non_relay_v6].into_iter().flatten().collect();
+        non_relay.sort_by_key(|(index, _, _)| *index);
+        out.extend(non_relay.into_iter().map(|(_, addr, ty)| (addr, ty)));
+        out
     }
 
     /// Wait for DHT network response via oneshot channel with timeout
@@ -4431,15 +4445,38 @@ mod tests {
     }
 
     #[test]
-    fn select_dial_candidates_relay_only_without_direct_is_one() {
-        // With a relay but no direct we do NOT fall back to an Unverified
-        // guess — relay paths are already the robust fallback, and the
-        // caller gets a deterministic single-dial budget.
+    fn select_dial_candidates_relay_plus_dual_stack_direct_keeps_both_families() {
+        let addrs = typed(vec![
+            ("/ip4/198.51.100.1/udp/9000/quic", AddressType::Relay),
+            ("/ip6/2001:db8::7/udp/9001/quic", AddressType::Direct),
+            ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
+        ]);
+        let picks = DhtNetworkManager::select_dial_candidates(&addrs);
+        assert_eq!(picks.len(), 3);
+        assert_eq!(picks[0].1, AddressType::Relay);
+        assert_eq!(picks[1].0, addrs[1].0);
+        assert_eq!(picks[2].0, addrs[2].0);
+    }
+
+    #[test]
+    fn select_dial_candidates_relay_plus_unverified_gives_two() {
         let addrs = typed(vec![
             ("/ip4/198.51.100.1/udp/9000/quic", AddressType::Relay),
             ("/ip4/192.0.2.9/udp/9002/quic", AddressType::Unverified),
             ("/ip4/192.0.2.10/udp/9003/quic", AddressType::NATted),
         ]);
+        let picks = DhtNetworkManager::select_dial_candidates(&addrs);
+        assert_eq!(picks.len(), 2);
+        assert_eq!(picks[0].1, AddressType::Relay);
+        assert_eq!(picks[1].1, AddressType::Unverified);
+    }
+
+    #[test]
+    fn select_dial_candidates_relay_only_is_one() {
+        let addrs = typed(vec![(
+            "/ip4/198.51.100.1/udp/9000/quic",
+            AddressType::Relay,
+        )]);
         let picks = DhtNetworkManager::select_dial_candidates(&addrs);
         assert_eq!(picks.len(), 1);
         assert_eq!(picks[0].1, AddressType::Relay);
@@ -4449,13 +4486,24 @@ mod tests {
     fn select_dial_candidates_direct_plus_unverified_when_no_relay() {
         let addrs = typed(vec![
             ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
-            ("/ip4/192.0.2.9/udp/9002/quic", AddressType::Unverified),
-            ("/ip4/192.0.2.10/udp/9003/quic", AddressType::NATted),
+            ("/ip6/2001:db8::9/udp/9002/quic", AddressType::Unverified),
+            ("/ip6/2001:db8::10/udp/9003/quic", AddressType::NATted),
         ]);
         let picks = DhtNetworkManager::select_dial_candidates(&addrs);
         assert_eq!(picks.len(), 2);
         assert_eq!(picks[0].1, AddressType::Direct);
         assert_eq!(picks[1].1, AddressType::Unverified);
+    }
+
+    #[test]
+    fn select_dial_candidates_direct_dominates_same_family_unverified() {
+        let addrs = typed(vec![
+            ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
+            ("/ip4/192.0.2.9/udp/9002/quic", AddressType::Unverified),
+        ]);
+        let picks = DhtNetworkManager::select_dial_candidates(&addrs);
+        assert_eq!(picks.len(), 1);
+        assert_eq!(picks[0].1, AddressType::Direct);
     }
 
     #[test]
@@ -4479,6 +4527,18 @@ mod tests {
         let picks = DhtNetworkManager::select_dial_candidates(&addrs);
         assert_eq!(picks.len(), 1);
         assert_eq!(picks[0].1, AddressType::Unverified);
+    }
+
+    #[test]
+    fn select_dial_candidates_only_unverified_keeps_both_families() {
+        let addrs = typed(vec![
+            ("/ip4/192.0.2.9/udp/9002/quic", AddressType::Unverified),
+            ("/ip6/2001:db8::9/udp/9002/quic", AddressType::Unverified),
+        ]);
+        let picks = DhtNetworkManager::select_dial_candidates(&addrs);
+        assert_eq!(picks.len(), 2);
+        assert_eq!(picks[0].0, addrs[0].0);
+        assert_eq!(picks[1].0, addrs[1].0);
     }
 
     #[test]
@@ -4516,8 +4576,8 @@ mod tests {
         // has a lower AddressType priority index than NATted.
         let addrs = typed(vec![
             ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
-            ("/ip4/192.0.2.10/udp/9003/quic", AddressType::NATted),
-            ("/ip4/192.0.2.9/udp/9002/quic", AddressType::Unverified),
+            ("/ip6/2001:db8::10/udp/9003/quic", AddressType::NATted),
+            ("/ip6/2001:db8::9/udp/9002/quic", AddressType::Unverified),
         ]);
         let picks = DhtNetworkManager::select_dial_candidates(&addrs);
         assert_eq!(picks.len(), 2);

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,6 +87,7 @@
 //! ```
 
 use std::borrow::Cow;
+use std::fmt;
 use std::io;
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -371,6 +372,50 @@ pub enum StateError {
     CorruptionDetected(Cow<'static, str>),
 }
 
+/// Categories of send failure used by reconnect policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SendFailureKind {
+    /// The mapped channel was already gone before any stream bytes were written.
+    StaleChannel,
+    /// Opening a stream made no progress within the progress timeout.
+    OpenStreamProgressTimeout,
+    /// A stream write made no progress within the progress timeout.
+    WriteProgressTimeout,
+    /// The stream write failed after a stream had been opened.
+    StreamWrite,
+    /// The stream could not be finished after bytes were queued.
+    StreamFinish,
+    /// The remote peer explicitly stopped the stream.
+    PeerStopped,
+    /// The send failed while observing acknowledgement/stop state.
+    Acknowledgement,
+    /// The lower layer did not provide a more specific classification.
+    Other,
+}
+
+impl SendFailureKind {
+    /// Whether this failure is safe to treat as a stale channel and reconnect.
+    pub fn is_stale_channel(self) -> bool {
+        matches!(self, Self::StaleChannel)
+    }
+}
+
+impl fmt::Display for SendFailureKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::StaleChannel => "stale_channel",
+            Self::OpenStreamProgressTimeout => "open_stream_progress_timeout",
+            Self::WriteProgressTimeout => "write_progress_timeout",
+            Self::StreamWrite => "stream_write",
+            Self::StreamFinish => "stream_finish",
+            Self::PeerStopped => "peer_stopped",
+            Self::Acknowledgement => "acknowledgement",
+            Self::Other => "other",
+        };
+        f.write_str(label)
+    }
+}
+
 /// Transport-related errors
 #[derive(Debug, Error)]
 pub enum TransportError {
@@ -388,6 +433,14 @@ pub enum TransportError {
 
     #[error("Stream error: {0}")]
     StreamError(Cow<'static, str>),
+
+    #[error("Send failed ({kind}): {reason}")]
+    SendFailed {
+        /// Failure kind used by retry/reconnect policy.
+        kind: SendFailureKind,
+        /// Human-readable failure reason.
+        reason: Cow<'static, str>,
+    },
 
     #[error("Certificate error: {0}")]
     CertificateError(Cow<'static, str>),
@@ -539,6 +592,15 @@ impl P2PError {
     pub fn internal(msg: impl Into<Cow<'static, str>>) -> Self {
         P2PError::Internal(msg.into())
     }
+
+    /// Whether retrying this send by reconnecting is safe.
+    pub(crate) fn is_stale_channel_send_failure(&self) -> bool {
+        match self {
+            P2PError::Network(NetworkError::PeerNotFound(_)) => true,
+            P2PError::Transport(TransportError::SendFailed { kind, .. }) => kind.is_stale_channel(),
+            _ => false,
+        }
+    }
 }
 
 /// Logging integration for errors
@@ -644,5 +706,29 @@ mod tests {
             err.to_string(),
             "Cryptography error: Invalid key length: expected 32, got 16"
         );
+    }
+
+    #[test]
+    fn test_send_failure_reconnect_classification() {
+        let stale = P2PError::Transport(TransportError::SendFailed {
+            kind: SendFailureKind::StaleChannel,
+            reason: "closed before stream open".into(),
+        });
+        assert!(stale.is_stale_channel_send_failure());
+
+        let progress_timeout = P2PError::Transport(TransportError::SendFailed {
+            kind: SendFailureKind::WriteProgressTimeout,
+            reason: "no write progress".into(),
+        });
+        assert!(!progress_timeout.is_stale_channel_send_failure());
+
+        let open_timeout = P2PError::Transport(TransportError::SendFailed {
+            kind: SendFailureKind::OpenStreamProgressTimeout,
+            reason: "no stream-open progress".into(),
+        });
+        assert!(!open_timeout.is_stale_channel_send_failure());
+
+        let missing = P2PError::Network(NetworkError::PeerNotFound("peer".into()));
+        assert!(missing.is_stale_channel_send_failure());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -385,10 +385,6 @@ pub enum SendFailureKind {
     StreamWrite,
     /// The stream could not be finished after bytes were queued.
     StreamFinish,
-    /// The remote peer explicitly stopped the stream.
-    PeerStopped,
-    /// The send failed while observing acknowledgement/stop state.
-    Acknowledgement,
     /// The lower layer did not provide a more specific classification.
     Other,
 }
@@ -408,8 +404,6 @@ impl fmt::Display for SendFailureKind {
             Self::WriteProgressTimeout => "write_progress_timeout",
             Self::StreamWrite => "stream_write",
             Self::StreamFinish => "stream_finish",
-            Self::PeerStopped => "peer_stopped",
-            Self::Acknowledgement => "acknowledgement",
             Self::Other => "other",
         };
         f.write_str(label)

--- a/src/network.rs
+++ b/src/network.rs
@@ -21,6 +21,7 @@ use crate::adaptive::trust::{TrustRecord, TrustSnapshot};
 use crate::adaptive::{AdaptiveDHT, AdaptiveDhtConfig, TrustEngine, TrustEvent};
 use crate::bootstrap::cache::{CachedCloseGroupPeer, CloseGroupCache};
 use crate::bootstrap::{BootstrapConfig, BootstrapManager};
+use crate::dht::core_engine::AddressType;
 use crate::dht_network_manager::{
     DhtNetworkConfig, DhtNetworkEvent, DhtNetworkManager, IDENTITY_EXCHANGE_TIMEOUT,
 };
@@ -1428,8 +1429,26 @@ impl P2PNode {
     /// the authenticated peer identity, call
     /// [`wait_for_peer_identity`](Self::wait_for_peer_identity) with the
     /// returned channel ID.
+    ///
+    /// Callers that already know how the address was classified should
+    /// prefer [`Self::connect_peer_typed`] so the resulting log line
+    /// carries an accurate `kind` field instead of `unknown`.
     pub async fn connect_peer(&self, address: &MultiAddr) -> Result<String> {
         self.transport.connect_peer(address).await
+    }
+
+    /// Connect to a peer at the given typed address.
+    ///
+    /// Same as [`Self::connect_peer`] but threads the [`AddressType`]
+    /// through to the transport-level dial log so an operator can tell,
+    /// after the fact, whether a failed dial was against a `Direct`,
+    /// `Relay`, `Unverified`, or `NATted` address.
+    pub async fn connect_peer_typed(
+        &self,
+        address: &MultiAddr,
+        kind: AddressType,
+    ) -> Result<String> {
+        self.transport.connect_peer_typed(address, kind).await
     }
 
     /// Wait for the identity exchange on `channel_id` to complete, returning
@@ -1567,7 +1586,7 @@ impl P2PNode {
         stale_channels: &[String],
     ) -> Result<()> {
         // Resolve a dial address: caller-provided > saved > DHT.
-        let address = self
+        let (address, kind) = self
             .resolve_dial_address(peer_id, addrs, saved_addrs)
             .await
             .ok_or_else(|| {
@@ -1587,7 +1606,7 @@ impl P2PNode {
         }
 
         // Dial and wait for identity exchange.
-        let channel_id = self.transport.connect_peer(&address).await?;
+        let channel_id = self.transport.connect_peer_typed(&address, kind).await?;
         let authenticated = match self
             .transport
             .wait_for_peer_identity(&channel_id, IDENTITY_EXCHANGE_TIMEOUT)
@@ -1617,28 +1636,53 @@ impl P2PNode {
     /// Resolve a dial address for `peer_id`, preferring caller-provided
     /// addresses over cached/DHT sources.
     ///
-    /// Returns the first dialable (QUIC, non-unspecified) address found, or
-    /// `None` when no address is available.
+    /// Returns the first dialable (QUIC, non-unspecified) address found,
+    /// paired with the [`AddressType`] the DHT routing table believes
+    /// for that address. Caller-provided / saved addresses that don't
+    /// appear in the routing table fall back to
+    /// [`AddressType::Unverified`] — the same default the routing table
+    /// applies to legacy peers that never asserted reachability.
+    /// Returns `None` when no dialable address is available.
     async fn resolve_dial_address(
         &self,
         peer_id: &PeerId,
         caller_addrs: &[MultiAddr],
         saved_addrs: &[MultiAddr],
-    ) -> Option<MultiAddr> {
+    ) -> Option<(MultiAddr, AddressType)> {
+        // Pull the typed DHT view once so we can both prefer it as a
+        // fallback source and use it to look up the kind for caller- /
+        // saved-supplied addresses.
+        let dht_typed = self
+            .adaptive_dht
+            .peer_addresses_for_dial_typed(peer_id)
+            .await;
+        let lookup_kind = |addr: &MultiAddr| -> AddressType {
+            dht_typed
+                .iter()
+                .find(|(a, _)| a == addr)
+                .map(|(_, ty)| *ty)
+                .unwrap_or(AddressType::Unverified)
+        };
+
         // 1. Caller-provided addresses (highest priority).
         if let Some(addr) = Self::first_dialable(caller_addrs) {
-            return Some(addr);
+            let kind = lookup_kind(&addr);
+            return Some((addr, kind));
         }
 
         // 2. Addresses snapshotted from the transport layer before the send
         //    attempt cleaned them up.
         if let Some(addr) = Self::first_dialable(saved_addrs) {
-            return Some(addr);
+            let kind = lookup_kind(&addr);
+            return Some((addr, kind));
         }
 
-        // 3. DHT routing table — apply the same dialability filter.
-        let dht_addrs = self.adaptive_dht.peer_addresses_for_dial(peer_id).await;
-        Self::first_dialable(&dht_addrs)
+        // 3. DHT routing table — apply the same dialability filter and
+        //    keep the type tag the routing table provided.
+        dht_typed.into_iter().find(|(a, _)| {
+            a.dialable_socket_addr()
+                .is_some_and(|sa| !sa.ip().is_unspecified())
+        })
     }
 
     /// Return the first dialable QUIC address from a slice, skipping
@@ -2224,7 +2268,15 @@ impl P2PNode {
         identity_timeout: Duration,
     ) -> Option<PeerId> {
         for addr in addrs {
-            match self.connect_peer(addr).await {
+            // Bootstrap addresses come from operator-supplied seeds (CLI
+            // flags, config file, bootstrap cache). The local reachability
+            // classifier hasn't proven them yet, so log them as
+            // `Unverified` rather than `unknown`.
+            match self
+                .transport
+                .connect_peer_typed(addr, AddressType::Unverified)
+                .await
+            {
                 Ok(channel_id) => match self
                     .transport
                     .wait_for_peer_identity(&channel_id, identity_timeout)

--- a/src/network.rs
+++ b/src/network.rs
@@ -1536,18 +1536,27 @@ impl P2PNode {
             .map(|info| info.addresses)
             .unwrap_or_default();
 
-        // Clone data for retry — transport.send_message consumes the Vec,
-        // so we need a copy if the first attempt fails.
+        // Clone data for retry — only stale-channel failures are retried, but
+        // transport.send_message consumes the Vec.
         let retry_data = data.clone();
 
         // Fast path: try existing connection.
         match self.transport.send_message(peer_id, protocol, data).await {
             Ok(()) => return Ok(()),
             Err(e) => {
+                if !e.is_stale_channel_send_failure() {
+                    debug!(
+                        peer = %peer_id.to_hex(),
+                        error = %e,
+                        "send failed during active channel use, not reconnecting",
+                    );
+                    return Err(e);
+                }
+
                 debug!(
                     peer = %peer_id.to_hex(),
                     error = %e,
-                    "send failed, attempting reconnect",
+                    "stale channel send failed, attempting reconnect",
                 );
             }
         }

--- a/src/network.rs
+++ b/src/network.rs
@@ -131,9 +131,10 @@ const DEFAULT_MAX_CONNECTIONS: usize = 10_000;
 
 /// Default connection timeout in seconds.
 ///
-/// Derived from the sum of connection strategy stages: direct (2s) +
-/// 2 × hole-punch rounds (3s + 1s retry each) + relay (10s) = ~20s.
-/// 25s provides margin for handshake jitter.
+/// The transport adapter keeps each direct Happy Eyeballs attempt short so
+/// DHT lookups can move past offline peers quickly. 25s leaves room for
+/// multi-stage connection strategies and identity exchange while preserving
+/// the historical API default.
 const DEFAULT_CONNECTION_TIMEOUT_SECS: u64 = 25;
 
 /// Number of cached bootstrap peers to retrieve.
@@ -1272,27 +1273,33 @@ impl P2PNode {
                         _ = shutdown.cancelled() => break,
                         update = transport.recv_peer_address_update() => {
                             let Some((peer_addr, advertised_addr)) = update else { break };
-                            info!(
-                                "DHT_BRIDGE: processing update peer={} addr={} same_ip={}",
-                                peer_addr,
-                                advertised_addr,
-                                peer_addr.ip() == advertised_addr.ip()
-                            );
+                            let normalized_peer =
+                                saorsa_transport::shared::normalize_socket_addr(peer_addr);
+                            let normalized_adv =
+                                saorsa_transport::shared::normalize_socket_addr(advertised_addr);
                             // Only update DHT when the advertised IP differs
                             // from the peer's connection IP. Same-IP updates
                             // are just different NATted ports (useless for
                             // symmetric NAT); different-IP means a relay.
-                            if peer_addr.ip() == advertised_addr.ip() {
+                            if normalized_peer.ip() == normalized_adv.ip() {
+                                debug!(
+                                    "DHT_BRIDGE: dropping same-IP update peer={} addr={}",
+                                    normalized_peer,
+                                    normalized_adv
+                                );
                                 continue;
                             }
+                            info!(
+                                "DHT_BRIDGE: processing relay update peer={} addr={}",
+                                normalized_peer,
+                                normalized_adv
+                            );
                             // Look up peer ID by address (tries both IPv4 and
                             // IPv4-mapped IPv6 forms via dual_stack_alternate).
                             // For symmetric NAT, this may fail because the
                             // connection's channel key uses a different NATted port.
-                            if let Some(peer_id) = transport.peer_id_for_addr(&peer_addr).await {
-                                let normalized_adv =
-                                    saorsa_transport::shared::normalize_socket_addr(advertised_addr);
-                                let multi_addr = crate::MultiAddr::quic(normalized_adv);
+                            if let Some(peer_id) = transport.peer_id_for_addr(&normalized_peer).await {
+                                let multi_addr = MultiAddr::quic(normalized_adv);
                                 info!(
                                     "Updating DHT: peer {} relay address {} (connection was {})",
                                     peer_id, advertised_addr, peer_addr
@@ -1300,7 +1307,7 @@ impl P2PNode {
                                 dht.touch_node_typed(
                                     &peer_id,
                                     Some(&multi_addr),
-                                    crate::dht::AddressType::Relay,
+                                    AddressType::Relay,
                                 )
                                 .await;
                             }

--- a/src/network.rs
+++ b/src/network.rs
@@ -1665,40 +1665,27 @@ impl P2PNode {
         caller_addrs: &[MultiAddr],
         saved_addrs: &[MultiAddr],
     ) -> Option<(MultiAddr, AddressType)> {
-        // Pull the typed DHT view once so we can both prefer it as a
-        // fallback source and use it to look up the kind for caller- /
-        // saved-supplied addresses.
-        let dht_typed = self
-            .adaptive_dht
-            .peer_addresses_for_dial_typed(peer_id)
-            .await;
-        let lookup_kind = |addr: &MultiAddr| -> AddressType {
-            dht_typed
-                .iter()
-                .find(|(a, _)| a == addr)
-                .map(|(_, ty)| *ty)
-                .unwrap_or(AddressType::Unverified)
-        };
-
-        // 1. Caller-provided addresses (highest priority).
+        // Caller- and saved-supplied addresses skip the routing-table read.
+        // The kind is only consumed as a log tag by `connect_peer_typed`, so
+        // defaulting to Unverified — the same fallback the routing table
+        // applies to legacy peers — saves an async lookup on the hot
+        // reconnect path. Only consult the DHT when both upstream sources
+        // are exhausted.
         if let Some(addr) = Self::first_dialable(caller_addrs) {
-            let kind = lookup_kind(&addr);
-            return Some((addr, kind));
+            return Some((addr, AddressType::Unverified));
         }
-
-        // 2. Addresses snapshotted from the transport layer before the send
-        //    attempt cleaned them up.
         if let Some(addr) = Self::first_dialable(saved_addrs) {
-            let kind = lookup_kind(&addr);
-            return Some((addr, kind));
+            return Some((addr, AddressType::Unverified));
         }
 
-        // 3. DHT routing table — apply the same dialability filter and
-        //    keep the type tag the routing table provided.
-        dht_typed.into_iter().find(|(a, _)| {
-            a.dialable_socket_addr()
-                .is_some_and(|sa| !sa.ip().is_unspecified())
-        })
+        self.adaptive_dht
+            .peer_addresses_for_dial_typed(peer_id)
+            .await
+            .into_iter()
+            .find(|(a, _)| {
+                a.dialable_socket_addr()
+                    .is_some_and(|sa| !sa.ip().is_unspecified())
+            })
     }
 
     /// Return the first dialable QUIC address from a slice, skipping

--- a/src/reachability/driver.rs
+++ b/src/reachability/driver.rs
@@ -204,7 +204,7 @@ impl AcquisitionDriver {
     /// peers how to reach it.
     async fn publish_typed_set(&self, relay: Option<SocketAddr>) {
         let listen = self.transport.listen_addrs().await;
-        let observed = self.transport.direct_external_addresses();
+        let observed = self.transport.non_relay_external_addresses();
 
         debug!(
             relay = ?relay,
@@ -300,6 +300,23 @@ impl AcquisitionDriver {
                         }
                     }
                 }
+                updated = self.transport.recv_self_address_updated() => {
+                    match updated {
+                        Some(addr) => {
+                            let relay = *self.relay_address.read().await;
+                            info!(
+                                address = %addr,
+                                relay = ?relay,
+                                "driver: self address updated, republishing typed self address set"
+                            );
+                            self.publish_typed_set(relay).await;
+                        }
+                        None => {
+                            // Channel closed — transport is shutting down.
+                            return true;
+                        }
+                    }
+                }
                 event = events.recv() => {
                     match event {
                         Ok(DhtNetworkEvent::KClosestPeersChanged { ref new, .. }) => {
@@ -372,6 +389,21 @@ impl AcquisitionDriver {
                             info!(
                                 address = %addr,
                                 "driver: direct address promoted during relay backoff, republishing typed self address set"
+                            );
+                            self.publish_typed_set(None).await;
+                        }
+                        None => {
+                            // Channel closed — transport is shutting down.
+                            return true;
+                        }
+                    }
+                }
+                updated = self.transport.recv_self_address_updated() => {
+                    match updated {
+                        Some(addr) => {
+                            info!(
+                                address = %addr,
+                                "driver: self address updated during relay backoff, republishing typed self address set"
                             );
                             self.publish_typed_set(None).await;
                         }

--- a/src/reachability/driver.rs
+++ b/src/reachability/driver.rs
@@ -213,6 +213,15 @@ impl AcquisitionDriver {
             None
         };
 
+        debug!(
+            relay = ?relay,
+            direct_verified,
+            direct_tag = ?direct_tag,
+            observed = ?observed,
+            listen = ?listen,
+            "driver: preparing typed self address set"
+        );
+
         let mut typed: Vec<(MultiAddr, AddressType)> = Vec::new();
         // Normalize addresses before dedup so IPv4-mapped IPv6
         // (::ffff:a.b.c.d) and plain IPv4 (a.b.c.d) are treated as
@@ -227,30 +236,76 @@ impl AcquisitionDriver {
             if !observed.is_empty() {
                 for sa in observed {
                     if sa.ip().is_unspecified() {
+                        debug!(
+                            address = %sa,
+                            "driver: skipping unspecified observed self address"
+                        );
                         continue;
                     }
                     let normalized = saorsa_transport::shared::normalize_socket_addr(sa);
                     if seen.insert(normalized) {
+                        debug!(
+                            address = %normalized,
+                            tag = ?tag,
+                            "driver: adding observed self address to publish set"
+                        );
                         typed.push((MultiAddr::quic(normalized), tag));
+                    } else {
+                        trace!(
+                            address = %normalized,
+                            tag = ?tag,
+                            "driver: deduped observed self address"
+                        );
                     }
                 }
             }
             for addr in listen {
                 let Some(sa) = addr.dialable_socket_addr() else {
+                    trace!(
+                        address = %addr,
+                        "driver: skipping non-dialable listen address"
+                    );
                     continue;
                 };
                 if sa.ip().is_unspecified() {
+                    debug!(
+                        address = %sa,
+                        "driver: skipping unspecified listen address"
+                    );
                     continue;
                 }
                 let normalized = saorsa_transport::shared::normalize_socket_addr(sa);
                 if seen.insert(normalized) {
+                    debug!(
+                        address = %normalized,
+                        tag = ?tag,
+                        "driver: adding listen self address to publish set"
+                    );
                     typed.push((MultiAddr::quic(normalized), tag));
+                } else {
+                    trace!(
+                        address = %normalized,
+                        tag = ?tag,
+                        "driver: deduped listen self address"
+                    );
                 }
             }
+        } else {
+            debug!(
+                relay = ?relay,
+                direct_verified,
+                observed_count = observed.len(),
+                listen_count = listen.len(),
+                "driver: suppressing unverified direct addresses while relay is held"
+            );
         }
 
         if let Some(relay_addr) = relay {
             let normalized = saorsa_transport::shared::normalize_socket_addr(relay_addr);
+            debug!(
+                address = %normalized,
+                "driver: adding relay self address to publish set"
+            );
             typed.push((MultiAddr::quic(normalized), AddressType::Relay));
         }
 
@@ -264,6 +319,12 @@ impl AcquisitionDriver {
             .dht
             .find_closest_nodes_local(&own_key, self.dht.k_value())
             .await;
+        debug!(
+            peers = all_peers.len(),
+            typed_addresses = ?typed,
+            relay = ?relay,
+            "driver: publishing typed self address set"
+        );
         trace!(
             peers = all_peers.len(),
             addrs = typed.len(),

--- a/src/reachability/driver.rs
+++ b/src/reachability/driver.rs
@@ -175,19 +175,28 @@ impl AcquisitionDriver {
 
     /// Publish this node's current typed address set to K-closest peers.
     ///
-    /// The direct tier's [`AddressType`] depends on the passive
-    /// reachability classifier (see
-    /// [`TransportHandle::direct_reachability_observed`]): when at least
-    /// one unsolicited inbound handshake has completed, observed external
-    /// addresses are tagged [`AddressType::Direct`]; otherwise they are
-    /// tagged [`AddressType::Unverified`] so dialers know they may time
-    /// out. When `relay` is `Some`, the relay-allocated socket is appended
+    /// Each address's [`AddressType`] is computed independently from the
+    /// passive per-address reachability proof (see
+    /// [`TransportHandle::is_external_proven`]): an address is tagged
+    /// [`AddressType::Direct`] only after at least
+    /// `MIN_DISTINCT_OBSERVERS_FOR_DIRECT` source-disjoint inbounds have
+    /// been attributed to it; otherwise it is tagged
+    /// [`AddressType::Unverified`] (so dialers know they may time out)
+    /// or — when a relay is held — suppressed entirely (the relay is the
+    /// authoritative contact and publishing undialable direct entries
+    /// alongside it just adds timeout cost for dialers).
+    ///
+    /// When `relay` is `Some`, the relay-allocated socket is appended
     /// tagged [`AddressType::Relay`].
     ///
-    /// When a relay has been acquired, unverified-only addresses are
-    /// suppressed — the relay address is the authoritative contact and
-    /// publishing undialable direct entries alongside it just adds
-    /// timeout cost for dialers.
+    /// Per-address (not global) tagging matters for two cases the previous
+    /// global-flag approach got wrong:
+    ///
+    /// 1. A v4 inbound proves nothing about a v6 external; the classifier
+    ///    only credits same-family externals, and the tag is computed
+    ///    per address from that per-address proof.
+    /// 2. On a multi-NAT host, one external being proven Direct does not
+    ///    promote unrelated externals.
     ///
     /// Quietly drops the publish when there are no dialable addresses to
     /// advertise — a fully wildcard-bound node cannot meaningfully tell
@@ -195,28 +204,10 @@ impl AcquisitionDriver {
     async fn publish_typed_set(&self, relay: Option<SocketAddr>) {
         let listen = self.transport.listen_addrs().await;
         let observed = self.transport.direct_external_addresses();
-        let direct_verified = self.transport.direct_reachability_observed();
-
-        // Choose the tag for observed/listen addresses:
-        //   - classifier has proven reachability → Direct
-        //   - no proof yet, no relay either      → Unverified (cold-start;
-        //                                          dialers eat the risk)
-        //   - no proof yet, but relay is held    → suppress (relay is
-        //                                          authoritative; don't
-        //                                          waste dialers on
-        //                                          unverified direct)
-        let direct_tag: Option<AddressType> = if direct_verified {
-            Some(AddressType::Direct)
-        } else if relay.is_none() {
-            Some(AddressType::Unverified)
-        } else {
-            None
-        };
+        let relay_held = relay.is_some();
 
         debug!(
             relay = ?relay,
-            direct_verified,
-            direct_tag = ?direct_tag,
             observed = ?observed,
             listen = ?listen,
             "driver: preparing typed self address set"
@@ -229,75 +220,91 @@ impl AcquisitionDriver {
         // different representations.
         let mut seen: HashSet<SocketAddr> = HashSet::new();
 
-        if let Some(tag) = direct_tag {
-            // Prefer observed (post-NAT) addresses for the direct tier since
-            // those are what peers actually see from the outside. Fall back
-            // to locally-bound listen addresses when no observations exist.
-            if !observed.is_empty() {
-                for sa in observed {
-                    if sa.ip().is_unspecified() {
-                        debug!(
-                            address = %sa,
-                            "driver: skipping unspecified observed self address"
-                        );
-                        continue;
-                    }
-                    let normalized = saorsa_transport::shared::normalize_socket_addr(sa);
-                    if seen.insert(normalized) {
-                        debug!(
-                            address = %normalized,
-                            tag = ?tag,
-                            "driver: adding observed self address to publish set"
-                        );
-                        typed.push((MultiAddr::quic(normalized), tag));
-                    } else {
-                        trace!(
-                            address = %normalized,
-                            tag = ?tag,
-                            "driver: deduped observed self address"
-                        );
-                    }
-                }
+        // Resolve the publish tag for one external address:
+        //   - per-address classifier proof          → Direct
+        //   - no proof yet, no relay held           → Unverified
+        //   - no proof yet, relay held              → suppress (None)
+        let tag_for = |sa: SocketAddr| -> Option<AddressType> {
+            if self.transport.is_external_proven(sa) {
+                Some(AddressType::Direct)
+            } else if !relay_held {
+                Some(AddressType::Unverified)
+            } else {
+                None
             }
-            for addr in listen {
-                let Some(sa) = addr.dialable_socket_addr() else {
-                    trace!(
-                        address = %addr,
-                        "driver: skipping non-dialable listen address"
-                    );
-                    continue;
-                };
-                if sa.ip().is_unspecified() {
-                    debug!(
-                        address = %sa,
-                        "driver: skipping unspecified listen address"
-                    );
-                    continue;
-                }
-                let normalized = saorsa_transport::shared::normalize_socket_addr(sa);
-                if seen.insert(normalized) {
-                    debug!(
-                        address = %normalized,
-                        tag = ?tag,
-                        "driver: adding listen self address to publish set"
-                    );
-                    typed.push((MultiAddr::quic(normalized), tag));
-                } else {
-                    trace!(
-                        address = %normalized,
-                        tag = ?tag,
-                        "driver: deduped listen self address"
-                    );
-                }
+        };
+
+        // Prefer observed (post-NAT) addresses for the direct tier since
+        // those are what peers actually see from the outside. Listen
+        // addresses are emitted alongside them — same per-address tagging.
+        for sa in observed {
+            if sa.ip().is_unspecified() {
+                debug!(
+                    address = %sa,
+                    "driver: skipping unspecified observed self address"
+                );
+                continue;
             }
-        } else {
-            debug!(
-                relay = ?relay,
-                direct_verified,
-                observed_count = observed.len(),
-                listen_count = listen.len(),
-                "driver: suppressing unverified direct addresses while relay is held"
-            );
+            let normalized = saorsa_transport::shared::normalize_socket_addr(sa);
+            let Some(tag) = tag_for(normalized) else {
+                trace!(
+                    address = %normalized,
+                    "driver: suppressing unverified observed address while relay is held"
+                );
+                continue;
+            };
+            if seen.insert(normalized) {
+                debug!(
+                    address = %normalized,
+                    tag = ?tag,
+                    "driver: adding observed self address to publish set"
+                );
+                typed.push((MultiAddr::quic(normalized), tag));
+            } else {
+                trace!(
+                    address = %normalized,
+                    tag = ?tag,
+                    "driver: deduped observed self address"
+                );
+            }
+        }
+        for addr in listen {
+            let Some(sa) = addr.dialable_socket_addr() else {
+                trace!(
+                    address = %addr,
+                    "driver: skipping non-dialable listen address"
+                );
+                continue;
+            };
+            if sa.ip().is_unspecified() {
+                debug!(
+                    address = %sa,
+                    "driver: skipping unspecified listen address"
+                );
+                continue;
+            }
+            let normalized = saorsa_transport::shared::normalize_socket_addr(sa);
+            let Some(tag) = tag_for(normalized) else {
+                trace!(
+                    address = %normalized,
+                    "driver: suppressing unverified listen address while relay is held"
+                );
+                continue;
+            };
+            if seen.insert(normalized) {
+                debug!(
+                    address = %normalized,
+                    tag = ?tag,
+                    "driver: adding listen self address to publish set"
+                );
+                typed.push((MultiAddr::quic(normalized), tag));
+            } else {
+                trace!(
+                    address = %normalized,
+                    tag = ?tag,
+                    "driver: deduped listen self address"
+                );
+            }
         }
 
         if let Some(relay_addr) = relay {

--- a/src/reachability/driver.rs
+++ b/src/reachability/driver.rs
@@ -110,6 +110,7 @@ pub(crate) fn spawn_acquisition_driver(
             relay_address,
             shutdown,
             current_backoff: BACKOFF_INITIAL,
+            last_published_typed_set: None,
         };
         driver.run().await;
     });
@@ -125,6 +126,13 @@ struct AcquisitionDriver {
     relay_address: Arc<RwLock<Option<SocketAddr>>>,
     shutdown: CancellationToken,
     current_backoff: Duration,
+    last_published_typed_set: Option<PublishedTypedSet>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct PublishedTypedSet {
+    typed_addresses: Vec<(MultiAddr, AddressType)>,
+    peers: Vec<PeerId>,
 }
 
 impl AcquisitionDriver {
@@ -144,7 +152,7 @@ impl AcquisitionDriver {
                     *self.relay_address.write().await = Some(relay.allocated_public_addr);
                     self.transport
                         .set_relay_address(relay.allocated_public_addr);
-                    self.publish_typed_set(Some(relay.allocated_public_addr))
+                    self.force_publish_typed_set(Some(relay.allocated_public_addr))
                         .await;
                     info!(
                         relayer = ?relay.relayer,
@@ -202,7 +210,15 @@ impl AcquisitionDriver {
     /// Quietly drops the publish when there are no dialable addresses to
     /// advertise — a fully wildcard-bound node cannot meaningfully tell
     /// peers how to reach it.
-    async fn publish_typed_set(&self, relay: Option<SocketAddr>) {
+    async fn publish_typed_set(&mut self, relay: Option<SocketAddr>) {
+        self.publish_typed_set_with_policy(relay, false).await;
+    }
+
+    async fn force_publish_typed_set(&mut self, relay: Option<SocketAddr>) {
+        self.publish_typed_set_with_policy(relay, true).await;
+    }
+
+    async fn publish_typed_set_with_policy(&mut self, relay: Option<SocketAddr>, force: bool) {
         let listen = self.transport.listen_addrs().await;
         let observed = self.transport.non_relay_external_addresses();
 
@@ -227,6 +243,21 @@ impl AcquisitionDriver {
             .dht
             .find_closest_nodes_local(&own_key, self.dht.k_value())
             .await;
+        let peers = all_peers.iter().map(|node| node.peer_id).collect();
+        let publish_snapshot = PublishedTypedSet {
+            typed_addresses: typed.clone(),
+            peers,
+        };
+        if !force && self.last_published_typed_set.as_ref() == Some(&publish_snapshot) {
+            debug!(
+                peers = all_peers.len(),
+                typed_addresses = ?typed,
+                relay = ?relay,
+                "driver: publish skipped, typed self address set unchanged"
+            );
+            return;
+        }
+
         debug!(
             peers = all_peers.len(),
             typed_addresses = ?typed,
@@ -242,13 +273,14 @@ impl AcquisitionDriver {
         self.dht
             .publish_address_set_to_peers(typed, &all_peers)
             .await;
+        self.last_published_typed_set = Some(publish_snapshot);
     }
 
     /// Hold the acquired relay until an eviction or death event forces a
     /// rebind. Returns `true` on shutdown (caller should exit), `false`
     /// when the relay is considered lost and a republish+reacquire is
     /// needed.
-    async fn hold_until_lost(&self) -> bool {
+    async fn hold_until_lost(&mut self) -> bool {
         let mut events = self.dht.subscribe_events();
         let mut health = tokio::time::interval(HEALTH_POLL_INTERVAL);
         health.tick().await; // drop the immediate first tick
@@ -304,10 +336,10 @@ impl AcquisitionDriver {
                     match updated {
                         Some(addr) => {
                             let relay = *self.relay_address.read().await;
-                            info!(
+                            debug!(
                                 address = %addr,
                                 relay = ?relay,
-                                "driver: self address updated, republishing typed self address set"
+                                "driver: self address updated, refreshing typed self address set"
                             );
                             self.publish_typed_set(relay).await;
                         }
@@ -360,17 +392,17 @@ impl AcquisitionDriver {
     /// pre-retry publish is critical — without it, other peers would
     /// continue dialing the dead relay address during the 1–10 s
     /// acquisition walk.
-    async fn lose_relay_and_republish(&self) {
+    async fn lose_relay_and_republish(&mut self) {
         *self.relayer_peer_id.write().await = None;
         *self.relay_address.write().await = None;
         self.transport.clear_relay_address();
-        self.publish_typed_set(None).await;
+        self.force_publish_typed_set(None).await;
     }
 
     /// Wait out the current backoff window, or short-circuit on a
     /// `KClosestPeersChanged` event (new peers may offer fresh candidates).
     /// Returns `true` on shutdown.
-    async fn wait_backoff_or_event(&self) -> bool {
+    async fn wait_backoff_or_event(&mut self) -> bool {
         let mut events = self.dht.subscribe_events();
         let sleep = tokio::time::sleep(self.current_backoff);
         tokio::pin!(sleep);
@@ -401,9 +433,9 @@ impl AcquisitionDriver {
                 updated = self.transport.recv_self_address_updated() => {
                     match updated {
                         Some(addr) => {
-                            info!(
+                            debug!(
                                 address = %addr,
-                                "driver: self address updated during relay backoff, republishing typed self address set"
+                                "driver: self address updated during relay backoff, refreshing typed self address set"
                             );
                             self.publish_typed_set(None).await;
                         }

--- a/src/reachability/driver.rs
+++ b/src/reachability/driver.rs
@@ -24,25 +24,29 @@
 //! The driver runs as a single tokio task and cycles through three states:
 //!
 //! 1. **Acquiring**: call [`run_relay_acquisition`]. On success, publish
-//!    the full typed self-record (direct addresses + relay-allocated
-//!    address tagged [`AddressType::Relay`]) to K-closest peers, store
-//!    the relayer peer ID, and enter the **Holding** state. Relay
-//!    serving stays permanently enabled. On failure, publish the
-//!    direct-only address set so the node remains as reachable as
-//!    possible, arm the exponential backoff timer, and enter the
-//!    **Backoff** state.
-//! 2. **Holding**: subscribe to `KClosestPeersChanged` events and poll
+//!    the full typed self-record (relay-allocated address tagged
+//!    [`AddressType::Relay`] first, then one best non-relay address per
+//!    IP family) to K-closest peers, store the relayer peer ID, and enter
+//!    the **Holding** state. Relay serving stays permanently enabled. On
+//!    failure, publish the direct-only address set so the node remains as
+//!    reachable as possible, arm the exponential backoff timer, and enter
+//!    the **Backoff** state.
+//! 2. **Holding**: subscribe to `KClosestPeersChanged` events, republish
+//!    when a pinned external address is promoted to
+//!    [`AddressType::Direct`], and poll
 //!    [`TransportHandle::is_relay_healthy`] every
-//!    [`HEALTH_POLL_INTERVAL`]. On relayer-evicted, unhealthy-tunnel,
-//!    or shutdown, transition to **Lost**.
+//!    [`HEALTH_POLL_INTERVAL`]. On relayer-evicted or unhealthy-tunnel,
+//!    transition to **Lost**; on shutdown, exit the driver.
 //! 3. **Lost**: run the `republish-direct-only → reacquire` sequence.
 //!    The republish MUST happen **before** the acquisition walk starts,
 //!    so the network stops dialing the dead relay address during the
 //!    1–10 s acquisition window. After republishing, loop back to
 //!    **Acquiring**.
 //! 4. **Backoff**: wait for the current backoff window or a
-//!    `KClosestPeersChanged` event (whichever comes first), then loop
-//!    back to **Acquiring**. Successful acquisition resets the backoff.
+//!    `KClosestPeersChanged` event (whichever comes first), republishing
+//!    if a pinned external is promoted to [`AddressType::Direct`] while
+//!    waiting, then loop back to **Acquiring**. Successful acquisition
+//!    resets the backoff.
 //!
 //! Clients ([`NodeMode::Client`](crate::network::NodeMode::Client)) do
 //! not spawn the driver at all — they are outbound-only and do not need
@@ -181,13 +185,10 @@ impl AcquisitionDriver {
     /// [`AddressType::Direct`] only after at least
     /// `MIN_DISTINCT_OBSERVERS_FOR_DIRECT` source-disjoint inbounds have
     /// been attributed to it; otherwise it is tagged
-    /// [`AddressType::Unverified`] (so dialers know they may time out)
-    /// or — when a relay is held — suppressed entirely (the relay is the
-    /// authoritative contact and publishing undialable direct entries
-    /// alongside it just adds timeout cost for dialers).
+    /// [`AddressType::Unverified`] (so dialers know they may time out).
     ///
-    /// When `relay` is `Some`, the relay-allocated socket is appended
-    /// tagged [`AddressType::Relay`].
+    /// When `relay` is `Some`, the relay-allocated socket is emitted
+    /// first, tagged [`AddressType::Relay`].
     ///
     /// Per-address (not global) tagging matters for two cases the previous
     /// global-flag approach got wrong:
@@ -204,7 +205,6 @@ impl AcquisitionDriver {
     async fn publish_typed_set(&self, relay: Option<SocketAddr>) {
         let listen = self.transport.listen_addrs().await;
         let observed = self.transport.direct_external_addresses();
-        let relay_held = relay.is_some();
 
         debug!(
             relay = ?relay,
@@ -213,108 +213,9 @@ impl AcquisitionDriver {
             "driver: preparing typed self address set"
         );
 
-        let mut typed: Vec<(MultiAddr, AddressType)> = Vec::new();
-        // Normalize addresses before dedup so IPv4-mapped IPv6
-        // (::ffff:a.b.c.d) and plain IPv4 (a.b.c.d) are treated as
-        // equal, preventing the same address from appearing twice with
-        // different representations.
-        let mut seen: HashSet<SocketAddr> = HashSet::new();
-
-        // Resolve the publish tag for one external address:
-        //   - per-address classifier proof          → Direct
-        //   - no proof yet, no relay held           → Unverified
-        //   - no proof yet, relay held              → suppress (None)
-        let tag_for = |sa: SocketAddr| -> Option<AddressType> {
-            if self.transport.is_external_proven(sa) {
-                Some(AddressType::Direct)
-            } else if !relay_held {
-                Some(AddressType::Unverified)
-            } else {
-                None
-            }
-        };
-
-        // Prefer observed (post-NAT) addresses for the direct tier since
-        // those are what peers actually see from the outside. Listen
-        // addresses are emitted alongside them — same per-address tagging.
-        for sa in observed {
-            if sa.ip().is_unspecified() {
-                debug!(
-                    address = %sa,
-                    "driver: skipping unspecified observed self address"
-                );
-                continue;
-            }
-            let normalized = saorsa_transport::shared::normalize_socket_addr(sa);
-            let Some(tag) = tag_for(normalized) else {
-                trace!(
-                    address = %normalized,
-                    "driver: suppressing unverified observed address while relay is held"
-                );
-                continue;
-            };
-            if seen.insert(normalized) {
-                debug!(
-                    address = %normalized,
-                    tag = ?tag,
-                    "driver: adding observed self address to publish set"
-                );
-                typed.push((MultiAddr::quic(normalized), tag));
-            } else {
-                trace!(
-                    address = %normalized,
-                    tag = ?tag,
-                    "driver: deduped observed self address"
-                );
-            }
-        }
-        for addr in listen {
-            let Some(sa) = addr.dialable_socket_addr() else {
-                trace!(
-                    address = %addr,
-                    "driver: skipping non-dialable listen address"
-                );
-                continue;
-            };
-            if sa.ip().is_unspecified() {
-                debug!(
-                    address = %sa,
-                    "driver: skipping unspecified listen address"
-                );
-                continue;
-            }
-            let normalized = saorsa_transport::shared::normalize_socket_addr(sa);
-            let Some(tag) = tag_for(normalized) else {
-                trace!(
-                    address = %normalized,
-                    "driver: suppressing unverified listen address while relay is held"
-                );
-                continue;
-            };
-            if seen.insert(normalized) {
-                debug!(
-                    address = %normalized,
-                    tag = ?tag,
-                    "driver: adding listen self address to publish set"
-                );
-                typed.push((MultiAddr::quic(normalized), tag));
-            } else {
-                trace!(
-                    address = %normalized,
-                    tag = ?tag,
-                    "driver: deduped listen self address"
-                );
-            }
-        }
-
-        if let Some(relay_addr) = relay {
-            let normalized = saorsa_transport::shared::normalize_socket_addr(relay_addr);
-            debug!(
-                address = %normalized,
-                "driver: adding relay self address to publish set"
-            );
-            typed.push((MultiAddr::quic(normalized), AddressType::Relay));
-        }
+        let typed = build_typed_self_address_set(observed, listen, relay, |sa| {
+            self.transport.is_external_proven(sa)
+        });
 
         if typed.is_empty() {
             debug!("driver: publish skipped, no dialable self addresses");
@@ -378,6 +279,23 @@ impl AcquisitionDriver {
                         None => {
                             // Channel closed — transport is shutting
                             // down. Treat as shutdown.
+                            return true;
+                        }
+                    }
+                }
+                promoted = self.transport.recv_direct_address_promoted() => {
+                    match promoted {
+                        Some(addr) => {
+                            let relay = *self.relay_address.read().await;
+                            info!(
+                                address = %addr,
+                                relay = ?relay,
+                                "driver: direct address promoted, republishing typed self address set"
+                            );
+                            self.publish_typed_set(relay).await;
+                        }
+                        None => {
+                            // Channel closed — transport is shutting down.
                             return true;
                         }
                     }
@@ -448,6 +366,21 @@ impl AcquisitionDriver {
                     trace!(window = ?self.current_backoff, "driver: backoff window expired");
                     return false;
                 }
+                promoted = self.transport.recv_direct_address_promoted() => {
+                    match promoted {
+                        Some(addr) => {
+                            info!(
+                                address = %addr,
+                                "driver: direct address promoted during relay backoff, republishing typed self address set"
+                            );
+                            self.publish_typed_set(None).await;
+                        }
+                        None => {
+                            // Channel closed — transport is shutting down.
+                            return true;
+                        }
+                    }
+                }
                 event = events.recv() => {
                     match event {
                         Ok(DhtNetworkEvent::KClosestPeersChanged { .. }) => {
@@ -467,5 +400,340 @@ impl AcquisitionDriver {
     fn advance_backoff(&mut self) {
         let next = self.current_backoff.saturating_mul(BACKOFF_FACTOR);
         self.current_backoff = next.min(BACKOFF_MAX);
+    }
+}
+
+fn build_typed_self_address_set<F>(
+    observed: impl IntoIterator<Item = SocketAddr>,
+    listen: impl IntoIterator<Item = MultiAddr>,
+    relay: Option<SocketAddr>,
+    mut is_external_proven: F,
+) -> Vec<(MultiAddr, AddressType)>
+where
+    F: FnMut(SocketAddr) -> bool,
+{
+    let mut typed: Vec<(MultiAddr, AddressType)> = Vec::new();
+    let mut non_relay: Vec<FamilyAddressChoice> = Vec::new();
+    // Normalize addresses before dedup so IPv4-mapped IPv6
+    // (::ffff:a.b.c.d) and plain IPv4 (a.b.c.d) are treated as equal.
+    let mut seen: HashSet<SocketAddr> = HashSet::new();
+
+    if let Some(relay_addr) = relay {
+        let normalized = saorsa_transport::shared::normalize_socket_addr(relay_addr);
+        debug!(
+            address = %normalized,
+            "driver: adding relay self address to publish set"
+        );
+        typed.push((MultiAddr::quic(normalized), AddressType::Relay));
+        seen.insert(normalized);
+    }
+
+    // Prefer observed (post-NAT) addresses for the direct tier since
+    // those are what peers actually see from the outside. Listen
+    // addresses are emitted alongside them with the same per-address
+    // tagging.
+    for sa in observed {
+        record_non_relay_self_address(
+            sa,
+            AddressSource::Observed,
+            &mut seen,
+            &mut non_relay,
+            &mut is_external_proven,
+        );
+    }
+    for addr in listen {
+        let Some(sa) = addr.dialable_socket_addr() else {
+            trace!(
+                address = %addr,
+                "driver: skipping non-dialable listen address"
+            );
+            continue;
+        };
+        record_non_relay_self_address(
+            sa,
+            AddressSource::Listen,
+            &mut seen,
+            &mut non_relay,
+            &mut is_external_proven,
+        );
+    }
+
+    for choice in non_relay {
+        typed.push((choice.address, choice.tag));
+    }
+
+    typed
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AddressSource {
+    Observed,
+    Listen,
+}
+
+impl AddressSource {
+    fn label(self) -> &'static str {
+        match self {
+            AddressSource::Observed => "observed",
+            AddressSource::Listen => "listen",
+        }
+    }
+
+    /// Observed externals are the most recent post-NAT signal we have, so a
+    /// new observation in the same tier supersedes the previous one (matches
+    /// NAT rebinding and mobile handoff behavior). Listen addresses are
+    /// static, so they should never displace an observed same-tier choice.
+    fn replace_same_tier(self) -> bool {
+        matches!(self, AddressSource::Observed)
+    }
+}
+
+fn record_non_relay_self_address<F>(
+    socket_addr: SocketAddr,
+    source: AddressSource,
+    seen: &mut HashSet<SocketAddr>,
+    non_relay: &mut Vec<FamilyAddressChoice>,
+    is_external_proven: &mut F,
+) where
+    F: FnMut(SocketAddr) -> bool,
+{
+    if socket_addr.ip().is_unspecified() {
+        debug!(
+            address = %socket_addr,
+            source = source.label(),
+            "driver: skipping unspecified self address"
+        );
+        return;
+    }
+    let normalized = saorsa_transport::shared::normalize_socket_addr(socket_addr);
+    let tag = if is_external_proven(normalized) {
+        AddressType::Direct
+    } else {
+        AddressType::Unverified
+    };
+    if seen.insert(normalized) {
+        debug!(
+            address = %normalized,
+            tag = ?tag,
+            source = source.label(),
+            "driver: adding self address to candidate publish set"
+        );
+        record_non_relay_choice(non_relay, normalized, tag, source.replace_same_tier());
+    } else {
+        trace!(
+            address = %normalized,
+            tag = ?tag,
+            source = source.label(),
+            "driver: deduped self address"
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum IpFamily {
+    V4,
+    V6,
+}
+
+#[derive(Clone, Debug)]
+struct FamilyAddressChoice {
+    family: IpFamily,
+    address: MultiAddr,
+    tag: AddressType,
+}
+
+fn record_non_relay_choice(
+    choices: &mut Vec<FamilyAddressChoice>,
+    socket_addr: SocketAddr,
+    tag: AddressType,
+    replace_same_tier: bool,
+) {
+    // Callers normalize before reaching this helper, so IPv4-mapped IPv6 is
+    // already represented as plain IPv4 and cannot be mis-bucketed as V6.
+    let family = if socket_addr.ip().is_ipv4() {
+        IpFamily::V4
+    } else {
+        IpFamily::V6
+    };
+
+    let address = MultiAddr::quic(socket_addr);
+    let Some(existing) = choices.iter_mut().find(|choice| choice.family == family) else {
+        choices.push(FamilyAddressChoice {
+            family,
+            address,
+            tag,
+        });
+        return;
+    };
+
+    if tag.priority() < existing.tag.priority()
+        || (replace_same_tier && tag.priority() == existing.tag.priority())
+    {
+        trace!(
+            family = ?family,
+            old_tag = ?existing.tag,
+            new_tag = ?tag,
+            "driver: replacing self address candidate for IP family"
+        );
+        existing.address = address;
+        existing.tag = tag;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sock(s: &str) -> SocketAddr {
+        s.parse().unwrap()
+    }
+
+    fn addr(s: &str) -> MultiAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn publish_set_keeps_relay_primary_and_unverified_fallback() {
+        let typed = build_typed_self_address_set(
+            [sock("203.0.113.10:10004")],
+            Vec::<MultiAddr>::new(),
+            Some(sock("198.51.100.1:45000")),
+            |_| false,
+        );
+
+        assert_eq!(
+            typed,
+            vec![
+                (addr("/ip4/198.51.100.1/udp/45000/quic"), AddressType::Relay),
+                (
+                    addr("/ip4/203.0.113.10/udp/10004/quic"),
+                    AddressType::Unverified,
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn publish_set_keeps_relay_primary_and_direct_fallback() {
+        let proven = sock("203.0.113.10:10004");
+        let typed = build_typed_self_address_set(
+            [proven],
+            Vec::<MultiAddr>::new(),
+            Some(sock("198.51.100.1:45000")),
+            |sa| sa == proven,
+        );
+
+        assert_eq!(
+            typed,
+            vec![
+                (addr("/ip4/198.51.100.1/udp/45000/quic"), AddressType::Relay),
+                (
+                    addr("/ip4/203.0.113.10/udp/10004/quic"),
+                    AddressType::Direct,
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn publish_set_without_relay_prefers_direct_over_unverified() {
+        let proven = sock("203.0.113.10:10004");
+        let typed = build_typed_self_address_set(
+            [proven, sock("203.0.113.11:10004")],
+            Vec::<MultiAddr>::new(),
+            None,
+            |sa| sa == proven,
+        );
+
+        assert_eq!(
+            typed,
+            vec![(
+                addr("/ip4/203.0.113.10/udp/10004/quic"),
+                AddressType::Direct,
+            )]
+        );
+    }
+
+    #[test]
+    fn publish_set_keeps_unverified_for_family_without_direct() {
+        let proven_v4 = sock("203.0.113.10:10004");
+        let unverified_v6 = sock("[2001:db8::10]:10004");
+        let typed = build_typed_self_address_set(
+            [proven_v4, unverified_v6],
+            Vec::<MultiAddr>::new(),
+            Some(sock("198.51.100.1:45000")),
+            |sa| sa == proven_v4,
+        );
+
+        assert_eq!(
+            typed,
+            vec![
+                (addr("/ip4/198.51.100.1/udp/45000/quic"), AddressType::Relay),
+                (
+                    addr("/ip4/203.0.113.10/udp/10004/quic"),
+                    AddressType::Direct,
+                ),
+                (
+                    addr("/ip6/2001:db8::10/udp/10004/quic"),
+                    AddressType::Unverified,
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn publish_set_keeps_one_best_non_relay_per_family() {
+        let older_v4 = sock("203.0.113.10:10004");
+        let newer_v4 = sock("203.0.113.11:10004");
+        let typed = build_typed_self_address_set(
+            [older_v4, newer_v4],
+            Vec::<MultiAddr>::new(),
+            None,
+            |sa| sa == older_v4 || sa == newer_v4,
+        );
+
+        assert_eq!(
+            typed,
+            vec![(
+                addr("/ip4/203.0.113.11/udp/10004/quic"),
+                AddressType::Direct,
+            )]
+        );
+    }
+
+    #[test]
+    fn publish_set_without_relay_publishes_unverified_when_no_direct() {
+        let typed = build_typed_self_address_set(
+            [sock("203.0.113.11:10004")],
+            Vec::<MultiAddr>::new(),
+            None,
+            |_| false,
+        );
+
+        assert_eq!(
+            typed,
+            vec![(
+                addr("/ip4/203.0.113.11/udp/10004/quic"),
+                AddressType::Unverified,
+            )]
+        );
+    }
+
+    #[test]
+    fn publish_set_dedupes_listen_address_after_observed_address() {
+        let typed = build_typed_self_address_set(
+            [sock("203.0.113.10:10004")],
+            [addr("/ip4/203.0.113.10/udp/10004/quic")],
+            None,
+            |_| false,
+        );
+
+        assert_eq!(
+            typed,
+            vec![(
+                addr("/ip4/203.0.113.10/udp/10004/quic"),
+                AddressType::Unverified,
+            )]
+        );
     }
 }

--- a/src/reachability/session.rs
+++ b/src/reachability/session.rs
@@ -95,13 +95,25 @@ pub(crate) async fn run_relay_acquisition(
     let own_key = *dht.peer_id().to_bytes();
     let closest = dht.find_closest_nodes_local(&own_key, dht.k_value()).await;
 
-    let candidates: Vec<RelayCandidate> = closest
-        .iter()
-        .filter_map(|node| {
-            let direct = DhtNetworkManager::first_direct_dialable(node)?;
-            Some(RelayCandidate::new(node.peer_id, direct))
-        })
-        .collect();
+    debug!(
+        closest_count = closest.len(),
+        "relay acquisition: evaluating closest peers for Direct relay candidates"
+    );
+
+    let mut candidates: Vec<RelayCandidate> = Vec::new();
+    for node in &closest {
+        let typed = node.typed_addresses();
+        let direct = DhtNetworkManager::first_direct_dialable(node);
+        debug!(
+            peer = %node.peer_id.to_hex(),
+            typed_addresses = ?typed,
+            selected_direct = ?direct,
+            "relay acquisition: evaluated peer as relay candidate"
+        );
+        if let Some(direct) = direct {
+            candidates.push(RelayCandidate::new(node.peer_id, direct));
+        }
+    }
 
     if candidates.is_empty() {
         warn!("relay acquisition: no direct-addressable candidates in routing table");

--- a/src/reachability/session.rs
+++ b/src/reachability/session.rs
@@ -53,9 +53,9 @@ pub(crate) enum RelayAcquisitionOutcome {
     /// The caller (acquisition driver) is responsible for:
     ///
     /// 1. Storing the relayer peer ID for the K-closest eviction monitor.
-    /// 2. Publishing the full typed self-record (direct addresses +
-    ///    relay-allocated address tagged [`AddressType::Relay`]) to K
-    ///    closest peers.
+    /// 2. Publishing the full typed self-record (relay-allocated address
+    ///    tagged [`AddressType::Relay`] first, then one best non-relay
+    ///    address per IP family) to K closest peers.
     /// 3. Disabling local relay serving so this node does not form a
     ///    relay loop by accepting reservations while its own traffic
     ///    tunnels through someone else.

--- a/src/transport/external_addresses.rs
+++ b/src/transport/external_addresses.rs
@@ -11,17 +11,18 @@
 // distributed under these licenses is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
-//! Pinned external addresses for this node.
+//! External addresses for this node.
 //!
 //! ## Why this exists
 //!
 //! A node behind NAT discovers its external (post-NAT) address from QUIC
-//! `OBSERVED_ADDRESS` frames sent by bootstrap peers during the initial
-//! connection phase. These addresses are **pinned** — once observed, they
-//! are retained for the lifetime of the process.
+//! `OBSERVED_ADDRESS` frames. A single report is retained as an
+//! unverified candidate so peers can attempt it after the relay. Once the
+//! transport emits `ExternalAddressDiscovered`, the address is **pinned**
+//! as direct and retained for the lifetime of the process.
 //!
 //! When the node acquires a MASQUE relay, the relay-allocated address is
-//! stored alongside the pinned direct addresses. The relay address is
+//! stored alongside the non-relay addresses. The relay address is
 //! considered the **preferred** address and is returned first by
 //! [`ExternalAddresses::all_addresses`].
 //!
@@ -32,6 +33,9 @@
 //! refresh the cache, and the direct address ages out. Pinning eliminates
 //! this problem: the address observed at bootstrap is valid for as long as
 //! the NAT mapping holds, and the relay provides reachability regardless.
+//! Unverified candidates are still retained because a relay-only self
+//! record gives dialers no chance to try a NAT mapping that peers have
+//! already observed.
 
 use std::net::SocketAddr;
 
@@ -45,10 +49,18 @@ use std::net::SocketAddr;
 /// published to K-closest peers.
 const MAX_DIRECT_ADDRESSES: usize = 16;
 
-/// Pinned external addresses observed from QUIC peers and the relay layer.
+/// Maximum number of observed-but-unproven addresses retained.
+///
+/// Kept separate from [`MAX_DIRECT_ADDRESSES`] so a stream of unverified
+/// NAT rebinding reports cannot evict addresses already pinned as direct.
+const MAX_UNVERIFIED_ADDRESSES: usize = 16;
+
+/// External addresses observed from QUIC peers and the relay layer.
 ///
 /// Direct addresses are pinned on first observation and evicted
-/// oldest-first when [`MAX_DIRECT_ADDRESSES`] is reached.
+/// oldest-first when [`MAX_DIRECT_ADDRESSES`] is reached. Unverified
+/// addresses are single-peer observations that have not been promoted to
+/// direct yet; they are also insertion-ordered and capped.
 /// The relay address is set/cleared by the relay acquisition driver.
 #[derive(Debug, Default)]
 pub(crate) struct ExternalAddresses {
@@ -56,6 +68,9 @@ pub(crate) struct ExternalAddresses {
     /// received during bootstrap. Insertion-ordered, deduplicated, capped
     /// at [`MAX_DIRECT_ADDRESSES`].
     direct: Vec<SocketAddr>,
+    /// Observed external addresses that are publishable as Unverified but
+    /// have not been promoted/pinned as Direct.
+    unverified: Vec<SocketAddr>,
     /// Relay-allocated address. `Some` when a MASQUE relay is held, `None`
     /// otherwise.
     relay: Option<SocketAddr>,
@@ -76,6 +91,7 @@ impl ExternalAddresses {
         if Some(addr) == self.relay || self.direct.contains(&addr) {
             return false;
         }
+        self.unverified.retain(|unverified| *unverified != addr);
         if self.direct.len() >= MAX_DIRECT_ADDRESSES {
             self.direct.remove(0);
         }
@@ -83,10 +99,37 @@ impl ExternalAddresses {
         true
     }
 
+    /// Retain an observed external address as an unverified publish
+    /// candidate.
+    ///
+    /// Returns `true` only when this changes the publishable address set.
+    /// Relay and already-pinned direct addresses are ignored.
+    pub(crate) fn record_unverified(&mut self, addr: SocketAddr) -> bool {
+        let addr = saorsa_transport::shared::normalize_socket_addr(addr);
+        if Some(addr) == self.relay || self.direct.contains(&addr) {
+            return false;
+        }
+        if let Some(pos) = self
+            .unverified
+            .iter()
+            .position(|unverified| *unverified == addr)
+        {
+            let existing = self.unverified.remove(pos);
+            self.unverified.push(existing);
+            return false;
+        }
+        if self.unverified.len() >= MAX_UNVERIFIED_ADDRESSES {
+            self.unverified.remove(0);
+        }
+        self.unverified.push(addr);
+        true
+    }
+
     /// Set the relay-allocated address.
     pub(crate) fn set_relay(&mut self, addr: SocketAddr) {
         let addr = saorsa_transport::shared::normalize_socket_addr(addr);
         self.direct.retain(|direct| *direct != addr);
+        self.unverified.retain(|unverified| *unverified != addr);
         self.relay = Some(addr);
     }
 
@@ -96,15 +139,20 @@ impl ExternalAddresses {
     }
 
     /// All external addresses, **relay first** (preferred), then pinned
-    /// direct addresses. If the relay address also appears in the direct
-    /// set, it is not duplicated.
+    /// direct addresses, then unverified observed addresses. If the relay
+    /// address also appears in either non-relay set, it is not duplicated.
     pub(crate) fn all_addresses(&self) -> Vec<SocketAddr> {
-        let mut out = Vec::with_capacity(self.direct.len() + 1);
+        let mut out = Vec::with_capacity(self.direct.len() + self.unverified.len() + 1);
         if let Some(relay) = self.relay {
             out.push(relay);
         }
         for &addr in &self.direct {
             if Some(addr) != self.relay {
+                out.push(addr);
+            }
+        }
+        for &addr in &self.unverified {
+            if Some(addr) != self.relay && !self.direct.contains(&addr) {
                 out.push(addr);
             }
         }
@@ -114,6 +162,19 @@ impl ExternalAddresses {
     /// Only the pinned direct addresses (no relay).
     pub(crate) fn direct_addresses(&self) -> Vec<SocketAddr> {
         self.direct.clone()
+    }
+
+    /// All non-relay addresses that should be considered for typed
+    /// self-publication.
+    pub(crate) fn non_relay_addresses(&self) -> Vec<SocketAddr> {
+        let mut out = Vec::with_capacity(self.direct.len() + self.unverified.len());
+        out.extend(self.direct.iter().copied());
+        for &addr in &self.unverified {
+            if !self.direct.contains(&addr) {
+                out.push(addr);
+            }
+        }
+        out
     }
 
     /// The relay address, if any.
@@ -160,6 +221,44 @@ mod tests {
         ext.set_relay(relay);
         assert_eq!(ext.all_addresses(), vec![relay, direct]);
         assert_eq!(ext.relay_address(), Some(relay));
+    }
+
+    #[test]
+    fn all_addresses_includes_unverified_after_relay() {
+        let mut ext = ExternalAddresses::new();
+        let relay = addr(1, 9000);
+        let unverified = addr(2, 9000);
+
+        ext.set_relay(relay);
+        assert!(ext.record_unverified(unverified));
+
+        assert_eq!(ext.all_addresses(), vec![relay, unverified]);
+        assert_eq!(ext.non_relay_addresses(), vec![unverified]);
+    }
+
+    #[test]
+    fn pin_direct_removes_matching_unverified() {
+        let mut ext = ExternalAddresses::new();
+        let direct = addr(1, 9000);
+
+        assert!(ext.record_unverified(direct));
+        assert!(ext.pin_direct(direct));
+
+        assert_eq!(ext.direct_addresses(), vec![direct]);
+        assert_eq!(ext.non_relay_addresses(), vec![direct]);
+        assert_eq!(ext.all_addresses(), vec![direct]);
+    }
+
+    #[test]
+    fn set_relay_removes_matching_unverified() {
+        let mut ext = ExternalAddresses::new();
+        let relay = addr(1, 9000);
+
+        assert!(ext.record_unverified(relay));
+        ext.set_relay(relay);
+
+        assert_eq!(ext.all_addresses(), vec![relay]);
+        assert!(ext.non_relay_addresses().is_empty());
     }
 
     #[test]

--- a/src/transport/external_addresses.rs
+++ b/src/transport/external_addresses.rs
@@ -71,18 +71,22 @@ impl ExternalAddresses {
     ///
     /// Inserts `addr` if it is not already present. When the list is at
     /// capacity, the oldest entry is evicted first.
-    pub(crate) fn pin_direct(&mut self, addr: SocketAddr) {
-        if self.direct.contains(&addr) {
-            return;
+    pub(crate) fn pin_direct(&mut self, addr: SocketAddr) -> bool {
+        let addr = saorsa_transport::shared::normalize_socket_addr(addr);
+        if Some(addr) == self.relay || self.direct.contains(&addr) {
+            return false;
         }
         if self.direct.len() >= MAX_DIRECT_ADDRESSES {
             self.direct.remove(0);
         }
         self.direct.push(addr);
+        true
     }
 
     /// Set the relay-allocated address.
     pub(crate) fn set_relay(&mut self, addr: SocketAddr) {
+        let addr = saorsa_transport::shared::normalize_socket_addr(addr);
+        self.direct.retain(|direct| *direct != addr);
         self.relay = Some(addr);
     }
 
@@ -140,9 +144,9 @@ mod tests {
     fn pin_direct_dedup() {
         let mut ext = ExternalAddresses::new();
         let a = addr(1, 9000);
-        ext.pin_direct(a);
-        ext.pin_direct(a);
-        ext.pin_direct(a);
+        assert!(ext.pin_direct(a));
+        assert!(!ext.pin_direct(a));
+        assert!(!ext.pin_direct(a));
         assert_eq!(ext.direct_addresses(), vec![a]);
         assert_eq!(ext.all_addresses(), vec![a]);
     }
@@ -178,6 +182,31 @@ mod tests {
         ext.set_relay(same);
         // Should appear only once, as relay (preferred position).
         assert_eq!(ext.all_addresses(), vec![same]);
+        assert!(ext.direct_addresses().is_empty());
+    }
+
+    #[test]
+    fn relay_address_is_not_pinned_as_direct() {
+        let mut ext = ExternalAddresses::new();
+        let same = addr(1, 9000);
+        ext.set_relay(same);
+        assert!(!ext.pin_direct(same));
+        assert!(ext.direct_addresses().is_empty());
+        assert_eq!(ext.all_addresses(), vec![same]);
+    }
+
+    #[test]
+    fn relay_address_is_normalized_before_direct_dedup() {
+        let mut ext = ExternalAddresses::new();
+        let plain = addr(1, 9000);
+        let mapped = "[::ffff:192.0.2.1]:9000".parse().unwrap();
+
+        ext.set_relay(mapped);
+
+        assert_eq!(ext.relay_address(), Some(plain));
+        assert!(!ext.pin_direct(plain));
+        assert!(ext.direct_addresses().is_empty());
+        assert_eq!(ext.all_addresses(), vec![plain]);
     }
 
     #[test]

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -1297,23 +1297,40 @@ impl DualStackNetworkNode<P2pLinkTransport> {
                         }) => {
                             if flag.load(Ordering::Relaxed) {
                                 // Already proven; nothing more to learn here.
+                                tracing::trace!(
+                                    remote = %addr,
+                                    "classifier: direct reachability already observed; ignoring inbound handshake"
+                                );
                                 continue;
                             }
                             let Some(socket_addr) = addr.as_socket_addr() else {
+                                tracing::trace!(
+                                    remote = %addr,
+                                    "classifier: ignoring inbound handshake from non-socket transport"
+                                );
                                 continue;
                             };
                             let normalized =
                                 saorsa_transport::shared::normalize_socket_addr(socket_addr);
                             if dialed.contains(&normalized) {
                                 // Simultaneous-open reply to our own dial; not proof.
+                                tracing::debug!(
+                                    remote = %normalized,
+                                    dialed_targets = dialed.len(),
+                                    "classifier: ignoring inbound handshake for an address we dialed"
+                                );
                                 continue;
                             }
                             let remote_ip = canonicalize_ip(normalized.ip());
-                            let is_own_external_ip = external
-                                .lock()
-                                .direct_addresses()
-                                .into_iter()
+                            let pinned_direct = external.lock().direct_addresses();
+                            let is_own_external_ip = pinned_direct
+                                .iter()
                                 .any(|sa| canonicalize_ip(sa.ip()) == remote_ip);
+                            tracing::debug!(
+                                remote = %normalized,
+                                pinned_direct = ?pinned_direct,
+                                "classifier: inbound server-side handshake is being evaluated"
+                            );
                             if is_own_external_ip {
                                 tracing::trace!(
                                     remote = %normalized,

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -42,11 +42,11 @@ use crate::error::{GeoRejectionError, GeographicConfig};
 use crate::security::canonicalize_ip;
 use crate::transport::external_addresses::ExternalAddresses;
 use anyhow::{Context, Result};
-use dashmap::DashSet;
-use std::collections::HashMap;
+use dashmap::{DashMap, DashSet};
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, SocketAddr, SocketAddrV6};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::sync::{RwLock, broadcast};
 use tokio::time::sleep;
@@ -1254,96 +1254,195 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         (rx, relay_rx, relay_lost_rx)
     }
 
-    /// Spawn a background task per stack that watches `P2pEvent::PeerConnected`
-    /// and sets `flag` the first time an unsolicited inbound handshake
-    /// completes — i.e. a connection accepted from a remote address that is
+    /// Spawn one background task per bound stack (v4, v6) to classify
+    /// inbound connections and accumulate per-pinned-external proof sets.
+    ///
+    /// ## What this proves
+    ///
+    /// `Side::Server` alone is not proof of cold-dialability — it only
+    /// proves "a packet landed at our listener," which on a NAT'd host
+    /// can be a redial through a NAT pinhole that the inbound peer
+    /// already knew about. The classifier records an inbound as proof
+    /// of cold-dialability for an external `E` iff **all** hold:
+    ///
+    /// 1. `Side::Server` (someone connected to us, we did not initiate).
+    /// 2. The remote socket is not in `dialed_addrs` — guards
+    ///    simultaneous-open replies. Pre-populated at every dial site
+    ///    (`TransportHandle::connect_peer`).
+    /// 3. The remote IP is not in `known_peer_ips` at the moment of the
+    ///    event — i.e. not a peer we have ever dialed or accepted from
+    ///    before. Closes the bootstrap-redial / pinhole-self-fulfillment
+    ///    case where a peer we previously connected to opens a fresh
+    ///    QUIC connection through their pre-existing NAT binding.
+    /// 4. The remote IP is not equal to any of our own pinned external
+    ///    IPs — sibling-hairpin filter (multiple nodes behind one shared
+    ///    NAT see each other's traffic as "inbound from our public IP"
+    ///    after MASQUERADE; this never left the LAN).
+    /// 5. The inbound's stack family (v4 vs v6) matches `E`'s family —
+    ///    a v4 inbound proves nothing about a v6 external.
+    ///
+    /// When all conditions hold, the remote IP is added to every matching
+    /// external's observer set in `proven_externals`. Once any external
+    /// reaches `MIN_DISTINCT_OBSERVERS_FOR_DIRECT` distinct observer IPs
+    /// it is considered cold-dialable, and
+    /// [`TransportHandle::is_external_proven`] returns `true` for it.
+    ///
+    /// ## What this also does
+    ///
+    /// On every `PeerConnected` event (any `Side`), the remote IP is
+    /// recorded in `known_peer_ips`. This means the very first inbound
+    /// from a stranger IP can contribute proof, but every subsequent
+    /// inbound from that same IP is recognised as not source-disjoint
+    /// and skipped — preventing one chatty peer from inflating its own
+    /// proof beyond the single observer slot it deserves.
+    ///
+    /// `Side::Client` events also write `known_peer_ips`, ensuring that
+    /// a peer we dial first cannot later "appear unsolicited" via a
+    /// pinhole redial — even if their NAT has remapped them to a port
     /// not in `dialed_addrs`.
-    ///
-    /// This is the passive NAT-reachability classifier: one confirmed
-    /// inbound from a peer we never dialed proves that our listener is
-    /// cold-dialable, which is what [`AcquisitionDriver::publish_typed_set`]
-    /// needs to decide whether to publish addresses tagged `Direct` or
-    /// `Unverified`.
-    ///
-    /// `dialed_addrs` is expected to be populated at the dial site
-    /// (`TransportHandle::connect_peer`) *before* the dial starts so that a
-    /// simultaneous-open race cannot mis-classify a reply as unsolicited.
-    ///
-    /// `external_addresses` is consulted to reject sibling-hairpin
-    /// handshakes: on a NAT droplet that hosts multiple nodes behind a
-    /// shared public IP, a sibling node opening a connection to us appears
-    /// as inbound from our own external IP after MASQUERADE. That traffic
-    /// is NOT evidence of public reachability — it never left the droplet.
-    /// Without this filter, sibling hairpins flip the flag true on NAT'd
-    /// hosts and defeat the whole Direct/Unverified distinction.
     pub fn spawn_direct_reachability_classifier(
         &self,
         dialed_addrs: Arc<DashSet<SocketAddr>>,
-        flag: Arc<AtomicBool>,
+        known_peer_ips: Arc<DashSet<IpAddr>>,
+        proven_externals: Arc<DashMap<SocketAddr, HashSet<IpAddr>>>,
         external_addresses: Arc<parking_lot::Mutex<ExternalAddresses>>,
     ) {
         for node in [&self.v6, &self.v4].into_iter().flatten() {
             let mut p2p_rx = node.transport.endpoint().subscribe();
             let dialed = Arc::clone(&dialed_addrs);
-            let flag = Arc::clone(&flag);
+            let known = Arc::clone(&known_peer_ips);
+            let proven = Arc::clone(&proven_externals);
             let external = Arc::clone(&external_addresses);
             tokio::spawn(async move {
                 loop {
                     match p2p_rx.recv().await {
-                        Ok(saorsa_transport::P2pEvent::PeerConnected {
-                            addr,
-                            side: Side::Server,
-                            ..
-                        }) => {
-                            if flag.load(Ordering::Relaxed) {
-                                // Already proven; nothing more to learn here.
-                                tracing::trace!(
-                                    remote = %addr,
-                                    "classifier: direct reachability already observed; ignoring inbound handshake"
-                                );
-                                continue;
-                            }
+                        Ok(saorsa_transport::P2pEvent::PeerConnected { addr, side, .. }) => {
+                            // Drop non-socket transports (BLE, LoRa) — proof
+                            // is tied to QUIC NAT mappings.
                             let Some(socket_addr) = addr.as_socket_addr() else {
                                 tracing::trace!(
                                     remote = %addr,
-                                    "classifier: ignoring inbound handshake from non-socket transport"
+                                    "classifier: ignoring non-socket transport handshake"
                                 );
                                 continue;
                             };
                             let normalized =
                                 saorsa_transport::shared::normalize_socket_addr(socket_addr);
-                            if dialed.contains(&normalized) {
-                                // Simultaneous-open reply to our own dial; not proof.
-                                tracing::debug!(
+                            let remote_ip = canonicalize_ip(normalized.ip());
+
+                            // Snapshot whether this IP was already known
+                            // BEFORE we record the event. Source-disjointness
+                            // is evaluated against the prior state — recording
+                            // first would lose the signal.
+                            let was_known_before =
+                                known.contains(&remote_ip) || dialed.contains(&normalized);
+
+                            // Always record so future inbounds from the same
+                            // IP are correctly recognised as not
+                            // source-disjoint.
+                            known.insert(remote_ip);
+
+                            // Only Side::Server inbounds are candidates for
+                            // proof. Side::Client (we initiated) only updates
+                            // `known_peer_ips`.
+                            if !matches!(side, Side::Server) {
+                                tracing::trace!(
                                     remote = %normalized,
-                                    dialed_targets = dialed.len(),
-                                    "classifier: ignoring inbound handshake for an address we dialed"
+                                    side = ?side,
+                                    "classifier: recorded outbound peer; not a proof candidate"
                                 );
                                 continue;
                             }
-                            let remote_ip = canonicalize_ip(normalized.ip());
+
+                            if was_known_before {
+                                tracing::debug!(
+                                    remote = %normalized,
+                                    "classifier: ignoring inbound from previously-known peer \
+                                     (not source-disjoint; possible pinhole redial)"
+                                );
+                                continue;
+                            }
+
+                            // Sibling-hairpin filter: source IP equals one of
+                            // our pinned externals → traffic that never left
+                            // the shared NAT.
                             let pinned_direct = external.lock().direct_addresses();
                             let is_own_external_ip = pinned_direct
                                 .iter()
                                 .any(|sa| canonicalize_ip(sa.ip()) == remote_ip);
-                            tracing::debug!(
-                                remote = %normalized,
-                                pinned_direct = ?pinned_direct,
-                                "classifier: inbound server-side handshake is being evaluated"
-                            );
                             if is_own_external_ip {
                                 tracing::trace!(
                                     remote = %normalized,
-                                    "classifier: ignoring sibling-hairpin handshake from own external IP"
+                                    "classifier: ignoring sibling-hairpin handshake from \
+                                     own external IP"
                                 );
                                 continue;
                             }
-                            tracing::info!(
-                                remote = %normalized,
-                                "direct reachability observed: unsolicited inbound handshake \
-                                 from peer not in dialed set"
-                            );
-                            flag.store(true, Ordering::Release);
+
+                            // Per-family attribution by the inbound's family
+                            // (not the bind family of the receiving stack):
+                            // a dual-stack v6 socket bound to `[::]:port`
+                            // accepts both v4 and v6 traffic, so we cannot
+                            // assume "v6 stack receives only v6 inbounds."
+                            // After `normalize_socket_addr`, IPv4-mapped-v6
+                            // addresses (`::ffff:a.b.c.d`) are flattened to
+                            // plain v4, so the inbound's `is_ipv6()` is the
+                            // canonical family. A v4 inbound only credits
+                            // v4 externals; same for v6.
+                            //
+                            // For a host with no externals of the matching
+                            // family yet pinned, the proof is dropped
+                            // silently — nothing to attribute it to. The
+                            // next inbound after pinning lands will start
+                            // accumulating proof.
+                            let inbound_is_v6 = normalized.is_ipv6();
+                            let attributable: Vec<SocketAddr> = pinned_direct
+                                .iter()
+                                .filter(|sa| sa.is_ipv6() == inbound_is_v6)
+                                .copied()
+                                .collect();
+
+                            if attributable.is_empty() {
+                                tracing::trace!(
+                                    remote = %normalized,
+                                    inbound_is_v6,
+                                    "classifier: no pinned externals of matching family; \
+                                     proof deferred until address pin"
+                                );
+                                continue;
+                            }
+
+                            for ext in attributable {
+                                let normalized_ext =
+                                    saorsa_transport::shared::normalize_socket_addr(ext);
+                                let mut entry = proven.entry(normalized_ext).or_default();
+                                let inserted = entry.insert(remote_ip);
+                                let count = entry.len();
+                                drop(entry);
+                                if inserted {
+                                    if count >= crate::transport_handle::MIN_DISTINCT_OBSERVERS_FOR_DIRECT {
+                                        tracing::info!(
+                                            external = %normalized_ext,
+                                            observers = count,
+                                            threshold =
+                                                crate::transport_handle::MIN_DISTINCT_OBSERVERS_FOR_DIRECT,
+                                            new_observer = %remote_ip,
+                                            "classifier: external promoted to Direct \
+                                             (source-disjoint quorum reached)"
+                                        );
+                                    } else {
+                                        tracing::debug!(
+                                            external = %normalized_ext,
+                                            observers = count,
+                                            threshold =
+                                                crate::transport_handle::MIN_DISTINCT_OBSERVERS_FOR_DIRECT,
+                                            new_observer = %remote_ip,
+                                            "classifier: source-disjoint observer recorded; \
+                                             below threshold"
+                                        );
+                                    }
+                                }
+                            }
                         }
                         Err(broadcast::error::RecvError::Closed) => break,
                         Err(broadcast::error::RecvError::Lagged(_)) => continue,

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -194,6 +194,233 @@ fn handle_address_event_drop<T>(
     }
 }
 
+/// Handle a `P2pEvent::PeerConnected` event for the passive
+/// reachability classifier.
+///
+/// Runs the source-disjoint / sibling-hairpin filters, updates
+/// `known_peer_ips`, and on a passing `Side::Server` inbound:
+/// 1. Marks the peer's IP as `proof_eligible`.
+/// 2. Credits the peer's IP against any externals they have already
+///    reported observing us at (intersected with currently pinned
+///    externals).
+///
+/// Pure with respect to its arguments — extracted from
+/// [`DualStackNetworkNode::spawn_direct_reachability_classifier`] so
+/// the per-event logic is independently testable without spawning the
+/// whole broadcast loop.
+fn handle_peer_connected_for_proof(
+    addr: saorsa_transport::TransportAddr,
+    side: Side,
+    dialed: &DashSet<SocketAddr>,
+    known: &DashSet<IpAddr>,
+    external: &parking_lot::Mutex<ExternalAddresses>,
+    observations: &DashMap<IpAddr, HashSet<SocketAddr>>,
+    eligible: &DashSet<IpAddr>,
+    proven: &DashMap<SocketAddr, HashSet<IpAddr>>,
+) {
+    let Some(socket_addr) = addr.as_socket_addr() else {
+        tracing::trace!(
+            remote = %addr,
+            "classifier: ignoring non-socket transport handshake"
+        );
+        return;
+    };
+    let normalized = saorsa_transport::shared::normalize_socket_addr(socket_addr);
+    let remote_ip = canonicalize_ip(normalized.ip());
+
+    let was_known_before = known.contains(&remote_ip) || dialed.contains(&normalized);
+    known.insert(remote_ip);
+
+    if !matches!(side, Side::Server) {
+        tracing::trace!(
+            remote = %normalized,
+            side = ?side,
+            "classifier: recorded outbound peer; not a proof candidate"
+        );
+        return;
+    }
+
+    if was_known_before {
+        tracing::debug!(
+            remote = %normalized,
+            "classifier: ignoring inbound from previously-known peer \
+             (not source-disjoint; possible pinhole redial)"
+        );
+        return;
+    }
+
+    let pinned_direct = external.lock().direct_addresses();
+    let is_own_external_ip = pinned_direct
+        .iter()
+        .any(|sa| canonicalize_ip(sa.ip()) == remote_ip);
+    if is_own_external_ip {
+        tracing::trace!(
+            remote = %normalized,
+            "classifier: ignoring sibling-hairpin handshake from own external IP"
+        );
+        return;
+    }
+
+    eligible.insert(remote_ip);
+
+    if let Some(reports) = observations.get(&remote_ip) {
+        // Materialise to a local Vec so the DashMap shard guard is
+        // released before recursing into other DashMaps; defensive
+        // against a future change adding self-referential writes.
+        let prior: Vec<SocketAddr> = reports.iter().copied().collect();
+        drop(reports);
+        for ext in prior {
+            credit_observation(remote_ip, ext, &pinned_direct, proven);
+        }
+    } else {
+        tracing::trace!(
+            remote = %remote_ip,
+            "classifier: peer is now proof-eligible but has no prior observations; \
+             credit deferred until OBSERVED_ADDRESS frame arrives"
+        );
+    }
+}
+
+/// Handle a `P2pEvent::PeerObservedExternal` event.
+///
+/// Records the peer's report in `peer_observations` (capped at
+/// [`crate::transport_handle::MAX_OBSERVATIONS_PER_PEER`]) and, if the
+/// peer is already proof-eligible and the reported external is currently
+/// pinned, credits the observation against `proven_externals`.
+fn handle_peer_observed_external(
+    peer_addr: SocketAddr,
+    observed_external: SocketAddr,
+    external: &parking_lot::Mutex<ExternalAddresses>,
+    observations: &DashMap<IpAddr, HashSet<SocketAddr>>,
+    eligible: &DashSet<IpAddr>,
+    proven: &DashMap<SocketAddr, HashSet<IpAddr>>,
+) {
+    let normalized_peer = saorsa_transport::shared::normalize_socket_addr(peer_addr);
+    let peer_ip = canonicalize_ip(normalized_peer.ip());
+    let normalized_ext = saorsa_transport::shared::normalize_socket_addr(observed_external);
+
+    let recorded = {
+        let mut entry = observations.entry(peer_ip).or_default();
+        if entry.len() >= crate::transport_handle::MAX_OBSERVATIONS_PER_PEER
+            && !entry.contains(&normalized_ext)
+        {
+            tracing::debug!(
+                peer = %peer_ip,
+                external = %normalized_ext,
+                cap = crate::transport_handle::MAX_OBSERVATIONS_PER_PEER,
+                "classifier: dropping OBSERVED_ADDRESS report; per-peer observation cap reached"
+            );
+            false
+        } else {
+            entry.insert(normalized_ext)
+        }
+    };
+
+    if !recorded {
+        return;
+    }
+
+    if !eligible.contains(&peer_ip) {
+        tracing::trace!(
+            peer = %peer_ip,
+            external = %normalized_ext,
+            "classifier: observation recorded; peer not yet proof-eligible — credit deferred"
+        );
+        return;
+    }
+
+    let pinned_direct = external.lock().direct_addresses();
+    credit_observation(peer_ip, normalized_ext, &pinned_direct, proven);
+}
+
+/// Back-fill `proven_externals` when an external is freshly pinned.
+///
+/// Walks `peer_observations` and credits every proof-eligible peer that
+/// previously reported `external` — closing the timing window where a
+/// peer's `OBSERVED_ADDRESS` report arrives before saorsa-transport's
+/// pinning quorum is reached. The pinned-status check is implicit
+/// (`external` is being pinned by the caller), so no further gating is
+/// needed before recording.
+fn back_fill_proof_on_pin(
+    external: SocketAddr,
+    observations: &DashMap<IpAddr, HashSet<SocketAddr>>,
+    eligible: &DashSet<IpAddr>,
+    proven: &DashMap<SocketAddr, HashSet<IpAddr>>,
+) {
+    let normalized_ext = saorsa_transport::shared::normalize_socket_addr(external);
+    for entry in observations.iter() {
+        let peer_ip = *entry.key();
+        if !eligible.contains(&peer_ip) {
+            continue;
+        }
+        if entry.value().contains(&normalized_ext) {
+            record_attributed_observer(peer_ip, normalized_ext, proven);
+        }
+    }
+}
+
+/// Credit `peer_ip` against `external` iff the address is currently
+/// pinned. Defers to [`record_attributed_observer`] for the actual
+/// write+log.
+///
+/// Used by the live event handlers; `back_fill_proof_on_pin` calls
+/// `record_attributed_observer` directly because the pinned check is
+/// trivially satisfied at the call site.
+fn credit_observation(
+    peer_ip: IpAddr,
+    external: SocketAddr,
+    pinned_direct: &[SocketAddr],
+    proven: &DashMap<SocketAddr, HashSet<IpAddr>>,
+) {
+    let normalized_ext = saorsa_transport::shared::normalize_socket_addr(external);
+    if !pinned_direct.contains(&normalized_ext) {
+        tracing::trace!(
+            peer = %peer_ip,
+            external = %normalized_ext,
+            "classifier: peer reported external but it is not currently pinned; \
+             back-fill on pin will catch this if quorum is reached later"
+        );
+        return;
+    }
+    record_attributed_observer(peer_ip, normalized_ext, proven);
+}
+
+/// Insert `peer_ip` into `proven_externals[external]` and log threshold
+/// crossings. Caller is responsible for confirming that `external` is
+/// pinned (or being pinned right now).
+fn record_attributed_observer(
+    peer_ip: IpAddr,
+    normalized_ext: SocketAddr,
+    proven: &DashMap<SocketAddr, HashSet<IpAddr>>,
+) {
+    let mut entry = proven.entry(normalized_ext).or_default();
+    let inserted = entry.insert(peer_ip);
+    let count = entry.len();
+    drop(entry);
+
+    if !inserted {
+        return;
+    }
+
+    if count >= crate::transport_handle::MIN_DISTINCT_OBSERVERS_FOR_DIRECT {
+        tracing::info!(
+            external = %normalized_ext,
+            observers = count,
+            threshold = crate::transport_handle::MIN_DISTINCT_OBSERVERS_FOR_DIRECT,
+            new_observer = %peer_ip,
+            "classifier: external promoted to Direct (per-address attribution)"
+        );
+    } else {
+        tracing::debug!(
+            external = %normalized_ext,
+            observers = count,
+            threshold = crate::transport_handle::MIN_DISTINCT_OBSERVERS_FOR_DIRECT,
+            new_observer = %peer_ip,
+            "classifier: source-disjoint observer recorded; below threshold"
+        );
+    }
+}
+
 #[allow(dead_code)]
 impl P2PNetworkNode<P2pLinkTransport> {
     /// Create a new P2P network node with default P2pLinkTransport
@@ -1154,6 +1381,9 @@ impl DualStackNetworkNode<P2pLinkTransport> {
     pub fn spawn_peer_address_update_forwarder(
         &self,
         external_addresses: Arc<parking_lot::Mutex<ExternalAddresses>>,
+        peer_observations: Arc<DashMap<IpAddr, HashSet<SocketAddr>>>,
+        proof_eligible_peers: Arc<DashSet<IpAddr>>,
+        proven_externals: Arc<DashMap<SocketAddr, HashSet<IpAddr>>>,
     ) -> (
         tokio::sync::mpsc::Receiver<(SocketAddr, SocketAddr)>,
         tokio::sync::mpsc::Receiver<SocketAddr>,
@@ -1170,6 +1400,9 @@ impl DualStackNetworkNode<P2pLinkTransport> {
             let relay_tx_clone = relay_tx.clone();
             let relay_lost_tx_clone = relay_lost_tx.clone();
             let ext_clone = Arc::clone(&external_addresses);
+            let observations_clone = Arc::clone(&peer_observations);
+            let eligible_clone = Arc::clone(&proof_eligible_peers);
+            let proven_clone = Arc::clone(&proven_externals);
             let drops = Arc::clone(&drop_counter);
             let local_bind = node.local_address();
             tokio::spawn(async move {
@@ -1228,6 +1461,21 @@ impl DualStackNetworkNode<P2pLinkTransport> {
                                     normalized
                                 );
                                 ext_clone.lock().pin_direct(normalized);
+
+                                // Back-fill: any peer that already reported
+                                // observing us at this address before it
+                                // cleared saorsa-transport's pinning quorum
+                                // gets credited now. Without this, the very
+                                // first peer's report (which doesn't trigger
+                                // a pin on its own) is lost — saorsa-core
+                                // would otherwise need a third independent
+                                // observer to reach the proof threshold.
+                                back_fill_proof_on_pin(
+                                    normalized,
+                                    &observations_clone,
+                                    &eligible_clone,
+                                    &proven_clone,
+                                );
                             }
                         }
                         Err(broadcast::error::RecvError::Closed) => {
@@ -1255,15 +1503,15 @@ impl DualStackNetworkNode<P2pLinkTransport> {
     }
 
     /// Spawn one background task per bound stack (v4, v6) to classify
-    /// inbound connections and accumulate per-pinned-external proof sets.
+    /// inbound connections and accumulate per-address proof sets.
     ///
     /// ## What this proves
     ///
     /// `Side::Server` alone is not proof of cold-dialability — it only
     /// proves "a packet landed at our listener," which on a NAT'd host
     /// can be a redial through a NAT pinhole that the inbound peer
-    /// already knew about. The classifier records an inbound as proof
-    /// of cold-dialability for an external `E` iff **all** hold:
+    /// already knew about. The classifier records an inbound peer `P`
+    /// as proof of cold-dialability for an external `E` iff **all** hold:
     ///
     /// 1. `Side::Server` (someone connected to us, we did not initiate).
     /// 2. The remote socket is not in `dialed_addrs` — guards
@@ -1278,14 +1526,32 @@ impl DualStackNetworkNode<P2pLinkTransport> {
     ///    IPs — sibling-hairpin filter (multiple nodes behind one shared
     ///    NAT see each other's traffic as "inbound from our public IP"
     ///    after MASQUERADE; this never left the LAN).
-    /// 5. The inbound's stack family (v4 vs v6) matches `E`'s family —
-    ///    a v4 inbound proves nothing about a v6 external.
+    /// 5. **`P` itself reported `E` via a QUIC `OBSERVED_ADDRESS` frame.**
+    ///    `E` is then the per-address attribution signal: the peer's own
+    ///    statement that they reached us at `E`. A v4 inbound from `P`
+    ///    that reported only `E_v4` cannot promote any other pinned
+    ///    external — same family or otherwise.
     ///
-    /// When all conditions hold, the remote IP is added to every matching
-    /// external's observer set in `proven_externals`. Once any external
-    /// reaches `MIN_DISTINCT_OBSERVERS_FOR_DIRECT` distinct observer IPs
-    /// it is considered cold-dialable, and
+    /// When all conditions hold, the remote IP is added to the **specific**
+    /// reported external's observer set in `proven_externals`. Once any
+    /// external reaches `MIN_DISTINCT_OBSERVERS_FOR_DIRECT` distinct
+    /// observer IPs it is considered cold-dialable, and
     /// [`TransportHandle::is_external_proven`] returns `true` for it.
+    ///
+    /// Per-address attribution is what condition 5 provides. Without it
+    /// (a peer that doesn't send `OBSERVED_ADDRESS` — older clients,
+    /// constrained transports), the inbound contributes no proof.
+    ///
+    /// ## Event ordering
+    ///
+    /// `P2pEvent::PeerConnected` and `P2pEvent::PeerObservedExternal`
+    /// arrive in arbitrary order from saorsa-transport. The classifier
+    /// stores both `peer_observations` and `proof_eligible_peers` and
+    /// credits at whichever event completes the pair (with the further
+    /// requirement that the address is currently in `pinned_direct`).
+    /// A back-fill on `ExternalAddressDiscovered` (in the address
+    /// forwarder) handles the third case where the observation arrives
+    /// before saorsa-transport's pinning quorum clears.
     ///
     /// ## What this also does
     ///
@@ -1306,6 +1572,8 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         known_peer_ips: Arc<DashSet<IpAddr>>,
         proven_externals: Arc<DashMap<SocketAddr, HashSet<IpAddr>>>,
         external_addresses: Arc<parking_lot::Mutex<ExternalAddresses>>,
+        peer_observations: Arc<DashMap<IpAddr, HashSet<SocketAddr>>>,
+        proof_eligible_peers: Arc<DashSet<IpAddr>>,
     ) {
         for node in [&self.v6, &self.v4].into_iter().flatten() {
             let mut p2p_rx = node.transport.endpoint().subscribe();
@@ -1313,136 +1581,35 @@ impl DualStackNetworkNode<P2pLinkTransport> {
             let known = Arc::clone(&known_peer_ips);
             let proven = Arc::clone(&proven_externals);
             let external = Arc::clone(&external_addresses);
+            let observations = Arc::clone(&peer_observations);
+            let eligible = Arc::clone(&proof_eligible_peers);
             tokio::spawn(async move {
                 loop {
                     match p2p_rx.recv().await {
                         Ok(saorsa_transport::P2pEvent::PeerConnected { addr, side, .. }) => {
-                            // Drop non-socket transports (BLE, LoRa) — proof
-                            // is tied to QUIC NAT mappings.
-                            let Some(socket_addr) = addr.as_socket_addr() else {
-                                tracing::trace!(
-                                    remote = %addr,
-                                    "classifier: ignoring non-socket transport handshake"
-                                );
-                                continue;
-                            };
-                            let normalized =
-                                saorsa_transport::shared::normalize_socket_addr(socket_addr);
-                            let remote_ip = canonicalize_ip(normalized.ip());
-
-                            // Snapshot whether this IP was already known
-                            // BEFORE we record the event. Source-disjointness
-                            // is evaluated against the prior state — recording
-                            // first would lose the signal.
-                            let was_known_before =
-                                known.contains(&remote_ip) || dialed.contains(&normalized);
-
-                            // Always record so future inbounds from the same
-                            // IP are correctly recognised as not
-                            // source-disjoint.
-                            known.insert(remote_ip);
-
-                            // Only Side::Server inbounds are candidates for
-                            // proof. Side::Client (we initiated) only updates
-                            // `known_peer_ips`.
-                            if !matches!(side, Side::Server) {
-                                tracing::trace!(
-                                    remote = %normalized,
-                                    side = ?side,
-                                    "classifier: recorded outbound peer; not a proof candidate"
-                                );
-                                continue;
-                            }
-
-                            if was_known_before {
-                                tracing::debug!(
-                                    remote = %normalized,
-                                    "classifier: ignoring inbound from previously-known peer \
-                                     (not source-disjoint; possible pinhole redial)"
-                                );
-                                continue;
-                            }
-
-                            // Sibling-hairpin filter: source IP equals one of
-                            // our pinned externals → traffic that never left
-                            // the shared NAT.
-                            let pinned_direct = external.lock().direct_addresses();
-                            let is_own_external_ip = pinned_direct
-                                .iter()
-                                .any(|sa| canonicalize_ip(sa.ip()) == remote_ip);
-                            if is_own_external_ip {
-                                tracing::trace!(
-                                    remote = %normalized,
-                                    "classifier: ignoring sibling-hairpin handshake from \
-                                     own external IP"
-                                );
-                                continue;
-                            }
-
-                            // Per-family attribution by the inbound's family
-                            // (not the bind family of the receiving stack):
-                            // a dual-stack v6 socket bound to `[::]:port`
-                            // accepts both v4 and v6 traffic, so we cannot
-                            // assume "v6 stack receives only v6 inbounds."
-                            // After `normalize_socket_addr`, IPv4-mapped-v6
-                            // addresses (`::ffff:a.b.c.d`) are flattened to
-                            // plain v4, so the inbound's `is_ipv6()` is the
-                            // canonical family. A v4 inbound only credits
-                            // v4 externals; same for v6.
-                            //
-                            // For a host with no externals of the matching
-                            // family yet pinned, the proof is dropped
-                            // silently — nothing to attribute it to. The
-                            // next inbound after pinning lands will start
-                            // accumulating proof.
-                            let inbound_is_v6 = normalized.is_ipv6();
-                            let attributable: Vec<SocketAddr> = pinned_direct
-                                .iter()
-                                .filter(|sa| sa.is_ipv6() == inbound_is_v6)
-                                .copied()
-                                .collect();
-
-                            if attributable.is_empty() {
-                                tracing::trace!(
-                                    remote = %normalized,
-                                    inbound_is_v6,
-                                    "classifier: no pinned externals of matching family; \
-                                     proof deferred until address pin"
-                                );
-                                continue;
-                            }
-
-                            for ext in attributable {
-                                let normalized_ext =
-                                    saorsa_transport::shared::normalize_socket_addr(ext);
-                                let mut entry = proven.entry(normalized_ext).or_default();
-                                let inserted = entry.insert(remote_ip);
-                                let count = entry.len();
-                                drop(entry);
-                                if inserted {
-                                    if count >= crate::transport_handle::MIN_DISTINCT_OBSERVERS_FOR_DIRECT {
-                                        tracing::info!(
-                                            external = %normalized_ext,
-                                            observers = count,
-                                            threshold =
-                                                crate::transport_handle::MIN_DISTINCT_OBSERVERS_FOR_DIRECT,
-                                            new_observer = %remote_ip,
-                                            "classifier: external promoted to Direct \
-                                             (source-disjoint quorum reached)"
-                                        );
-                                    } else {
-                                        tracing::debug!(
-                                            external = %normalized_ext,
-                                            observers = count,
-                                            threshold =
-                                                crate::transport_handle::MIN_DISTINCT_OBSERVERS_FOR_DIRECT,
-                                            new_observer = %remote_ip,
-                                            "classifier: source-disjoint observer recorded; \
-                                             below threshold"
-                                        );
-                                    }
-                                }
-                            }
+                            handle_peer_connected_for_proof(
+                                addr,
+                                side,
+                                &dialed,
+                                &known,
+                                &external,
+                                &observations,
+                                &eligible,
+                                &proven,
+                            );
+                        }
+                        Ok(saorsa_transport::P2pEvent::PeerObservedExternal {
+                            peer_addr,
+                            observed_external,
+                        }) => {
+                            handle_peer_observed_external(
+                                peer_addr,
+                                observed_external,
+                                &external,
+                                &observations,
+                                &eligible,
+                                &proven,
+                            );
                         }
                         Err(broadcast::error::RecvError::Closed) => break,
                         Err(broadcast::error::RecvError::Lagged(_)) => continue,
@@ -2412,5 +2579,379 @@ mod tests {
     #[test]
     fn to_dual_stack_dial_list_empty_input_empty_output() {
         assert!(to_dual_stack_dial_list(&[]).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod classifier_tests {
+    use super::{
+        back_fill_proof_on_pin, handle_peer_connected_for_proof, handle_peer_observed_external,
+    };
+    use crate::transport::external_addresses::ExternalAddresses;
+    use crate::transport_handle::{
+        MAX_OBSERVATIONS_PER_PEER, MIN_DISTINCT_OBSERVERS_FOR_DIRECT,
+        external_meets_proof_threshold,
+    };
+    use dashmap::{DashMap, DashSet};
+    use saorsa_transport::{Side, TransportAddr};
+    use std::collections::HashSet;
+    use std::net::{IpAddr, SocketAddr};
+
+    fn sa(s: &str) -> SocketAddr {
+        s.parse().expect("test socket addr")
+    }
+
+    /// One harness scoped to a single classifier under test.
+    ///
+    /// Wires up the same Arcs the real classifier owns so the helper
+    /// functions can be invoked directly with deterministic state.
+    struct ProofHarness {
+        dialed: DashSet<SocketAddr>,
+        known: DashSet<IpAddr>,
+        external: parking_lot::Mutex<ExternalAddresses>,
+        observations: DashMap<IpAddr, HashSet<SocketAddr>>,
+        eligible: DashSet<IpAddr>,
+        proven: DashMap<SocketAddr, HashSet<IpAddr>>,
+    }
+
+    impl ProofHarness {
+        fn new() -> Self {
+            Self {
+                dialed: DashSet::new(),
+                known: DashSet::new(),
+                external: parking_lot::Mutex::new(ExternalAddresses::new()),
+                observations: DashMap::new(),
+                eligible: DashSet::new(),
+                proven: DashMap::new(),
+            }
+        }
+
+        fn pin(&self, addr: SocketAddr) {
+            self.external.lock().pin_direct(addr);
+        }
+
+        fn inbound(&self, peer: SocketAddr) {
+            self.dispatch_peer_connected(peer, Side::Server);
+        }
+
+        fn outbound(&self, peer: SocketAddr) {
+            self.dispatch_peer_connected(peer, Side::Client);
+        }
+
+        fn dispatch_peer_connected(&self, peer: SocketAddr, side: Side) {
+            handle_peer_connected_for_proof(
+                TransportAddr::Quic(peer),
+                side,
+                &self.dialed,
+                &self.known,
+                &self.external,
+                &self.observations,
+                &self.eligible,
+                &self.proven,
+            );
+        }
+
+        fn observe(&self, peer: SocketAddr, observed: SocketAddr) {
+            handle_peer_observed_external(
+                peer,
+                observed,
+                &self.external,
+                &self.observations,
+                &self.eligible,
+                &self.proven,
+            );
+        }
+
+        fn pin_with_back_fill(&self, addr: SocketAddr) {
+            self.external.lock().pin_direct(addr);
+            back_fill_proof_on_pin(addr, &self.observations, &self.eligible, &self.proven);
+        }
+
+        fn is_proven(&self, addr: SocketAddr) -> bool {
+            external_meets_proof_threshold(addr, &self.proven)
+        }
+
+        fn observer_count(&self, addr: SocketAddr) -> usize {
+            let normalized = saorsa_transport::shared::normalize_socket_addr(addr);
+            self.proven.get(&normalized).map(|s| s.len()).unwrap_or(0)
+        }
+    }
+
+    /// **Reviewer's regression test.** Two pinned IPv4 externals and two
+    /// source-disjoint inbound peers. Each peer reports observing only
+    /// one — different — external. Neither external reaches the
+    /// distinct-observer quorum, because the other peer's inbound is not
+    /// per-address attribution for this address.
+    ///
+    /// Pre-fix behavior would have promoted **both** externals to Direct
+    /// (every same-family pinned external got credited by every
+    /// source-disjoint inbound). Post-fix, attribution is per the peer's
+    /// own `OBSERVED_ADDRESS` report — no leakage across externals.
+    #[test]
+    fn two_pinned_externals_two_disjoint_inbounds_each_reports_one_promotes_neither() {
+        let h = ProofHarness::new();
+        let ext_a = sa("198.51.100.1:10000");
+        let ext_b = sa("198.51.100.2:10000");
+        h.pin(ext_a);
+        h.pin(ext_b);
+
+        let p1 = sa("203.0.113.10:55555");
+        let p2 = sa("203.0.113.20:55555");
+
+        h.inbound(p1);
+        h.observe(p1, ext_a);
+
+        h.inbound(p2);
+        h.observe(p2, ext_b);
+
+        assert_eq!(
+            h.observer_count(ext_a),
+            1,
+            "ext_a only got attributed by P1"
+        );
+        assert_eq!(
+            h.observer_count(ext_b),
+            1,
+            "ext_b only got attributed by P2"
+        );
+        assert!(
+            !h.is_proven(ext_a),
+            "ext_a must NOT be promoted by P2's inbound — P2 reported a different external"
+        );
+        assert!(
+            !h.is_proven(ext_b),
+            "ext_b must NOT be promoted by P1's inbound — P1 reported a different external"
+        );
+    }
+
+    /// Convergent case: two pinned externals, both peers report the same
+    /// one. Only the reported external reaches quorum.
+    #[test]
+    fn two_disjoint_inbounds_reporting_same_external_promotes_only_that_external() {
+        let h = ProofHarness::new();
+        let ext_a = sa("198.51.100.1:10000");
+        let ext_b = sa("198.51.100.2:10000");
+        h.pin(ext_a);
+        h.pin(ext_b);
+
+        let p1 = sa("203.0.113.10:0");
+        let p2 = sa("203.0.113.20:0");
+
+        h.inbound(p1);
+        h.observe(p1, ext_a);
+        h.inbound(p2);
+        h.observe(p2, ext_a);
+
+        assert!(h.is_proven(ext_a));
+        assert!(!h.is_proven(ext_b));
+    }
+
+    /// Multi-WAN: two pinned externals, both peers genuinely reach us
+    /// via both (e.g. anycast or dual-WAN). Both promote.
+    #[test]
+    fn two_disjoint_inbounds_reporting_both_externals_promote_both() {
+        let h = ProofHarness::new();
+        let ext_a = sa("198.51.100.1:10000");
+        let ext_b = sa("198.51.100.2:10000");
+        h.pin(ext_a);
+        h.pin(ext_b);
+
+        let p1 = sa("203.0.113.10:0");
+        let p2 = sa("203.0.113.20:0");
+
+        h.inbound(p1);
+        h.observe(p1, ext_a);
+        h.observe(p1, ext_b);
+        h.inbound(p2);
+        h.observe(p2, ext_a);
+        h.observe(p2, ext_b);
+
+        assert!(h.is_proven(ext_a));
+        assert!(h.is_proven(ext_b));
+    }
+
+    /// Source-disjointness: an inbound from a peer we previously dialed
+    /// is not proof-eligible, and their `OBSERVED_ADDRESS` reports do not
+    /// credit.
+    #[test]
+    fn previously_dialed_peer_observation_does_not_credit() {
+        let h = ProofHarness::new();
+        let ext_a = sa("198.51.100.1:10000");
+        h.pin(ext_a);
+
+        let p1 = sa("203.0.113.10:0");
+        h.outbound(p1); // marks the peer's IP in `known`
+        h.inbound(p1); // arrives later; previously known → not eligible
+        h.observe(p1, ext_a);
+
+        assert_eq!(h.observer_count(ext_a), 0);
+    }
+
+    /// Sibling-hairpin: an inbound whose source IP equals one of our
+    /// own pinned externals is rejected (NAT loopback, never left LAN).
+    #[test]
+    fn inbound_from_own_external_ip_is_filtered() {
+        let h = ProofHarness::new();
+        let our_external = sa("198.51.100.1:10000");
+        h.pin(our_external);
+
+        let sibling = sa("198.51.100.1:55555"); // same IP, different port
+        h.inbound(sibling);
+        h.observe(sibling, our_external);
+
+        assert_eq!(h.observer_count(our_external), 0);
+    }
+
+    /// Out-of-order: observation arrives before its `PeerConnected`.
+    /// The cached observation is credited when the peer becomes
+    /// proof-eligible.
+    #[test]
+    fn observation_before_peer_connected_credits_on_inbound() {
+        let h = ProofHarness::new();
+        let ext_a = sa("198.51.100.1:10000");
+        h.pin(ext_a);
+
+        let p1 = sa("203.0.113.10:0");
+        h.observe(p1, ext_a); // recorded but peer not yet eligible
+        h.inbound(p1);
+
+        assert_eq!(h.observer_count(ext_a), 1);
+    }
+
+    /// Out-of-order: address pinned after its observation arrived.
+    /// The back-fill on pin credits the eligible peer.
+    #[test]
+    fn observation_before_pin_credits_on_back_fill() {
+        let h = ProofHarness::new();
+        let ext_a = sa("198.51.100.1:10000");
+
+        let p1 = sa("203.0.113.10:0");
+        h.inbound(p1); // eligible (no pinned externals to compare against)
+        h.observe(p1, ext_a); // observed external not yet pinned
+
+        assert_eq!(
+            h.observer_count(ext_a),
+            0,
+            "credit must wait until the address is actually pinned"
+        );
+
+        h.pin_with_back_fill(ext_a);
+
+        assert_eq!(h.observer_count(ext_a), 1);
+    }
+
+    /// Side::Client never becomes proof-eligible: even a peer we dialed
+    /// who later sends us OBSERVED_ADDRESS does not contribute proof.
+    #[test]
+    fn side_client_does_not_become_proof_eligible() {
+        let h = ProofHarness::new();
+        let ext_a = sa("198.51.100.1:10000");
+        h.pin(ext_a);
+
+        let p1 = sa("203.0.113.10:0");
+        h.outbound(p1);
+        h.observe(p1, ext_a);
+
+        assert_eq!(h.observer_count(ext_a), 0);
+    }
+
+    /// IP-level dedup: a chatty peer reconnecting from new ephemeral
+    /// ports cannot inflate their proof count beyond one slot.
+    #[test]
+    fn duplicate_observation_from_same_peer_ip_does_not_double_count() {
+        let h = ProofHarness::new();
+        let ext_a = sa("198.51.100.1:10000");
+        h.pin(ext_a);
+
+        let p1 = sa("203.0.113.10:0");
+        h.inbound(p1);
+        h.observe(p1, ext_a);
+        h.observe(p1, ext_a);
+
+        assert_eq!(h.observer_count(ext_a), 1);
+        assert!(!h.is_proven(ext_a));
+    }
+
+    /// Cross-family isolation: a v4-only inbound and a v6-only inbound
+    /// each credit only their reported externals. Neither external
+    /// reaches quorum.
+    #[test]
+    fn cross_family_attribution_does_not_leak() {
+        let h = ProofHarness::new();
+        let ext_v4 = sa("198.51.100.1:10000");
+        let ext_v6 = sa("[2001:db8::1]:10000");
+        h.pin(ext_v4);
+        h.pin(ext_v6);
+
+        let p_v4 = sa("203.0.113.10:0");
+        let p_v6 = sa("[2001:db8:cafe::10]:0");
+
+        h.inbound(p_v4);
+        h.observe(p_v4, ext_v4);
+        h.inbound(p_v6);
+        h.observe(p_v6, ext_v6);
+
+        assert_eq!(h.observer_count(ext_v4), 1);
+        assert_eq!(h.observer_count(ext_v6), 1);
+        assert!(!h.is_proven(ext_v4));
+        assert!(!h.is_proven(ext_v6));
+    }
+
+    /// Per-peer observation cap: reports beyond the cap are dropped.
+    /// The first `MAX_OBSERVATIONS_PER_PEER` distinct externals are
+    /// retained; further distinct externals from the same peer are
+    /// silently ignored.
+    #[test]
+    fn per_peer_observation_cap_enforced() {
+        let h = ProofHarness::new();
+
+        let p1 = sa("203.0.113.10:0");
+        h.inbound(p1);
+
+        let cap = MAX_OBSERVATIONS_PER_PEER;
+        for i in 0..cap {
+            let ext = format!("198.51.100.{}:10000", i + 1)
+                .parse::<SocketAddr>()
+                .expect("addr");
+            h.pin(ext);
+            h.observe(p1, ext);
+        }
+
+        let overflow = sa("198.51.100.250:10000");
+        h.pin(overflow);
+        h.observe(p1, overflow);
+
+        assert_eq!(
+            h.observer_count(overflow),
+            0,
+            "the cap+1 observation must be dropped, even with the address pinned"
+        );
+        // Within-cap observations are credited normally.
+        let first = sa("198.51.100.1:10000");
+        assert_eq!(h.observer_count(first), 1);
+    }
+
+    /// Threshold semantics: ≥ `MIN_DISTINCT_OBSERVERS_FOR_DIRECT`
+    /// distinct attributable peer IPs must promote to Direct.
+    #[test]
+    fn threshold_constant_is_respected() {
+        let h = ProofHarness::new();
+        let ext_a = sa("198.51.100.1:10000");
+        h.pin(ext_a);
+
+        let mut ips = Vec::new();
+        for i in 0..MIN_DISTINCT_OBSERVERS_FOR_DIRECT {
+            let p = format!("203.0.113.{}:0", 10 + i)
+                .parse::<SocketAddr>()
+                .expect("addr");
+            h.inbound(p);
+            h.observe(p, ext_a);
+            ips.push(p);
+        }
+
+        assert!(h.is_proven(ext_a));
+        // Sanity: ext_a got exactly MIN_DISTINCT_OBSERVERS_FOR_DIRECT
+        // observers, not more.
+        assert_eq!(h.observer_count(ext_a), MIN_DISTINCT_OBSERVERS_FOR_DIRECT);
     }
 }

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -154,11 +154,14 @@ const ADDRESS_EVENT_DROP_LOG_INTERVAL: u64 = 32;
 /// IPv4 take over quickly when the v6 attempt is failing or stalled.
 const HAPPY_EYEBALLS_V4_STAGGER: Duration = Duration::from_millis(50);
 
-/// Per-attempt direct-connect timeout used by the Happy Eyeballs race.
+/// Per-attempt direct-connect progress timeout used by the Happy Eyeballs race.
 ///
 /// Keep this short because DHT lookups expect to encounter unreachable
 /// candidates on live networks and should move on quickly.
-const DIRECT_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+const DIRECT_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Per-attempt direct handshake timeout after connection progress is observed.
+const DIRECT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(4);
 
 /// Increment the drop counter and log periodically when the address-event
 /// forwarder fails to push into a bounded channel.
@@ -470,7 +473,8 @@ impl P2PNetworkNode<P2pLinkTransport> {
             .with_default_strategy(
                 StrategyConfig::direct_only()
                     .with_ipv4_timeout(DIRECT_CONNECT_TIMEOUT)
-                    .with_ipv6_timeout(DIRECT_CONNECT_TIMEOUT),
+                    .with_ipv6_timeout(DIRECT_CONNECT_TIMEOUT)
+                    .with_direct_handshake_timeout(DIRECT_HANDSHAKE_TIMEOUT),
             );
 
         // Get the actual bound address from the endpoint (important for port 0 bindings)
@@ -491,7 +495,8 @@ impl P2PNetworkNode<P2pLinkTransport> {
             .with_default_strategy(
                 StrategyConfig::direct_only()
                     .with_ipv4_timeout(DIRECT_CONNECT_TIMEOUT)
-                    .with_ipv6_timeout(DIRECT_CONNECT_TIMEOUT),
+                    .with_ipv6_timeout(DIRECT_CONNECT_TIMEOUT)
+                    .with_direct_handshake_timeout(DIRECT_HANDSHAKE_TIMEOUT),
             );
 
         // Get the actual bound address from the endpoint
@@ -754,9 +759,9 @@ impl<T: LinkTransport + Send + Sync + 'static> P2PNetworkNode<T> {
         //
         // The transport's default StrategyConfig::direct_only() disables
         // hole-punching and the in-cascade relay fallback, so this dial
-        // is single-shot. 5 s covers a QUIC handshake (1 RTT) + ML-DSA
-        // verification + margin for network jitter.
-        const DIAL_TIMEOUT: Duration = Duration::from_secs(5);
+        // is single-shot. 6 s covers the transport's 1 s progress timeout
+        // plus 4 s handshake timeout, with margin for task scheduling.
+        const DIAL_TIMEOUT: Duration = Duration::from_secs(6);
 
         let conn = tokio::time::timeout(
             DIAL_TIMEOUT,

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -202,6 +202,16 @@ fn emit_direct_promotion(
     }
 }
 
+fn emit_self_address_update(
+    tx: &tokio::sync::mpsc::Sender<SocketAddr>,
+    drops: &AtomicU64,
+    address: SocketAddr,
+) {
+    if let Err(err) = tx.try_send(address) {
+        handle_address_event_drop(drops, "SelfAddressUpdated", &err);
+    }
+}
+
 /// Handle a `P2pEvent::PeerConnected` event for the passive
 /// reachability classifier.
 ///
@@ -294,10 +304,19 @@ fn handle_peer_connected_for_proof(
     }
 }
 
+#[derive(Debug, Default, Eq, PartialEq)]
+struct ObservedExternalOutcome {
+    /// The address crossed the Direct proof threshold.
+    promoted: Option<SocketAddr>,
+    /// The address newly became publishable as an Unverified candidate.
+    publishable_added: Option<SocketAddr>,
+}
+
 /// Handle a `P2pEvent::PeerObservedExternal` event.
 ///
 /// Records the peer's report in `peer_observations` (capped at
-/// [`crate::transport_handle::MAX_OBSERVATIONS_PER_PEER`]) and, if the
+/// [`crate::transport_handle::MAX_OBSERVATIONS_PER_PEER`]), retains the
+/// reported external as a publishable Unverified candidate, and, if the
 /// peer is already proof-eligible and the reported external is currently
 /// pinned, credits the observation against `proven_externals`.
 fn handle_peer_observed_external(
@@ -307,7 +326,7 @@ fn handle_peer_observed_external(
     observations: &DashMap<IpAddr, HashSet<SocketAddr>>,
     eligible: &DashSet<IpAddr>,
     proven: &DashMap<SocketAddr, HashSet<IpAddr>>,
-) -> Option<SocketAddr> {
+) -> ObservedExternalOutcome {
     let normalized_peer = saorsa_transport::shared::normalize_socket_addr(peer_addr);
     let peer_ip = canonicalize_ip(normalized_peer.ip());
     let normalized_ext = saorsa_transport::shared::normalize_socket_addr(observed_external);
@@ -330,8 +349,13 @@ fn handle_peer_observed_external(
     };
 
     if !recorded {
-        return None;
+        return ObservedExternalOutcome::default();
     }
+
+    let publishable_added = external
+        .lock()
+        .record_unverified(normalized_ext)
+        .then_some(normalized_ext);
 
     if !eligible.contains(&peer_ip) {
         tracing::trace!(
@@ -339,11 +363,17 @@ fn handle_peer_observed_external(
             external = %normalized_ext,
             "classifier: observation recorded; peer not yet proof-eligible — credit deferred"
         );
-        return None;
+        return ObservedExternalOutcome {
+            promoted: None,
+            publishable_added,
+        };
     }
 
     let pinned_direct = external.lock().direct_addresses();
-    credit_observation(peer_ip, normalized_ext, &pinned_direct, proven)
+    ObservedExternalOutcome {
+        promoted: credit_observation(peer_ip, normalized_ext, &pinned_direct, proven),
+        publishable_added,
+    }
 }
 
 /// Back-fill `proven_externals` when an external is freshly pinned.
@@ -1404,10 +1434,10 @@ impl DualStackNetworkNode<P2pLinkTransport> {
     ///   no longer reachable. The reachability driver republishes the
     ///   address set without the relay entry on receipt.  Returned via
     ///   the third mpsc receiver.
-    /// - **`ExternalAddressDiscovered`**: a peer reported the address it
-    ///   sees this node at, via a QUIC `OBSERVED_ADDRESS` frame. Pinned
-    ///   directly into the supplied [`ExternalAddresses`] store. Once
-    ///   pinned, the address is retained for the process lifetime.
+    /// - **`ExternalAddressDiscovered`**: saorsa-transport's observed
+    ///   address quorum cleared. The address is pinned into the supplied
+    ///   [`ExternalAddresses`] store and a self-address update is emitted
+    ///   unless the same event also promotes it to Direct.
     /// - **Direct address promoted**: not a transport event itself; emitted
     ///   to `direct_promoted_tx` when either live attribution or the
     ///   `ExternalAddressDiscovered` back-fill proves a pinned external
@@ -1422,6 +1452,7 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         proof_eligible_peers: Arc<DashSet<IpAddr>>,
         proven_externals: Arc<DashMap<SocketAddr, HashSet<IpAddr>>>,
         direct_promoted_tx: tokio::sync::mpsc::Sender<SocketAddr>,
+        self_address_updated_tx: tokio::sync::mpsc::Sender<SocketAddr>,
     ) -> (
         tokio::sync::mpsc::Receiver<(SocketAddr, SocketAddr)>,
         tokio::sync::mpsc::Receiver<SocketAddr>,
@@ -1442,6 +1473,7 @@ impl DualStackNetworkNode<P2pLinkTransport> {
             let eligible_clone = Arc::clone(&proof_eligible_peers);
             let proven_clone = Arc::clone(&proven_externals);
             let direct_promoted_tx_clone = direct_promoted_tx.clone();
+            let self_address_updated_tx_clone = self_address_updated_tx.clone();
             let drops = Arc::clone(&drop_counter);
             let local_bind = node.local_address();
             tokio::spawn(async move {
@@ -1510,16 +1542,25 @@ impl DualStackNetworkNode<P2pLinkTransport> {
                                 // would otherwise need a third independent
                                 // observer to reach the proof threshold.
                                 if pinned {
+                                    let mut promoted_any = false;
                                     for promoted in back_fill_proof_on_pin(
                                         normalized,
                                         &observations_clone,
                                         &eligible_clone,
                                         &proven_clone,
                                     ) {
+                                        promoted_any = true;
                                         emit_direct_promotion(
                                             &direct_promoted_tx_clone,
                                             &drops,
                                             promoted,
+                                        );
+                                    }
+                                    if !promoted_any {
+                                        emit_self_address_update(
+                                            &self_address_updated_tx_clone,
+                                            &drops,
+                                            normalized,
                                         );
                                     }
                                 } else {
@@ -1628,6 +1669,7 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         peer_observations: Arc<DashMap<IpAddr, HashSet<SocketAddr>>>,
         proof_eligible_peers: Arc<DashSet<IpAddr>>,
         direct_promoted_tx: tokio::sync::mpsc::Sender<SocketAddr>,
+        self_address_updated_tx: tokio::sync::mpsc::Sender<SocketAddr>,
     ) {
         let drop_counter = Arc::new(AtomicU64::new(0));
         for node in [&self.v6, &self.v4].into_iter().flatten() {
@@ -1639,6 +1681,7 @@ impl DualStackNetworkNode<P2pLinkTransport> {
             let observations = Arc::clone(&peer_observations);
             let eligible = Arc::clone(&proof_eligible_peers);
             let promoted_tx = direct_promoted_tx.clone();
+            let self_address_tx = self_address_updated_tx.clone();
             let drops = Arc::clone(&drop_counter);
             tokio::spawn(async move {
                 loop {
@@ -1661,14 +1704,18 @@ impl DualStackNetworkNode<P2pLinkTransport> {
                             peer_addr,
                             observed_external,
                         }) => {
-                            if let Some(promoted) = handle_peer_observed_external(
+                            let outcome = handle_peer_observed_external(
                                 peer_addr,
                                 observed_external,
                                 &external,
                                 &observations,
                                 &eligible,
                                 &proven,
-                            ) {
+                            );
+                            if let Some(address) = outcome.publishable_added {
+                                emit_self_address_update(&self_address_tx, &drops, address);
+                            }
+                            if let Some(promoted) = outcome.promoted {
                                 emit_direct_promotion(&promoted_tx, &drops, promoted);
                             }
                         }
@@ -2646,7 +2693,8 @@ mod tests {
 #[cfg(test)]
 mod classifier_tests {
     use super::{
-        back_fill_proof_on_pin, handle_peer_connected_for_proof, handle_peer_observed_external,
+        ObservedExternalOutcome, back_fill_proof_on_pin, handle_peer_connected_for_proof,
+        handle_peer_observed_external,
     };
     use crate::transport::external_addresses::ExternalAddresses;
     use crate::transport_handle::{
@@ -2717,6 +2765,14 @@ mod classifier_tests {
         }
 
         fn observe_promoted(&self, peer: SocketAddr, observed: SocketAddr) -> Option<SocketAddr> {
+            self.observe_outcome(peer, observed).promoted
+        }
+
+        fn observe_outcome(
+            &self,
+            peer: SocketAddr,
+            observed: SocketAddr,
+        ) -> ObservedExternalOutcome {
             handle_peer_observed_external(
                 peer,
                 observed,
@@ -2725,6 +2781,10 @@ mod classifier_tests {
                 &self.eligible,
                 &self.proven,
             )
+        }
+
+        fn non_relay_addresses(&self) -> Vec<SocketAddr> {
+            self.external.lock().non_relay_addresses()
         }
 
         fn pin_with_back_fill(&self, addr: SocketAddr) -> Vec<SocketAddr> {
@@ -2895,8 +2955,10 @@ mod classifier_tests {
 
         let p1 = sa("203.0.113.10:0");
         h.inbound(p1); // eligible (no pinned externals to compare against)
-        h.observe(p1, ext_a); // observed external not yet pinned
+        let outcome = h.observe_outcome(p1, ext_a); // observed external not yet pinned
 
+        assert_eq!(outcome.publishable_added, Some(ext_a));
+        assert_eq!(h.non_relay_addresses(), vec![ext_a]);
         assert_eq!(
             h.observer_count(ext_a),
             0,
@@ -2906,6 +2968,18 @@ mod classifier_tests {
         h.pin_with_back_fill(ext_a);
 
         assert_eq!(h.observer_count(ext_a), 1);
+    }
+
+    #[test]
+    fn unpinned_observation_is_retained_as_unverified_candidate_once() {
+        let h = ProofHarness::new();
+        let ext_a = sa("198.51.100.1:10000");
+        let p1 = sa("203.0.113.10:0");
+        let p2 = sa("203.0.113.20:0");
+
+        assert_eq!(h.observe_outcome(p1, ext_a).publishable_added, Some(ext_a));
+        assert_eq!(h.observe_outcome(p2, ext_a).publishable_added, None);
+        assert_eq!(h.non_relay_addresses(), vec![ext_a]);
     }
 
     /// Side::Client never becomes proof-eligible: even a peer we dialed

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -156,13 +156,8 @@ const HAPPY_EYEBALLS_V4_STAGGER: Duration = Duration::from_millis(50);
 
 /// Per-attempt direct-connect timeout used by the Happy Eyeballs race.
 ///
-/// saorsa-transport's `StrategyConfig` default is 3 s, sized for relay
-/// handshakes that add one extra RTT. With the dial planner now capping
-/// attempts at two addresses per peer (see
-/// [`crate::dht_network_manager::DhtNetworkManager::select_dial_candidates`]),
-/// a tighter 2 s budget matches the direct / relay-transport RTT we see
-/// in practice and shaves a full second off worst-case cold-start
-/// latency when the first address is unreachable.
+/// Keep this short because DHT lookups expect to encounter unreachable
+/// candidates on live networks and should move on quickly.
 const DIRECT_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Increment the drop counter and log periodically when the address-event
@@ -1232,15 +1227,18 @@ impl DualStackNetworkNode<P2pLinkTransport> {
     /// Register a peer ID at the low-level transport endpoint for PUNCH_ME_NOW
     /// relay routing. Called when identity exchange completes on a connection.
     pub async fn register_connection_peer_id(&self, addr: SocketAddr, peer_id: [u8; 32]) {
+        let normalized = saorsa_transport::shared::normalize_socket_addr(addr);
         for node in [&self.v6, &self.v4].into_iter().flatten() {
             let endpoint = node.transport.endpoint();
-            endpoint.register_connection_peer_id(addr, peer_id);
-            // Also register the dual-stack alternate form (IPv4 ↔ IPv4-mapped IPv6)
-            // so peer ID routing works regardless of which form the connection uses.
-            if let Some(alt) = saorsa_transport::shared::dual_stack_alternate(&addr) {
-                endpoint.register_connection_peer_id(alt, peer_id);
+            if endpoint.has_active_connection(&normalized) {
+                endpoint.register_connection_peer_id(normalized, peer_id);
+                return;
             }
         }
+        debug!(
+            "No active transport endpoint found while registering peer ID for {}",
+            normalized
+        );
     }
 
     /// Check if a peer has a live QUIC connection via either stack.

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -154,7 +154,7 @@ const ADDRESS_EVENT_DROP_LOG_INTERVAL: u64 = 32;
 /// IPv4 take over quickly when the v6 attempt is failing or stalled.
 const HAPPY_EYEBALLS_V4_STAGGER: Duration = Duration::from_millis(50);
 
-/// Per-attempt direct-connect progress timeout used by the Happy Eyeballs race.
+/// Per-attempt direct connect timeout used by the Happy Eyeballs race.
 ///
 /// Keep this short because DHT lookups expect to encounter unreachable
 /// candidates on live networks and should move on quickly.
@@ -472,8 +472,7 @@ impl P2PNetworkNode<P2pLinkTransport> {
             .context("Failed to create transport")?
             .with_default_strategy(
                 StrategyConfig::direct_only()
-                    .with_ipv4_timeout(DIRECT_CONNECT_TIMEOUT)
-                    .with_ipv6_timeout(DIRECT_CONNECT_TIMEOUT)
+                    .with_direct_connect_timeout(DIRECT_CONNECT_TIMEOUT)
                     .with_direct_handshake_timeout(DIRECT_HANDSHAKE_TIMEOUT),
             );
 
@@ -494,8 +493,7 @@ impl P2PNetworkNode<P2pLinkTransport> {
             .map_err(|e| anyhow::anyhow!("Failed to create transport: {}", e))?
             .with_default_strategy(
                 StrategyConfig::direct_only()
-                    .with_ipv4_timeout(DIRECT_CONNECT_TIMEOUT)
-                    .with_ipv6_timeout(DIRECT_CONNECT_TIMEOUT)
+                    .with_direct_connect_timeout(DIRECT_CONNECT_TIMEOUT)
                     .with_direct_handshake_timeout(DIRECT_HANDSHAKE_TIMEOUT),
             );
 

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -48,7 +48,7 @@ use std::net::{IpAddr, SocketAddr, SocketAddrV6};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
-use tokio::sync::{RwLock, broadcast};
+use tokio::sync::{RwLock, broadcast, watch};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace};
@@ -192,23 +192,33 @@ fn handle_address_event_drop<T>(
     }
 }
 
-fn emit_direct_promotion(
-    tx: &tokio::sync::mpsc::Sender<SocketAddr>,
-    drops: &AtomicU64,
-    promoted: SocketAddr,
-) {
-    if let Err(err) = tx.try_send(promoted) {
-        handle_address_event_drop(drops, "DirectAddressPromoted", &err);
-    }
+/// Paired address-event outputs: an mpsc work queue for the reachability
+/// driver and a watch-backed latest-value stream for observers/tests.
+#[derive(Clone)]
+pub(crate) struct AddressEventPublisher {
+    tx: tokio::sync::mpsc::Sender<SocketAddr>,
+    latest_tx: watch::Sender<Option<SocketAddr>>,
+    event_kind: &'static str,
 }
 
-fn emit_self_address_update(
-    tx: &tokio::sync::mpsc::Sender<SocketAddr>,
-    drops: &AtomicU64,
-    address: SocketAddr,
-) {
-    if let Err(err) = tx.try_send(address) {
-        handle_address_event_drop(drops, "SelfAddressUpdated", &err);
+impl AddressEventPublisher {
+    pub(crate) fn new(
+        event_kind: &'static str,
+        tx: tokio::sync::mpsc::Sender<SocketAddr>,
+        latest_tx: watch::Sender<Option<SocketAddr>>,
+    ) -> Self {
+        Self {
+            tx,
+            latest_tx,
+            event_kind,
+        }
+    }
+
+    fn emit(&self, drops: &AtomicU64, address: SocketAddr) {
+        let _ = self.latest_tx.send_replace(Some(address));
+        if let Err(err) = self.tx.try_send(address) {
+            handle_address_event_drop(drops, self.event_kind, &err);
+        }
     }
 }
 
@@ -1451,8 +1461,8 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         peer_observations: Arc<DashMap<IpAddr, HashSet<SocketAddr>>>,
         proof_eligible_peers: Arc<DashSet<IpAddr>>,
         proven_externals: Arc<DashMap<SocketAddr, HashSet<IpAddr>>>,
-        direct_promoted_tx: tokio::sync::mpsc::Sender<SocketAddr>,
-        self_address_updated_tx: tokio::sync::mpsc::Sender<SocketAddr>,
+        direct_promoted_events: AddressEventPublisher,
+        self_address_updated_events: AddressEventPublisher,
     ) -> (
         tokio::sync::mpsc::Receiver<(SocketAddr, SocketAddr)>,
         tokio::sync::mpsc::Receiver<SocketAddr>,
@@ -1472,8 +1482,8 @@ impl DualStackNetworkNode<P2pLinkTransport> {
             let observations_clone = Arc::clone(&peer_observations);
             let eligible_clone = Arc::clone(&proof_eligible_peers);
             let proven_clone = Arc::clone(&proven_externals);
-            let direct_promoted_tx_clone = direct_promoted_tx.clone();
-            let self_address_updated_tx_clone = self_address_updated_tx.clone();
+            let direct_promoted_events_clone = direct_promoted_events.clone();
+            let self_address_updated_events_clone = self_address_updated_events.clone();
             let drops = Arc::clone(&drop_counter);
             let local_bind = node.local_address();
             tokio::spawn(async move {
@@ -1550,18 +1560,10 @@ impl DualStackNetworkNode<P2pLinkTransport> {
                                         &proven_clone,
                                     ) {
                                         promoted_any = true;
-                                        emit_direct_promotion(
-                                            &direct_promoted_tx_clone,
-                                            &drops,
-                                            promoted,
-                                        );
+                                        direct_promoted_events_clone.emit(&drops, promoted);
                                     }
                                     if !promoted_any {
-                                        emit_self_address_update(
-                                            &self_address_updated_tx_clone,
-                                            &drops,
-                                            normalized,
-                                        );
+                                        self_address_updated_events_clone.emit(&drops, normalized);
                                     }
                                 } else {
                                     tracing::trace!(
@@ -1668,8 +1670,8 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         external_addresses: Arc<parking_lot::Mutex<ExternalAddresses>>,
         peer_observations: Arc<DashMap<IpAddr, HashSet<SocketAddr>>>,
         proof_eligible_peers: Arc<DashSet<IpAddr>>,
-        direct_promoted_tx: tokio::sync::mpsc::Sender<SocketAddr>,
-        self_address_updated_tx: tokio::sync::mpsc::Sender<SocketAddr>,
+        direct_promoted_events: AddressEventPublisher,
+        self_address_updated_events: AddressEventPublisher,
     ) {
         let drop_counter = Arc::new(AtomicU64::new(0));
         for node in [&self.v6, &self.v4].into_iter().flatten() {
@@ -1680,8 +1682,8 @@ impl DualStackNetworkNode<P2pLinkTransport> {
             let external = Arc::clone(&external_addresses);
             let observations = Arc::clone(&peer_observations);
             let eligible = Arc::clone(&proof_eligible_peers);
-            let promoted_tx = direct_promoted_tx.clone();
-            let self_address_tx = self_address_updated_tx.clone();
+            let promoted_events = direct_promoted_events.clone();
+            let self_address_events = self_address_updated_events.clone();
             let drops = Arc::clone(&drop_counter);
             tokio::spawn(async move {
                 loop {
@@ -1697,7 +1699,7 @@ impl DualStackNetworkNode<P2pLinkTransport> {
                                 &eligible,
                                 &proven,
                             ) {
-                                emit_direct_promotion(&promoted_tx, &drops, promoted);
+                                promoted_events.emit(&drops, promoted);
                             }
                         }
                         Ok(saorsa_transport::P2pEvent::PeerObservedExternal {
@@ -1713,10 +1715,10 @@ impl DualStackNetworkNode<P2pLinkTransport> {
                                 &proven,
                             );
                             if let Some(address) = outcome.publishable_added {
-                                emit_self_address_update(&self_address_tx, &drops, address);
+                                self_address_events.emit(&drops, address);
                             }
                             if let Some(promoted) = outcome.promoted {
-                                emit_direct_promotion(&promoted_tx, &drops, promoted);
+                                promoted_events.emit(&drops, promoted);
                             }
                         }
                         Err(broadcast::error::RecvError::Closed) => break,

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -1299,19 +1299,34 @@ impl DualStackNetworkNode<P2pLinkTransport> {
 
     /// Register a peer ID at the low-level transport endpoint for PUNCH_ME_NOW
     /// relay routing. Called when identity exchange completes on a connection.
+    ///
+    /// Walks both stacks rather than stopping at the first hit so a dual-stack
+    /// node registers the peer ID against every endpoint that actually owns a
+    /// connection to it. Also registers the IPv4-mapped alternate form so peer
+    /// ID lookups resolve regardless of which form the relay path supplies.
     pub async fn register_connection_peer_id(&self, addr: SocketAddr, peer_id: [u8; 32]) {
         let normalized = saorsa_transport::shared::normalize_socket_addr(addr);
+        let alternate = saorsa_transport::shared::dual_stack_alternate(&normalized);
+        let mut registered = false;
         for node in [&self.v6, &self.v4].into_iter().flatten() {
             let endpoint = node.transport.endpoint();
             if endpoint.has_active_connection(&normalized) {
                 endpoint.register_connection_peer_id(normalized, peer_id);
-                return;
+                registered = true;
+            }
+            if let Some(alt) = alternate
+                && endpoint.has_active_connection(&alt)
+            {
+                endpoint.register_connection_peer_id(alt, peer_id);
+                registered = true;
             }
         }
-        debug!(
-            "No active transport endpoint found while registering peer ID for {}",
-            normalized
-        );
+        if !registered {
+            debug!(
+                "No active transport endpoint found while registering peer ID for {}",
+                normalized
+            );
+        }
     }
 
     /// Check if a peer has a live QUIC connection via either stack.

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -192,6 +192,16 @@ fn handle_address_event_drop<T>(
     }
 }
 
+fn emit_direct_promotion(
+    tx: &tokio::sync::mpsc::Sender<SocketAddr>,
+    drops: &AtomicU64,
+    promoted: SocketAddr,
+) {
+    if let Err(err) = tx.try_send(promoted) {
+        handle_address_event_drop(drops, "DirectAddressPromoted", &err);
+    }
+}
+
 /// Handle a `P2pEvent::PeerConnected` event for the passive
 /// reachability classifier.
 ///
@@ -215,13 +225,13 @@ fn handle_peer_connected_for_proof(
     observations: &DashMap<IpAddr, HashSet<SocketAddr>>,
     eligible: &DashSet<IpAddr>,
     proven: &DashMap<SocketAddr, HashSet<IpAddr>>,
-) {
+) -> Vec<SocketAddr> {
     let Some(socket_addr) = addr.as_socket_addr() else {
         tracing::trace!(
             remote = %addr,
             "classifier: ignoring non-socket transport handshake"
         );
-        return;
+        return Vec::new();
     };
     let normalized = saorsa_transport::shared::normalize_socket_addr(socket_addr);
     let remote_ip = canonicalize_ip(normalized.ip());
@@ -235,7 +245,7 @@ fn handle_peer_connected_for_proof(
             side = ?side,
             "classifier: recorded outbound peer; not a proof candidate"
         );
-        return;
+        return Vec::new();
     }
 
     if was_known_before {
@@ -244,7 +254,7 @@ fn handle_peer_connected_for_proof(
             "classifier: ignoring inbound from previously-known peer \
              (not source-disjoint; possible pinhole redial)"
         );
-        return;
+        return Vec::new();
     }
 
     let pinned_direct = external.lock().direct_addresses();
@@ -256,7 +266,7 @@ fn handle_peer_connected_for_proof(
             remote = %normalized,
             "classifier: ignoring sibling-hairpin handshake from own external IP"
         );
-        return;
+        return Vec::new();
     }
 
     eligible.insert(remote_ip);
@@ -267,15 +277,20 @@ fn handle_peer_connected_for_proof(
         // against a future change adding self-referential writes.
         let prior: Vec<SocketAddr> = reports.iter().copied().collect();
         drop(reports);
+        let mut promoted = Vec::new();
         for ext in prior {
-            credit_observation(remote_ip, ext, &pinned_direct, proven);
+            if let Some(addr) = credit_observation(remote_ip, ext, &pinned_direct, proven) {
+                promoted.push(addr);
+            }
         }
+        promoted
     } else {
         tracing::trace!(
             remote = %remote_ip,
             "classifier: peer is now proof-eligible but has no prior observations; \
              credit deferred until OBSERVED_ADDRESS frame arrives"
         );
+        Vec::new()
     }
 }
 
@@ -292,7 +307,7 @@ fn handle_peer_observed_external(
     observations: &DashMap<IpAddr, HashSet<SocketAddr>>,
     eligible: &DashSet<IpAddr>,
     proven: &DashMap<SocketAddr, HashSet<IpAddr>>,
-) {
+) -> Option<SocketAddr> {
     let normalized_peer = saorsa_transport::shared::normalize_socket_addr(peer_addr);
     let peer_ip = canonicalize_ip(normalized_peer.ip());
     let normalized_ext = saorsa_transport::shared::normalize_socket_addr(observed_external);
@@ -315,7 +330,7 @@ fn handle_peer_observed_external(
     };
 
     if !recorded {
-        return;
+        return None;
     }
 
     if !eligible.contains(&peer_ip) {
@@ -324,11 +339,11 @@ fn handle_peer_observed_external(
             external = %normalized_ext,
             "classifier: observation recorded; peer not yet proof-eligible — credit deferred"
         );
-        return;
+        return None;
     }
 
     let pinned_direct = external.lock().direct_addresses();
-    credit_observation(peer_ip, normalized_ext, &pinned_direct, proven);
+    credit_observation(peer_ip, normalized_ext, &pinned_direct, proven)
 }
 
 /// Back-fill `proven_externals` when an external is freshly pinned.
@@ -344,17 +359,21 @@ fn back_fill_proof_on_pin(
     observations: &DashMap<IpAddr, HashSet<SocketAddr>>,
     eligible: &DashSet<IpAddr>,
     proven: &DashMap<SocketAddr, HashSet<IpAddr>>,
-) {
+) -> Vec<SocketAddr> {
     let normalized_ext = saorsa_transport::shared::normalize_socket_addr(external);
+    let mut promoted = Vec::new();
     for entry in observations.iter() {
         let peer_ip = *entry.key();
         if !eligible.contains(&peer_ip) {
             continue;
         }
-        if entry.value().contains(&normalized_ext) {
-            record_attributed_observer(peer_ip, normalized_ext, proven);
+        if entry.value().contains(&normalized_ext)
+            && let Some(addr) = record_attributed_observer(peer_ip, normalized_ext, proven)
+        {
+            promoted.push(addr);
         }
     }
+    promoted
 }
 
 /// Credit `peer_ip` against `external` iff the address is currently
@@ -369,7 +388,7 @@ fn credit_observation(
     external: SocketAddr,
     pinned_direct: &[SocketAddr],
     proven: &DashMap<SocketAddr, HashSet<IpAddr>>,
-) {
+) -> Option<SocketAddr> {
     let normalized_ext = saorsa_transport::shared::normalize_socket_addr(external);
     if !pinned_direct.contains(&normalized_ext) {
         tracing::trace!(
@@ -378,9 +397,9 @@ fn credit_observation(
             "classifier: peer reported external but it is not currently pinned; \
              back-fill on pin will catch this if quorum is reached later"
         );
-        return;
+        return None;
     }
-    record_attributed_observer(peer_ip, normalized_ext, proven);
+    record_attributed_observer(peer_ip, normalized_ext, proven)
 }
 
 /// Insert `peer_ip` into `proven_externals[external]` and log threshold
@@ -390,17 +409,17 @@ fn record_attributed_observer(
     peer_ip: IpAddr,
     normalized_ext: SocketAddr,
     proven: &DashMap<SocketAddr, HashSet<IpAddr>>,
-) {
+) -> Option<SocketAddr> {
     let mut entry = proven.entry(normalized_ext).or_default();
     let inserted = entry.insert(peer_ip);
     let count = entry.len();
     drop(entry);
 
     if !inserted {
-        return;
+        return None;
     }
 
-    if count >= crate::transport_handle::MIN_DISTINCT_OBSERVERS_FOR_DIRECT {
+    if count == crate::transport_handle::MIN_DISTINCT_OBSERVERS_FOR_DIRECT {
         tracing::info!(
             external = %normalized_ext,
             observers = count,
@@ -408,6 +427,16 @@ fn record_attributed_observer(
             new_observer = %peer_ip,
             "classifier: external promoted to Direct (per-address attribution)"
         );
+        Some(normalized_ext)
+    } else if count > crate::transport_handle::MIN_DISTINCT_OBSERVERS_FOR_DIRECT {
+        tracing::debug!(
+            external = %normalized_ext,
+            observers = count,
+            threshold = crate::transport_handle::MIN_DISTINCT_OBSERVERS_FOR_DIRECT,
+            new_observer = %peer_ip,
+            "classifier: additional source-disjoint observer recorded for Direct external"
+        );
+        None
     } else {
         tracing::debug!(
             external = %normalized_ext,
@@ -416,6 +445,7 @@ fn record_attributed_observer(
             new_observer = %peer_ip,
             "classifier: source-disjoint observer recorded; below threshold"
         );
+        None
     }
 }
 
@@ -1359,7 +1389,9 @@ impl DualStackNetworkNode<P2pLinkTransport> {
     /// Spawn background tasks that forward address-related `P2pEvent`s from
     /// each stack's `P2pEndpoint` to the upper layers.
     ///
-    /// Four event flavours are bridged:
+    /// Four transport event flavours are bridged, and direct-address
+    /// promotion notifications are emitted when the classifier state crosses
+    /// its proof threshold:
     ///
     /// - **`PeerAddressUpdated`**: a connected peer advertised a new
     ///   reachable address via an ADD_ADDRESS frame (typically a relay).
@@ -1376,6 +1408,10 @@ impl DualStackNetworkNode<P2pLinkTransport> {
     ///   sees this node at, via a QUIC `OBSERVED_ADDRESS` frame. Pinned
     ///   directly into the supplied [`ExternalAddresses`] store. Once
     ///   pinned, the address is retained for the process lifetime.
+    /// - **Direct address promoted**: not a transport event itself; emitted
+    ///   to `direct_promoted_tx` when either live attribution or the
+    ///   `ExternalAddressDiscovered` back-fill proves a pinned external
+    ///   address is cold-dialable.
     ///
     /// Other `P2pEvent` variants are not consumed by saorsa-core and are
     /// silently ignored.
@@ -1385,6 +1421,7 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         peer_observations: Arc<DashMap<IpAddr, HashSet<SocketAddr>>>,
         proof_eligible_peers: Arc<DashSet<IpAddr>>,
         proven_externals: Arc<DashMap<SocketAddr, HashSet<IpAddr>>>,
+        direct_promoted_tx: tokio::sync::mpsc::Sender<SocketAddr>,
     ) -> (
         tokio::sync::mpsc::Receiver<(SocketAddr, SocketAddr)>,
         tokio::sync::mpsc::Receiver<SocketAddr>,
@@ -1404,6 +1441,7 @@ impl DualStackNetworkNode<P2pLinkTransport> {
             let observations_clone = Arc::clone(&peer_observations);
             let eligible_clone = Arc::clone(&proof_eligible_peers);
             let proven_clone = Arc::clone(&proven_externals);
+            let direct_promoted_tx_clone = direct_promoted_tx.clone();
             let drops = Arc::clone(&drop_counter);
             let local_bind = node.local_address();
             tokio::spawn(async move {
@@ -1461,7 +1499,7 @@ impl DualStackNetworkNode<P2pLinkTransport> {
                                     "ADDR_FWD: pinning observed external address {}",
                                     normalized
                                 );
-                                ext_clone.lock().pin_direct(normalized);
+                                let pinned = ext_clone.lock().pin_direct(normalized);
 
                                 // Back-fill: any peer that already reported
                                 // observing us at this address before it
@@ -1471,12 +1509,26 @@ impl DualStackNetworkNode<P2pLinkTransport> {
                                 // a pin on its own) is lost — saorsa-core
                                 // would otherwise need a third independent
                                 // observer to reach the proof threshold.
-                                back_fill_proof_on_pin(
-                                    normalized,
-                                    &observations_clone,
-                                    &eligible_clone,
-                                    &proven_clone,
-                                );
+                                if pinned {
+                                    for promoted in back_fill_proof_on_pin(
+                                        normalized,
+                                        &observations_clone,
+                                        &eligible_clone,
+                                        &proven_clone,
+                                    ) {
+                                        emit_direct_promotion(
+                                            &direct_promoted_tx_clone,
+                                            &drops,
+                                            promoted,
+                                        );
+                                    }
+                                } else {
+                                    tracing::trace!(
+                                        local_bind = %local_bind,
+                                        address = %normalized,
+                                        "ADDR_FWD: observed external address was already pinned or is the active relay; skipping direct back-fill"
+                                    );
+                                }
                             }
                         }
                         Err(broadcast::error::RecvError::Closed) => {
@@ -1575,7 +1627,9 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         external_addresses: Arc<parking_lot::Mutex<ExternalAddresses>>,
         peer_observations: Arc<DashMap<IpAddr, HashSet<SocketAddr>>>,
         proof_eligible_peers: Arc<DashSet<IpAddr>>,
+        direct_promoted_tx: tokio::sync::mpsc::Sender<SocketAddr>,
     ) {
+        let drop_counter = Arc::new(AtomicU64::new(0));
         for node in [&self.v6, &self.v4].into_iter().flatten() {
             let mut p2p_rx = node.transport.endpoint().subscribe();
             let dialed = Arc::clone(&dialed_addrs);
@@ -1584,11 +1638,13 @@ impl DualStackNetworkNode<P2pLinkTransport> {
             let external = Arc::clone(&external_addresses);
             let observations = Arc::clone(&peer_observations);
             let eligible = Arc::clone(&proof_eligible_peers);
+            let promoted_tx = direct_promoted_tx.clone();
+            let drops = Arc::clone(&drop_counter);
             tokio::spawn(async move {
                 loop {
                     match p2p_rx.recv().await {
                         Ok(saorsa_transport::P2pEvent::PeerConnected { addr, side, .. }) => {
-                            handle_peer_connected_for_proof(
+                            for promoted in handle_peer_connected_for_proof(
                                 addr,
                                 side,
                                 &dialed,
@@ -1597,20 +1653,24 @@ impl DualStackNetworkNode<P2pLinkTransport> {
                                 &observations,
                                 &eligible,
                                 &proven,
-                            );
+                            ) {
+                                emit_direct_promotion(&promoted_tx, &drops, promoted);
+                            }
                         }
                         Ok(saorsa_transport::P2pEvent::PeerObservedExternal {
                             peer_addr,
                             observed_external,
                         }) => {
-                            handle_peer_observed_external(
+                            if let Some(promoted) = handle_peer_observed_external(
                                 peer_addr,
                                 observed_external,
                                 &external,
                                 &observations,
                                 &eligible,
                                 &proven,
-                            );
+                            ) {
+                                emit_direct_promotion(&promoted_tx, &drops, promoted);
+                            }
                         }
                         Err(broadcast::error::RecvError::Closed) => break,
                         Err(broadcast::error::RecvError::Lagged(_)) => continue,
@@ -2632,14 +2692,14 @@ mod classifier_tests {
         }
 
         fn inbound(&self, peer: SocketAddr) {
-            self.dispatch_peer_connected(peer, Side::Server);
+            let _ = self.dispatch_peer_connected(peer, Side::Server);
         }
 
         fn outbound(&self, peer: SocketAddr) {
-            self.dispatch_peer_connected(peer, Side::Client);
+            let _ = self.dispatch_peer_connected(peer, Side::Client);
         }
 
-        fn dispatch_peer_connected(&self, peer: SocketAddr, side: Side) {
+        fn dispatch_peer_connected(&self, peer: SocketAddr, side: Side) -> Vec<SocketAddr> {
             handle_peer_connected_for_proof(
                 TransportAddr::Quic(peer),
                 side,
@@ -2649,10 +2709,14 @@ mod classifier_tests {
                 &self.observations,
                 &self.eligible,
                 &self.proven,
-            );
+            )
         }
 
         fn observe(&self, peer: SocketAddr, observed: SocketAddr) {
+            let _ = self.observe_promoted(peer, observed);
+        }
+
+        fn observe_promoted(&self, peer: SocketAddr, observed: SocketAddr) -> Option<SocketAddr> {
             handle_peer_observed_external(
                 peer,
                 observed,
@@ -2660,12 +2724,15 @@ mod classifier_tests {
                 &self.observations,
                 &self.eligible,
                 &self.proven,
-            );
+            )
         }
 
-        fn pin_with_back_fill(&self, addr: SocketAddr) {
-            self.external.lock().pin_direct(addr);
-            back_fill_proof_on_pin(addr, &self.observations, &self.eligible, &self.proven);
+        fn pin_with_back_fill(&self, addr: SocketAddr) -> Vec<SocketAddr> {
+            if self.external.lock().pin_direct(addr) {
+                back_fill_proof_on_pin(addr, &self.observations, &self.eligible, &self.proven)
+            } else {
+                Vec::new()
+            }
         }
 
         fn is_proven(&self, addr: SocketAddr) -> bool {
@@ -2954,5 +3021,44 @@ mod classifier_tests {
         // Sanity: ext_a got exactly MIN_DISTINCT_OBSERVERS_FOR_DIRECT
         // observers, not more.
         assert_eq!(h.observer_count(ext_a), MIN_DISTINCT_OBSERVERS_FOR_DIRECT);
+    }
+
+    #[test]
+    fn promotion_is_reported_once_on_threshold_crossing() {
+        let h = ProofHarness::new();
+        let ext_a = sa("198.51.100.1:10000");
+        h.pin(ext_a);
+
+        let p1 = sa("203.0.113.10:0");
+        let p2 = sa("203.0.113.20:0");
+        let p3 = sa("203.0.113.30:0");
+
+        h.inbound(p1);
+        assert_eq!(h.observe_promoted(p1, ext_a), None);
+        h.inbound(p2);
+        assert_eq!(h.observe_promoted(p2, ext_a), Some(ext_a));
+        h.inbound(p3);
+        assert_eq!(h.observe_promoted(p3, ext_a), None);
+
+        assert!(h.is_proven(ext_a));
+        assert_eq!(h.observer_count(ext_a), 3);
+    }
+
+    #[test]
+    fn back_fill_reports_promotion_when_pin_completes_threshold() {
+        let h = ProofHarness::new();
+        let ext_a = sa("198.51.100.1:10000");
+
+        let p1 = sa("203.0.113.10:0");
+        let p2 = sa("203.0.113.20:0");
+
+        h.inbound(p1);
+        h.observe(p1, ext_a);
+        h.inbound(p2);
+        h.observe(p2, ext_a);
+
+        assert_eq!(h.observer_count(ext_a), 0);
+        assert_eq!(h.pin_with_back_fill(ext_a), vec![ext_a]);
+        assert!(h.is_proven(ext_a));
     }
 }

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -20,6 +20,7 @@
 use crate::MultiAddr;
 use crate::PeerId;
 use crate::bgp_geo_provider::BgpGeoProvider;
+use crate::dht::core_engine::AddressType;
 use crate::error::{NetworkError, P2PError, P2pResult as Result};
 use crate::identity::node_identity::NodeIdentity;
 use crate::network::{
@@ -86,6 +87,20 @@ pub(crate) fn external_meets_proof_threshold(
         .get(&normalized)
         .map(|set| set.len() >= MIN_DISTINCT_OBSERVERS_FOR_DIRECT)
         .unwrap_or(false)
+}
+
+/// Stable label for an address-type tag, used as a structured `kind`
+/// field on the `connect_peer` success/failure logs. `None` is rendered
+/// as `"unknown"` for callers that don't carry a tag (e.g., the public
+/// `connect_peer` entry point used by tests).
+fn address_kind_label(kind: Option<AddressType>) -> &'static str {
+    match kind {
+        Some(AddressType::Relay) => "Relay",
+        Some(AddressType::Direct) => "Direct",
+        Some(AddressType::Unverified) => "Unverified",
+        Some(AddressType::NATted) => "NATted",
+        None => "unknown",
+    }
 }
 
 /// Internal protocol for automatic identity announcement on connect.
@@ -912,7 +927,37 @@ impl TransportHandle {
     ///
     /// Only QUIC [`MultiAddr`] values are accepted. Non-QUIC transports
     /// return [`NetworkError::InvalidAddress`].
+    ///
+    /// Callers that already know how the address was classified (Direct,
+    /// Relay, Unverified, NATted) should prefer
+    /// [`Self::connect_peer_typed`] so the success/failure logs include
+    /// the address kind. This entry point is preserved for callers
+    /// (tests, public API consumers) that don't have type metadata.
     pub async fn connect_peer(&self, address: &MultiAddr) -> Result<String> {
+        self.connect_peer_inner(address, None).await
+    }
+
+    /// Connect to a peer at the given typed address.
+    ///
+    /// Same as [`Self::connect_peer`] but additionally records the
+    /// [`AddressType`] tag in the success/failure logs so an operator
+    /// can tell, after the fact, whether a failed dial was against a
+    /// `Direct`, `Relay`, `Unverified`, or `NATted` address.
+    pub async fn connect_peer_typed(
+        &self,
+        address: &MultiAddr,
+        kind: AddressType,
+    ) -> Result<String> {
+        self.connect_peer_inner(address, Some(kind)).await
+    }
+
+    async fn connect_peer_inner(
+        &self,
+        address: &MultiAddr,
+        kind: Option<AddressType>,
+    ) -> Result<String> {
+        let kind_label = address_kind_label(kind);
+
         // Require a dialable (QUIC) transport.
         let socket_addr = address.dialable_socket_addr().ok_or_else(|| {
             P2PError::Network(NetworkError::InvalidAddress(
@@ -961,8 +1006,10 @@ impl TransportHandle {
                 };
                 if is_self {
                     warn!(
-                        "Detected self-connection to own address {} (channel_id: {}), rejecting",
-                        address, connected_peer_id
+                        kind = kind_label,
+                        %address,
+                        channel_id = %connected_peer_id,
+                        "Detected self-connection to own address, rejecting"
                     );
                     self.dual_node.disconnect_peer_by_addr(&addr).await;
                     return Err(P2PError::Network(NetworkError::InvalidAddress(
@@ -970,11 +1017,21 @@ impl TransportHandle {
                     )));
                 }
 
-                info!("Successfully connected to channel: {}", connected_peer_id);
+                info!(
+                    kind = kind_label,
+                    %address,
+                    channel_id = %connected_peer_id,
+                    "Successfully connected to channel"
+                );
                 connected_peer_id
             }
             Ok(Err(e)) => {
-                warn!("connect_happy_eyeballs failed for {}: {}", address, e);
+                warn!(
+                    kind = kind_label,
+                    %address,
+                    error = %e,
+                    "connect_happy_eyeballs failed"
+                );
                 return Err(P2PError::Transport(
                     crate::error::TransportError::ConnectionFailed {
                         addr: normalized_addr,
@@ -984,8 +1041,10 @@ impl TransportHandle {
             }
             Err(_) => {
                 warn!(
-                    "connect_happy_eyeballs timed out for {} after {:?}",
-                    address, self.connection_timeout
+                    kind = kind_label,
+                    %address,
+                    timeout = ?self.connection_timeout,
+                    "connect_happy_eyeballs timed out"
                 );
                 return Err(P2PError::Timeout(self.connection_timeout));
             }

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -143,8 +143,6 @@ fn classify_transport_send_stage(stage: saorsa_transport::SendFailureStage) -> S
         }
         saorsa_transport::SendFailureStage::Write => SendFailureKind::StreamWrite,
         saorsa_transport::SendFailureStage::Finish => SendFailureKind::StreamFinish,
-        saorsa_transport::SendFailureStage::Stopped => SendFailureKind::PeerStopped,
-        saorsa_transport::SendFailureStage::Acknowledgement => SendFailureKind::Acknowledgement,
     }
 }
 

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -71,6 +71,19 @@ const TEST_CONNECTION_TIMEOUT_SECS: u64 = 30;
 /// path (`nat_traversal_api.rs`) — same statistical argument.
 pub(crate) const MIN_DISTINCT_OBSERVERS_FOR_DIRECT: usize = 2;
 
+/// Cap on the number of distinct externals a single peer's IP may
+/// have on record in `peer_observations` before further reports are
+/// dropped.
+///
+/// A well-behaved peer observes us at exactly one external per family
+/// (the one their packets reached us through). The cap protects against
+/// a hostile peer flooding many fake `OBSERVED_ADDRESS` entries to bloat
+/// memory or to "vote" for arbitrary externals — that vote still requires
+/// a separate Side::Server inbound from the same peer to count, but the
+/// table itself should not grow without bound under attack. 8 is well
+/// above the realistic 1–2 needed for v4+v6 and dual-NAT setups.
+pub(crate) const MAX_OBSERVATIONS_PER_PEER: usize = 8;
+
 /// Return `true` iff `external` has cleared the per-address proof
 /// threshold in `proven_externals`.
 ///
@@ -253,17 +266,55 @@ pub struct TransportHandle {
     known_peer_ips: Arc<DashSet<IpAddr>>,
     /// Distinct source-disjoint observer IPs per pinned external address.
     ///
-    /// An entry is added when a `Side::Server` inbound arrives whose remote
-    /// IP is not in `known_peer_ips` and not equal to any pinned external
-    /// IP (sibling-hairpin filter). The inbound's stack-family (v4 vs v6)
-    /// determines which pinned externals receive the credit.
+    /// An entry is added when a peer that passed the source-disjoint /
+    /// sibling-hairpin / Side::Server filter reports — via a QUIC
+    /// `OBSERVED_ADDRESS` frame — that they observe us at the named
+    /// external. The peer's own report is the per-address attribution
+    /// signal: an inbound from peer P on local v4 stack only credits the
+    /// externals P actually told us about, never any other same-family
+    /// pinned external.
     ///
     /// An external is considered cold-dialable
     /// ([`AddressType::Direct`](crate::dht::AddressType::Direct)) once its
     /// observer set reaches [`MIN_DISTINCT_OBSERVERS_FOR_DIRECT`].
     /// Per-address — never globally — so one external's proof does not
-    /// promote unrelated externals.
+    /// promote unrelated externals, even on multi-WAN hosts with several
+    /// concurrently-pinned same-family externals.
     proven_externals: Arc<DashMap<SocketAddr, HashSet<IpAddr>>>,
+    /// Per-peer-IP set of externals each peer has reported observing us
+    /// at, derived from `P2pEvent::PeerObservedExternal`.
+    ///
+    /// Used by the classifier to do per-address attribution: when peer P
+    /// makes a source-disjoint Side::Server inbound, only the externals
+    /// P has told us about (intersected with currently pinned externals)
+    /// are credited with P's IP. A peer reporting external `E` is the
+    /// peer's own statement that they reached us at `E` — there is no
+    /// stronger per-address signal available at this layer.
+    ///
+    /// Capped at [`MAX_OBSERVATIONS_PER_PEER`] entries per peer to bound
+    /// memory under hostile reporting. Per-IP (not per-SocketAddr)
+    /// because NAT remappings rotate the port between sessions while the
+    /// IP — and therefore the proof identity — is what matters.
+    ///
+    /// Held to keep the `Arc` alive for the classifier and forwarder
+    /// tasks that captured clones — `self`-side accesses go through the
+    /// background tasks, not through this field directly.
+    #[allow(dead_code)]
+    peer_observations: Arc<DashMap<IpAddr, HashSet<SocketAddr>>>,
+    /// IPs of source-disjoint Side::Server inbounds that passed the
+    /// classifier's filters and are therefore eligible to contribute proof.
+    ///
+    /// An observation from a peer not in this set is recorded in
+    /// `peer_observations` but does not credit `proven_externals`.
+    /// Membership is monotonic: once a peer's IP is added (i.e. they
+    /// arrived as a stranger), their observations remain attributable
+    /// for the lifetime of the handle.
+    ///
+    /// Held to keep the `Arc` alive for the classifier and forwarder
+    /// tasks that captured clones — `self`-side accesses go through the
+    /// background tasks, not through this field directly.
+    #[allow(dead_code)]
+    proof_eligible_peers: Arc<DashSet<IpAddr>>,
 }
 
 // ============================================================================
@@ -324,17 +375,10 @@ impl TransportHandle {
         // address is pinned it is retained for the process lifetime.
         let external_addresses = Arc::new(parking_lot::Mutex::new(ExternalAddresses::new()));
 
-        // Subscribe to address-related P2pEvents from the transport layer:
-        //   - PeerAddressUpdated → mpsc, drained by the DHT bridge
-        //   - RelayEstablished → mpsc, drained by the DHT bridge
-        //   - RelayLost → mpsc, drained by the reachability driver
-        //   - ExternalAddressDiscovered → pinned into external_addresses
-        let (peer_addr_update_rx, relay_established_rx, relay_lost_rx) =
-            dual_node.spawn_peer_address_update_forwarder(Arc::clone(&external_addresses));
-
         // Passive direct-reachability classifier: subscribe to
-        // `P2pEvent::PeerConnected` and accumulate per-pinned-external proof
-        // sets keyed on source-disjoint remote IPs. Consumed by
+        // `P2pEvent::PeerConnected` and `P2pEvent::PeerObservedExternal`,
+        // attribute proof per-address using each peer's own
+        // `OBSERVED_ADDRESS` reports. Consumed by
         // `AcquisitionDriver::publish_typed_set` (via
         // `Self::is_external_proven`) to tag each address as
         // `AddressType::Direct` only once that address itself has cleared
@@ -344,11 +388,31 @@ impl TransportHandle {
         let dialed_addrs: Arc<DashSet<SocketAddr>> = Arc::new(DashSet::new());
         let known_peer_ips: Arc<DashSet<IpAddr>> = Arc::new(DashSet::new());
         let proven_externals: Arc<DashMap<SocketAddr, HashSet<IpAddr>>> = Arc::new(DashMap::new());
+        let peer_observations: Arc<DashMap<IpAddr, HashSet<SocketAddr>>> = Arc::new(DashMap::new());
+        let proof_eligible_peers: Arc<DashSet<IpAddr>> = Arc::new(DashSet::new());
+
+        // Subscribe to address-related P2pEvents from the transport layer:
+        //   - PeerAddressUpdated → mpsc, drained by the DHT bridge
+        //   - RelayEstablished → mpsc, drained by the DHT bridge
+        //   - RelayLost → mpsc, drained by the reachability driver
+        //   - ExternalAddressDiscovered → pinned into external_addresses
+        //     and triggers a back-fill of any earlier observations now
+        //     that the address is known.
+        let (peer_addr_update_rx, relay_established_rx, relay_lost_rx) = dual_node
+            .spawn_peer_address_update_forwarder(
+                Arc::clone(&external_addresses),
+                Arc::clone(&peer_observations),
+                Arc::clone(&proof_eligible_peers),
+                Arc::clone(&proven_externals),
+            );
+
         dual_node.spawn_direct_reachability_classifier(
             Arc::clone(&dialed_addrs),
             Arc::clone(&known_peer_ips),
             Arc::clone(&proven_externals),
             Arc::clone(&external_addresses),
+            Arc::clone(&peer_observations),
+            Arc::clone(&proof_eligible_peers),
         );
 
         // Subscribe to connection events BEFORE spawning the monitor task
@@ -418,6 +482,8 @@ impl TransportHandle {
             dialed_addrs,
             known_peer_ips,
             proven_externals,
+            peer_observations,
+            proof_eligible_peers,
         })
     }
 
@@ -501,6 +567,8 @@ impl TransportHandle {
             dialed_addrs: Arc::new(DashSet::new()),
             known_peer_ips: Arc::new(DashSet::new()),
             proven_externals: Arc::new(DashMap::new()),
+            peer_observations: Arc::new(DashMap::new()),
+            proof_eligible_peers: Arc::new(DashSet::new()),
         })
     }
 }

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -31,7 +31,9 @@ use crate::network::{
 };
 use crate::reachability::{RelaySessionEstablishError, RelaySessionEstablisher};
 use crate::transport::external_addresses::ExternalAddresses;
-use crate::transport::saorsa_transport_adapter::{ConnectionEvent, DualStackNetworkNode};
+use crate::transport::saorsa_transport_adapter::{
+    AddressEventPublisher, ConnectionEvent, DualStackNetworkNode,
+};
 use crate::validation::{RateLimitConfig, RateLimiter};
 
 use dashmap::mapref::entry::Entry as DashEntry;
@@ -43,7 +45,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
-use tokio::sync::{RwLock, broadcast};
+use tokio::sync::{RwLock, broadcast, watch};
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -260,6 +262,12 @@ pub struct TransportHandle {
     /// Bounded mpsc with the same drop semantics as
     /// `peer_address_update_rx`.
     direct_address_promoted_rx: tokio::sync::Mutex<tokio::sync::mpsc::Receiver<SocketAddr>>,
+    /// Latest direct-address promotion for observers/tests. This is
+    /// separate from the driver's single-consumer mpsc receiver so callers
+    /// can observe state changes without contending with the driver's
+    /// `recv().await`.
+    direct_address_promoted_watch_tx: watch::Sender<Option<SocketAddr>>,
+    direct_address_promoted_watch_rx: parking_lot::Mutex<watch::Receiver<Option<SocketAddr>>>,
     /// Self-address update events — received when a newly observed
     /// external address becomes publishable as Unverified or is pinned as
     /// Direct without crossing the Direct proof threshold. Drained by the
@@ -269,6 +277,11 @@ pub struct TransportHandle {
     /// Bounded mpsc with the same drop semantics as
     /// `peer_address_update_rx`.
     self_address_updated_rx: tokio::sync::Mutex<tokio::sync::mpsc::Receiver<SocketAddr>>,
+    /// Latest self-address update for observers/tests. Separate from the
+    /// driver's single-consumer mpsc receiver for the same reason as
+    /// `direct_address_promoted_watch_rx`.
+    self_address_updated_watch_tx: watch::Sender<Option<SocketAddr>>,
+    self_address_updated_watch_rx: parking_lot::Mutex<watch::Receiver<Option<SocketAddr>>>,
     /// External addresses: direct addresses pinned from transport quorum,
     /// unverified candidates from QUIC `OBSERVED_ADDRESS` frames, plus the
     /// relay-allocated address when a MASQUE relay is held. Populated by
@@ -458,14 +471,27 @@ impl TransportHandle {
         let (self_address_updated_tx, self_address_updated_rx) = tokio::sync::mpsc::channel(
             crate::transport::saorsa_transport_adapter::ADDRESS_EVENT_CHANNEL_CAPACITY,
         );
+        let (direct_address_promoted_watch_tx, direct_address_promoted_watch_rx) =
+            watch::channel(None);
+        let (self_address_updated_watch_tx, self_address_updated_watch_rx) = watch::channel(None);
+        let direct_promoted_events = AddressEventPublisher::new(
+            "DirectAddressPromoted",
+            direct_promoted_tx,
+            direct_address_promoted_watch_tx.clone(),
+        );
+        let self_address_updated_events = AddressEventPublisher::new(
+            "SelfAddressUpdated",
+            self_address_updated_tx,
+            self_address_updated_watch_tx.clone(),
+        );
         let (peer_addr_update_rx, relay_established_rx, relay_lost_rx) = dual_node
             .spawn_peer_address_update_forwarder(
                 Arc::clone(&external_addresses),
                 Arc::clone(&peer_observations),
                 Arc::clone(&proof_eligible_peers),
                 Arc::clone(&proven_externals),
-                direct_promoted_tx.clone(),
-                self_address_updated_tx.clone(),
+                direct_promoted_events.clone(),
+                self_address_updated_events.clone(),
             );
 
         dual_node.spawn_direct_reachability_classifier(
@@ -475,8 +501,8 @@ impl TransportHandle {
             Arc::clone(&external_addresses),
             Arc::clone(&peer_observations),
             Arc::clone(&proof_eligible_peers),
-            direct_promoted_tx,
-            self_address_updated_tx,
+            direct_promoted_events,
+            self_address_updated_events,
         );
 
         // Subscribe to connection events BEFORE spawning the monitor task
@@ -534,7 +560,13 @@ impl TransportHandle {
             relay_established_rx: tokio::sync::Mutex::new(relay_established_rx),
             relay_lost_rx: tokio::sync::Mutex::new(relay_lost_rx),
             direct_address_promoted_rx: tokio::sync::Mutex::new(direct_address_promoted_rx),
+            direct_address_promoted_watch_tx,
+            direct_address_promoted_watch_rx: parking_lot::Mutex::new(
+                direct_address_promoted_watch_rx,
+            ),
             self_address_updated_rx: tokio::sync::Mutex::new(self_address_updated_rx),
+            self_address_updated_watch_tx,
+            self_address_updated_watch_rx: parking_lot::Mutex::new(self_address_updated_watch_rx),
             external_addresses,
             connection_timeout: config.connection_timeout,
             connection_monitor_handle,
@@ -586,6 +618,9 @@ impl TransportHandle {
             };
             Arc::new(dual)
         };
+        let (direct_address_promoted_watch_tx, direct_address_promoted_watch_rx) =
+            watch::channel(None);
+        let (self_address_updated_watch_tx, self_address_updated_watch_rx) = watch::channel(None);
 
         Ok(Self {
             dual_node,
@@ -626,12 +661,18 @@ impl TransportHandle {
                 );
                 tokio::sync::Mutex::new(rx)
             },
+            direct_address_promoted_watch_tx,
+            direct_address_promoted_watch_rx: parking_lot::Mutex::new(
+                direct_address_promoted_watch_rx,
+            ),
             self_address_updated_rx: {
                 let (_tx, rx) = tokio::sync::mpsc::channel(
                     crate::transport::saorsa_transport_adapter::ADDRESS_EVENT_CHANNEL_CAPACITY,
                 );
                 tokio::sync::Mutex::new(rx)
             },
+            self_address_updated_watch_tx,
+            self_address_updated_watch_rx: parking_lot::Mutex::new(self_address_updated_watch_rx),
             external_addresses: Arc::new(parking_lot::Mutex::new(ExternalAddresses::new())),
             connection_timeout: Duration::from_secs(TEST_CONNECTION_TIMEOUT_SECS),
             connection_monitor_handle: Arc::new(RwLock::new(None)),
@@ -962,18 +1003,54 @@ impl TransportHandle {
         rx.try_recv().ok()
     }
 
-    /// Drain any direct-address promotion events. Returns the address that
-    /// just crossed the proof threshold, if one is queued.
-    pub async fn drain_direct_address_promoted(&self) -> Option<SocketAddr> {
-        let mut rx = self.direct_address_promoted_rx.lock().await;
-        rx.try_recv().ok()
+    fn drain_latest_socket_event(
+        rx: &parking_lot::Mutex<watch::Receiver<Option<SocketAddr>>>,
+    ) -> Option<SocketAddr> {
+        let mut rx = rx.lock();
+        if rx.has_changed().ok()? {
+            *rx.borrow_and_update()
+        } else {
+            None
+        }
     }
 
-    /// Drain any self-address update events. Returns the address that
-    /// newly became publishable, if one is queued.
+    /// Drain the latest direct-address promotion notification, if one has
+    /// arrived since the previous drain.
+    ///
+    /// This is watch-backed and never waits on the reachability driver's
+    /// single-consumer mpsc receiver. Multiple raw promotion events may
+    /// coalesce to the latest address.
+    pub async fn drain_direct_address_promoted(&self) -> Option<SocketAddr> {
+        Self::drain_latest_socket_event(&self.direct_address_promoted_watch_rx)
+    }
+
+    /// Drain the latest self-address update notification, if one has
+    /// arrived since the previous drain.
+    ///
+    /// This is watch-backed and never waits on the reachability driver's
+    /// single-consumer mpsc receiver. Multiple raw update events may
+    /// coalesce to the latest address.
     pub async fn drain_self_address_updated(&self) -> Option<SocketAddr> {
-        let mut rx = self.self_address_updated_rx.lock().await;
-        rx.try_recv().ok()
+        Self::drain_latest_socket_event(&self.self_address_updated_watch_rx)
+    }
+
+    /// Subscribe to direct-address promotion notifications.
+    ///
+    /// The returned watch receiver retains only the latest promoted
+    /// address. Its initial value is `None`; after `changed().await`,
+    /// read the current value with `borrow_and_update()`.
+    pub fn subscribe_direct_address_promoted(&self) -> watch::Receiver<Option<SocketAddr>> {
+        self.direct_address_promoted_watch_tx.subscribe()
+    }
+
+    /// Subscribe to self-address update notifications.
+    ///
+    /// The returned watch receiver retains only the latest publishable
+    /// address update. Its initial value is `None`; after
+    /// `changed().await`, read the current value with
+    /// `borrow_and_update()`.
+    pub fn subscribe_self_address_updated(&self) -> watch::Receiver<Option<SocketAddr>> {
+        self.self_address_updated_watch_tx.subscribe()
     }
 
     /// Wait for the next relay-lost event.
@@ -2667,6 +2744,30 @@ impl RelaySessionEstablisher for Arc<TransportHandle> {
         relay_addr: SocketAddr,
     ) -> std::result::Result<SocketAddr, RelaySessionEstablishError> {
         self.setup_proactive_relay_session(relay_addr).await
+    }
+}
+
+#[cfg(test)]
+mod address_event_observer_tests {
+    use super::*;
+
+    #[test]
+    fn watch_drain_returns_latest_event_once() {
+        let (tx, rx) = watch::channel(None);
+        let rx = parking_lot::Mutex::new(rx);
+        let first: SocketAddr = "198.51.100.1:10000".parse().expect("test addr");
+        let second: SocketAddr = "198.51.100.2:10000".parse().expect("test addr");
+
+        assert_eq!(TransportHandle::drain_latest_socket_event(&rx), None);
+
+        let _ = tx.send_replace(Some(first));
+        let _ = tx.send_replace(Some(second));
+
+        assert_eq!(
+            TransportHandle::drain_latest_socket_event(&rx),
+            Some(second)
+        );
+        assert_eq!(TransportHandle::drain_latest_socket_event(&rx), None);
     }
 }
 

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -810,8 +810,8 @@ impl TransportHandle {
 
     /// Look up the peer ID for a given connection address.
     pub async fn peer_id_for_addr(&self, addr: &SocketAddr) -> Option<PeerId> {
-        // Try the exact stringified address first.
-        let channel_id = addr.to_string();
+        let normalized = saorsa_transport::shared::normalize_socket_addr(*addr);
+        let channel_id = normalized.to_string();
         if let Some(peer_id) = self
             .channel_to_peers
             .get(&channel_id)
@@ -820,9 +820,9 @@ impl TransportHandle {
             return Some(peer_id);
         }
 
-        // The channel key may be stored as IPv4-mapped IPv6 (e.g., "[::ffff:1.2.3.4]:PORT")
-        // while the lookup address was normalized to IPv4 ("1.2.3.4:PORT"), or vice versa.
-        let alt_addr = saorsa_transport::shared::dual_stack_alternate(addr)?;
+        // Defensive lookup against the IPv4-mapped IPv6 alternate form in case
+        // any code path inserts via a non-canonical key.
+        let alt_addr = saorsa_transport::shared::dual_stack_alternate(&normalized)?;
         let alt_channel_id = alt_addr.to_string();
         self.channel_to_peers
             .get(&alt_channel_id)
@@ -1064,7 +1064,7 @@ impl TransportHandle {
         .await
         {
             Ok(Ok(addr)) => {
-                let connected_peer_id = addr.to_string();
+                let connected_peer_id = canonical_channel_id(addr);
 
                 // Prevent self-connections by comparing against all listen
                 // addresses (dual-stack nodes may have both IPv4 and IPv6).
@@ -1896,7 +1896,7 @@ impl TransportHandle {
                     continue;
                 }
 
-                let channel_id = remote_sock.to_string();
+                let channel_id = canonical_channel_id(remote_sock);
                 let remote_addr = MultiAddr::quic(remote_sock);
                 // PeerConnected is emitted later when the peer's identity is
                 // authenticated via a signed message — not at transport level.
@@ -2074,7 +2074,7 @@ impl TransportHandle {
     ) {
         info!("Message dispatch shard {shard_idx} started");
         while let Some((from_addr, bytes)) = shard_rx.recv().await {
-            let channel_id = from_addr.to_string();
+            let channel_id = canonical_channel_id(from_addr);
             trace!(
                 shard = shard_idx,
                 "Received {} bytes from channel {}",
@@ -2095,6 +2095,10 @@ impl TransportHandle {
                     if let Some(ref app_id) = authenticated_node_id
                         && *app_id != self_peer_id
                     {
+                        let already_mapped = peer_to_channel
+                            .get(app_id)
+                            .is_some_and(|channels| channels.value().contains(&channel_id));
+
                         // Register peer ID at the low-level transport
                         // endpoint BEFORE inserting into peer_to_channel so
                         // any concurrent reader who observes the app-level
@@ -2104,9 +2108,11 @@ impl TransportHandle {
                         // await; under sharded `DashMap` we can't hold a
                         // shard guard across an await, so we rely on
                         // happens-before via operation ordering instead.
-                        dual_node_for_peer_reg
-                            .register_connection_peer_id(from_addr, *app_id.to_bytes())
-                            .await;
+                        if !already_mapped {
+                            dual_node_for_peer_reg
+                                .register_connection_peer_id(from_addr, *app_id.to_bytes())
+                                .await;
+                        }
 
                         // Atomically determine whether this is the peer's
                         // first channel. Using `entry` per-shard avoids the
@@ -2257,6 +2263,10 @@ fn shard_index_for_addr(addr: &SocketAddr) -> usize {
     (hasher.finish() as usize) % MESSAGE_DISPATCH_SHARDS
 }
 
+fn canonical_channel_id(addr: SocketAddr) -> String {
+    saorsa_transport::shared::normalize_socket_addr(addr).to_string()
+}
+
 // ============================================================================
 // Shutdown
 // ============================================================================
@@ -2347,7 +2357,7 @@ impl TransportHandle {
                             ConnectionEvent::Established {
                                 remote_address, ..
                             } => {
-                                let channel_id = remote_address.to_string();
+                                let channel_id = canonical_channel_id(remote_address);
                                 debug!(
                                     "Connection established: channel={}, addr={}",
                                     channel_id, remote_address
@@ -2411,7 +2421,7 @@ impl TransportHandle {
                             }
                             ConnectionEvent::Lost { remote_address, reason }
                             | ConnectionEvent::Failed { remote_address, reason } => {
-                                let channel_id = remote_address.to_string();
+                                let channel_id = canonical_channel_id(remote_address);
                                 debug!("Connection lost/failed: channel={channel_id}, reason={reason}");
 
                                 active_connections.remove(&channel_id);

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -21,7 +21,7 @@ use crate::MultiAddr;
 use crate::PeerId;
 use crate::bgp_geo_provider::BgpGeoProvider;
 use crate::dht::core_engine::AddressType;
-use crate::error::{NetworkError, P2PError, P2pResult as Result};
+use crate::error::{NetworkError, P2PError, P2pResult as Result, SendFailureKind, TransportError};
 use crate::identity::node_identity::NodeIdentity;
 use crate::network::{
     ConnectionStatus, MAX_ACTIVE_REQUESTS, MAX_REQUEST_TIMEOUT, MESSAGE_RECV_CHANNEL_CAPACITY,
@@ -116,6 +116,38 @@ fn address_kind_label(kind: Option<AddressType>) -> &'static str {
     }
 }
 
+fn classify_send_error(error: &anyhow::Error) -> SendFailureKind {
+    for cause in error.chain() {
+        if let Some(endpoint_error) = cause.downcast_ref::<saorsa_transport::EndpointError>() {
+            return match endpoint_error {
+                saorsa_transport::EndpointError::PeerNotFound(_) => SendFailureKind::StaleChannel,
+                saorsa_transport::EndpointError::SendFailed { stage, .. } => {
+                    classify_transport_send_stage(*stage)
+                }
+                _ => SendFailureKind::Other,
+            };
+        }
+    }
+
+    SendFailureKind::Other
+}
+
+fn classify_transport_send_stage(stage: saorsa_transport::SendFailureStage) -> SendFailureKind {
+    match stage {
+        saorsa_transport::SendFailureStage::OpenStream => SendFailureKind::StaleChannel,
+        saorsa_transport::SendFailureStage::OpenStreamProgressTimeout => {
+            SendFailureKind::OpenStreamProgressTimeout
+        }
+        saorsa_transport::SendFailureStage::WriteProgressTimeout => {
+            SendFailureKind::WriteProgressTimeout
+        }
+        saorsa_transport::SendFailureStage::Write => SendFailureKind::StreamWrite,
+        saorsa_transport::SendFailureStage::Finish => SendFailureKind::StreamFinish,
+        saorsa_transport::SendFailureStage::Stopped => SendFailureKind::PeerStopped,
+        saorsa_transport::SendFailureStage::Acknowledgement => SendFailureKind::Acknowledgement,
+    }
+}
+
 /// Internal protocol for automatic identity announcement on connect.
 /// Filtered from P2PEvent::Message emission — not visible to applications.
 const IDENTITY_ANNOUNCE_PROTOCOL: &str = "/saorsa/identity/1.0";
@@ -125,7 +157,7 @@ pub struct TransportConfig {
     /// Addresses to bind on. The transport partitions these into at most
     /// one IPv4 and one IPv6 QUIC endpoint.
     pub listen_addrs: Vec<MultiAddr>,
-    /// Connection timeout for outbound dials and sends.
+    /// Connection timeout for outbound dials and request waits.
     pub connection_timeout: Duration,
     /// Maximum concurrent connections.
     pub max_connections: usize,
@@ -1297,8 +1329,9 @@ impl TransportHandle {
     /// Send a message to an authenticated peer (raw, no trust reporting).
     ///
     /// Resolves the app-level [`PeerId`] to transport channels via the
-    /// `peer_to_channel` mapping and tries each channel until one succeeds.
-    /// Dead channels are pruned during the attempt loop.
+    /// `peer_to_channel` mapping. Stale channels are pruned and skipped, but
+    /// active send failures are returned without trying another channel so
+    /// large/partial writes are not duplicated.
     pub async fn send_message(
         &self,
         peer_id: &PeerId,
@@ -1326,14 +1359,26 @@ impl TransportHandle {
             {
                 Ok(()) => return Ok(()),
                 Err(e) => {
+                    if e.is_stale_channel_send_failure() {
+                        warn!(
+                            peer = %peer_hex,
+                            channel = %channel_id,
+                            error = %e,
+                            "Stale channel send failed, removing and trying next",
+                        );
+                        self.remove_channel(channel_id).await;
+                        last_err = Some(e);
+                        continue;
+                    }
+
                     warn!(
                         peer = %peer_hex,
                         channel = %channel_id,
                         error = %e,
-                        "Channel send failed, removing and trying next",
+                        "Channel send failed during active send, removing without retry",
                     );
                     self.remove_channel(channel_id).await;
-                    last_err = Some(e);
+                    return Err(e);
                 }
             }
         }
@@ -1419,18 +1464,16 @@ impl TransportHandle {
                 format!("Invalid channel ID address: {e}").into(),
             ))
         })?;
-        let send_fut = self.dual_node.send_to_peer_optimized(&addr, &message_data);
-        let result = tokio::time::timeout(self.connection_timeout, send_fut)
+        let result = self
+            .dual_node
+            .send_to_peer_optimized(&addr, &message_data)
             .await
-            .map_err(|_| {
-                P2PError::Transport(crate::error::TransportError::StreamError(
-                    "Timed out sending message".into(),
-                ))
-            })?
             .map_err(|e| {
-                P2PError::Transport(crate::error::TransportError::StreamError(
-                    e.to_string().into(),
-                ))
+                let kind = classify_send_error(&e);
+                P2PError::Transport(TransportError::SendFailed {
+                    kind,
+                    reason: e.to_string().into(),
+                })
             });
 
         if result.is_ok() {

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -260,10 +260,20 @@ pub struct TransportHandle {
     /// Bounded mpsc with the same drop semantics as
     /// `peer_address_update_rx`.
     direct_address_promoted_rx: tokio::sync::Mutex<tokio::sync::mpsc::Receiver<SocketAddr>>,
-    /// Pinned external addresses: direct addresses observed from QUIC
-    /// `OBSERVED_ADDRESS` frames during bootstrap, plus the relay-allocated
-    /// address when a MASQUE relay is held. Populated by the address-update
-    /// forwarder; survives connection drops; reset on process restart.
+    /// Self-address update events — received when a newly observed
+    /// external address becomes publishable as Unverified or is pinned as
+    /// Direct without crossing the Direct proof threshold. Drained by the
+    /// reachability driver so a relay-only self-record can be corrected as
+    /// soon as a non-relay fallback appears.
+    ///
+    /// Bounded mpsc with the same drop semantics as
+    /// `peer_address_update_rx`.
+    self_address_updated_rx: tokio::sync::Mutex<tokio::sync::mpsc::Receiver<SocketAddr>>,
+    /// External addresses: direct addresses pinned from transport quorum,
+    /// unverified candidates from QUIC `OBSERVED_ADDRESS` frames, plus the
+    /// relay-allocated address when a MASQUE relay is held. Populated by
+    /// the address-update forwarder and reachability classifier; survives
+    /// connection drops; reset on process restart.
     external_addresses: Arc<parking_lot::Mutex<ExternalAddresses>>,
     connection_timeout: Duration,
     connection_monitor_handle: Arc<RwLock<Option<JoinHandle<()>>>>,
@@ -409,9 +419,11 @@ impl TransportHandle {
 
         let shutdown = CancellationToken::new();
 
-        // Pinned external addresses. The forwarder spawned below feeds
-        // this from `P2pEvent::ExternalAddressDiscovered` events; once an
-        // address is pinned it is retained for the process lifetime.
+        // External addresses. The forwarder and classifier below feed this
+        // from `ExternalAddressDiscovered` and `PeerObservedExternal`
+        // events; pinned direct addresses are retained for the process
+        // lifetime and single-observer reports are retained as Unverified
+        // publish candidates.
         let external_addresses = Arc::new(parking_lot::Mutex::new(ExternalAddresses::new()));
 
         // Passive direct-reachability classifier: subscribe to
@@ -435,10 +447,15 @@ impl TransportHandle {
         //   - RelayEstablished → mpsc, drained by the DHT bridge
         //   - RelayLost → mpsc, drained by the reachability driver
         //   - DirectAddressPromoted → mpsc, drained by the reachability driver
+        //   - SelfAddressUpdated → mpsc, drained by the reachability driver
         //   - ExternalAddressDiscovered → pinned into external_addresses
         //     and triggers a back-fill of any earlier observations now
-        //     that the address is known.
+        //     that the address is known. PeerObservedExternal is consumed
+        //     by the classifier and retained as an Unverified candidate.
         let (direct_promoted_tx, direct_address_promoted_rx) = tokio::sync::mpsc::channel(
+            crate::transport::saorsa_transport_adapter::ADDRESS_EVENT_CHANNEL_CAPACITY,
+        );
+        let (self_address_updated_tx, self_address_updated_rx) = tokio::sync::mpsc::channel(
             crate::transport::saorsa_transport_adapter::ADDRESS_EVENT_CHANNEL_CAPACITY,
         );
         let (peer_addr_update_rx, relay_established_rx, relay_lost_rx) = dual_node
@@ -448,6 +465,7 @@ impl TransportHandle {
                 Arc::clone(&proof_eligible_peers),
                 Arc::clone(&proven_externals),
                 direct_promoted_tx.clone(),
+                self_address_updated_tx.clone(),
             );
 
         dual_node.spawn_direct_reachability_classifier(
@@ -458,6 +476,7 @@ impl TransportHandle {
             Arc::clone(&peer_observations),
             Arc::clone(&proof_eligible_peers),
             direct_promoted_tx,
+            self_address_updated_tx,
         );
 
         // Subscribe to connection events BEFORE spawning the monitor task
@@ -515,6 +534,7 @@ impl TransportHandle {
             relay_established_rx: tokio::sync::Mutex::new(relay_established_rx),
             relay_lost_rx: tokio::sync::Mutex::new(relay_lost_rx),
             direct_address_promoted_rx: tokio::sync::Mutex::new(direct_address_promoted_rx),
+            self_address_updated_rx: tokio::sync::Mutex::new(self_address_updated_rx),
             external_addresses,
             connection_timeout: config.connection_timeout,
             connection_monitor_handle,
@@ -606,6 +626,12 @@ impl TransportHandle {
                 );
                 tokio::sync::Mutex::new(rx)
             },
+            self_address_updated_rx: {
+                let (_tx, rx) = tokio::sync::mpsc::channel(
+                    crate::transport::saorsa_transport_adapter::ADDRESS_EVENT_CHANNEL_CAPACITY,
+                );
+                tokio::sync::Mutex::new(rx)
+            },
             external_addresses: Arc::new(parking_lot::Mutex::new(ExternalAddresses::new())),
             connection_timeout: Duration::from_secs(TEST_CONNECTION_TIMEOUT_SECS),
             connection_monitor_handle: Arc::new(RwLock::new(None)),
@@ -687,31 +713,34 @@ impl TransportHandle {
     }
 
     /// Return **all** external addresses for this node: relay first
-    /// (preferred), then pinned direct addresses from bootstrap
-    /// OBSERVED_ADDRESS frames.
+    /// (preferred), then pinned direct addresses, then observed-but-
+    /// unverified external candidates from QUIC `OBSERVED_ADDRESS` frames.
     ///
-    /// Returns an empty vec if nothing has been pinned yet — the
-    /// `ExternalAddressDiscovered` events that drive pinning are
-    /// quorum-gated in saorsa-transport (≥ 2 distinct observers per
-    /// address), so any caller that wants to publish or otherwise act on
-    /// these addresses gets only the quorum-cleared set. There is no
-    /// live-observation fallback: a single peer's unconfirmed
-    /// `OBSERVED_ADDRESS` is not strong enough evidence to advertise.
+    /// Callers should still use [`Self::is_external_proven`] to decide
+    /// whether a non-relay address is Direct or Unverified. A single
+    /// observation is publishable as Unverified so dialers can try it
+    /// after the relay, but it is not treated as proven Direct until it
+    /// crosses the passive proof threshold.
     pub fn observed_external_addresses(&self) -> Vec<SocketAddr> {
         self.external_addresses.lock().all_addresses()
     }
 
-    /// Return only the pinned **direct** external addresses (no relay).
+    /// Return only the pinned **direct** external addresses (no relay, no
+    /// unverified candidates).
+    pub fn direct_external_addresses(&self) -> Vec<SocketAddr> {
+        self.external_addresses.lock().direct_addresses()
+    }
+
+    /// Return all non-relay external addresses that should be considered
+    /// for typed self-publication.
     ///
     /// Used by callers that tag addresses by type (e.g. the relay driver's
     /// `publish_typed_set`) to avoid double-tagging the relay address as
-    /// both Direct and Relay.
-    ///
-    /// Same quorum guarantee as
-    /// [`Self::observed_external_addresses`]: only addresses cleared by
-    /// saorsa-transport's `MIN_OBSERVERS_FOR_QUORUM` gate are returned.
-    pub fn direct_external_addresses(&self) -> Vec<SocketAddr> {
-        self.external_addresses.lock().direct_addresses()
+    /// both Direct and Relay. Returned addresses may be Direct or
+    /// Unverified; call [`Self::is_external_proven`] per address to tag
+    /// them correctly.
+    pub fn non_relay_external_addresses(&self) -> Vec<SocketAddr> {
+        self.external_addresses.lock().non_relay_addresses()
     }
 
     /// Store the relay-allocated address so it is included (first) in
@@ -940,6 +969,13 @@ impl TransportHandle {
         rx.try_recv().ok()
     }
 
+    /// Drain any self-address update events. Returns the address that
+    /// newly became publishable, if one is queued.
+    pub async fn drain_self_address_updated(&self) -> Option<SocketAddr> {
+        let mut rx = self.self_address_updated_rx.lock().await;
+        rx.try_recv().ok()
+    }
+
     /// Wait for the next relay-lost event.
     ///
     /// Resolves when a previously-advertised MASQUE relay address has
@@ -964,6 +1000,16 @@ impl TransportHandle {
     /// if the underlying channel has closed.
     pub async fn recv_direct_address_promoted(&self) -> Option<SocketAddr> {
         let mut rx = self.direct_address_promoted_rx.lock().await;
+        rx.recv().await
+    }
+
+    /// Wait for the next self-address update event.
+    ///
+    /// Resolves when a non-relay external address newly becomes
+    /// publishable as Unverified or is pinned as Direct without crossing
+    /// the Direct proof threshold, or `None` if the channel has closed.
+    pub async fn recv_self_address_updated(&self) -> Option<SocketAddr> {
+        let mut rx = self.self_address_updated_rx.lock().await;
         rx.recv().await
     }
 

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -38,9 +38,9 @@ use dashmap::{DashMap, DashSet};
 use std::collections::HashSet;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::sync::{RwLock, broadcast};
 use tokio::task::JoinHandle;
@@ -54,6 +54,39 @@ const TEST_MAX_REQUESTS: u32 = 100;
 const TEST_BURST_SIZE: u32 = 100;
 const TEST_RATE_LIMIT_WINDOW_SECS: u64 = 1;
 const TEST_CONNECTION_TIMEOUT_SECS: u64 = 30;
+
+/// Minimum distinct source-disjoint observers required before an external
+/// address is considered cold-dialable.
+///
+/// "Source-disjoint" means the observer IP was not already in this node's
+/// known-peer set at the time of the inbound — i.e. not a peer we had ever
+/// dialed or seen connect to us. Two such observers eliminates the
+/// pinhole-self-fulfillment case (one already-known peer redialing through
+/// their pre-existing NAT binding) while still allowing prompt promotion
+/// in healthy clusters where multiple bootstraps independently reach the
+/// node within the first connect window.
+///
+/// Matches `MIN_OBSERVERS_FOR_QUORUM` in saorsa-transport's address-pinning
+/// path (`nat_traversal_api.rs`) — same statistical argument.
+pub(crate) const MIN_DISTINCT_OBSERVERS_FOR_DIRECT: usize = 2;
+
+/// Return `true` iff `external` has cleared the per-address proof
+/// threshold in `proven_externals`.
+///
+/// Free function so the threshold semantics — and the address
+/// normalisation that backs lookups — can be exercised in unit tests
+/// without constructing a full [`TransportHandle`] (which performs real
+/// network binds).
+pub(crate) fn external_meets_proof_threshold(
+    external: SocketAddr,
+    proven_externals: &DashMap<SocketAddr, HashSet<IpAddr>>,
+) -> bool {
+    let normalized = saorsa_transport::shared::normalize_socket_addr(external);
+    proven_externals
+        .get(&normalized)
+        .map(|set| set.len() >= MIN_DISTINCT_OBSERVERS_FOR_DIRECT)
+        .unwrap_or(false)
+}
 
 /// Internal protocol for automatic identity announcement on connect.
 /// Filtered from P2PEvent::Message emission — not visible to applications.
@@ -192,15 +225,30 @@ pub struct TransportHandle {
     /// entries are never removed for the lifetime of the handle because the
     /// classifier only cares about "did we ever dial this remote?".
     dialed_addrs: Arc<DashSet<SocketAddr>>,
-    /// Becomes `true` the first time an unsolicited inbound handshake
-    /// completes (an accepted connection from a remote address that is not
-    /// in `dialed_addrs`). Once set, the flag latches — reachability does
-    /// not "un-prove" itself within a single process lifetime. Consumed by
-    /// [`crate::reachability::driver::AcquisitionDriver::publish_typed_set`]
-    /// to decide between publishing `AddressType::Direct` and
-    /// `AddressType::Unverified` for the local node's observed external
-    /// addresses.
-    direct_reachability_observed: Arc<AtomicBool>,
+    /// IPs of every peer this handle has ever interacted with. Populated by
+    /// [`Self::connect_peer`] (alongside `dialed_addrs`) and by the passive
+    /// reachability classifier on every `PeerConnected` event (both sides).
+    /// Used as the source-disjointness exclusion set for the per-address
+    /// proof: an inbound from an IP already in this set does not prove
+    /// cold-dialability — that peer already had reason to know our address
+    /// (we dialed them, or they connected to us before) and could therefore
+    /// reach us through a pre-existing NAT pinhole. Per-IP (not per
+    /// SocketAddr) because NAT remappings between sessions change the port
+    /// while the IP — and therefore the pinhole — is what matters.
+    known_peer_ips: Arc<DashSet<IpAddr>>,
+    /// Distinct source-disjoint observer IPs per pinned external address.
+    ///
+    /// An entry is added when a `Side::Server` inbound arrives whose remote
+    /// IP is not in `known_peer_ips` and not equal to any pinned external
+    /// IP (sibling-hairpin filter). The inbound's stack-family (v4 vs v6)
+    /// determines which pinned externals receive the credit.
+    ///
+    /// An external is considered cold-dialable
+    /// ([`AddressType::Direct`](crate::dht::AddressType::Direct)) once its
+    /// observer set reaches [`MIN_DISTINCT_OBSERVERS_FOR_DIRECT`].
+    /// Per-address — never globally — so one external's proof does not
+    /// promote unrelated externals.
+    proven_externals: Arc<DashMap<SocketAddr, HashSet<IpAddr>>>,
 }
 
 // ============================================================================
@@ -270,17 +318,21 @@ impl TransportHandle {
             dual_node.spawn_peer_address_update_forwarder(Arc::clone(&external_addresses));
 
         // Passive direct-reachability classifier: subscribe to
-        // `P2pEvent::PeerConnected` and flip `direct_reachability_observed`
-        // the first time an inbound (`Side::Server`) handshake completes
-        // from a remote we did not dial first. Consumed by
-        // `AcquisitionDriver::publish_typed_set` to pick between
-        // `AddressType::Direct` and `AddressType::Unverified` for the
-        // self-record's observed external addresses.
+        // `P2pEvent::PeerConnected` and accumulate per-pinned-external proof
+        // sets keyed on source-disjoint remote IPs. Consumed by
+        // `AcquisitionDriver::publish_typed_set` (via
+        // `Self::is_external_proven`) to tag each address as
+        // `AddressType::Direct` only once that address itself has cleared
+        // the observer threshold. The classifier also writes into
+        // `known_peer_ips` on every `PeerConnected` event so subsequent
+        // inbounds from the same IP do not count as fresh proof.
         let dialed_addrs: Arc<DashSet<SocketAddr>> = Arc::new(DashSet::new());
-        let direct_reachability_observed: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+        let known_peer_ips: Arc<DashSet<IpAddr>> = Arc::new(DashSet::new());
+        let proven_externals: Arc<DashMap<SocketAddr, HashSet<IpAddr>>> = Arc::new(DashMap::new());
         dual_node.spawn_direct_reachability_classifier(
             Arc::clone(&dialed_addrs),
-            Arc::clone(&direct_reachability_observed),
+            Arc::clone(&known_peer_ips),
+            Arc::clone(&proven_externals),
             Arc::clone(&external_addresses),
         );
 
@@ -349,7 +401,8 @@ impl TransportHandle {
             channel_to_peers,
             peer_user_agents,
             dialed_addrs,
-            direct_reachability_observed,
+            known_peer_ips,
+            proven_externals,
         })
     }
 
@@ -431,7 +484,8 @@ impl TransportHandle {
             channel_to_peers: Arc::new(DashMap::new()),
             peer_user_agents: Arc::new(DashMap::new()),
             dialed_addrs: Arc::new(DashSet::new()),
-            direct_reachability_observed: Arc::new(AtomicBool::new(false)),
+            known_peer_ips: Arc::new(DashSet::new()),
+            proven_externals: Arc::new(DashMap::new()),
         })
     }
 }
@@ -451,22 +505,28 @@ impl TransportHandle {
         &self.node_identity
     }
 
-    /// Whether the local listener is known to be cold-dialable.
+    /// Whether the named external address has been proven cold-dialable.
     ///
-    /// Set by the passive reachability classifier (see
-    /// [`crate::transport::saorsa_transport_adapter::DualStackNetworkNode::spawn_direct_reachability_classifier`])
-    /// the first time a `Side::Server` handshake completes from a remote
-    /// address we had not previously dialed. Once set, the flag latches —
-    /// reachability is not considered to have "un-proven" itself for the
-    /// lifetime of this `TransportHandle`.
+    /// Returns `true` iff at least
+    /// [`MIN_DISTINCT_OBSERVERS_FOR_DIRECT`] distinct source-disjoint peers
+    /// have made unsolicited inbound connections that the classifier
+    /// attributed to this external. "Source-disjoint" means the observer
+    /// IP was not in `known_peer_ips` at the time of the inbound — i.e.
+    /// not a peer this handle had any prior reason to know about.
     ///
-    /// Consumed by [`crate::reachability::driver::AcquisitionDriver::publish_typed_set`]
-    /// to decide whether this node's observed external addresses are
-    /// published as [`crate::dht::AddressType::Direct`] (flag set) or
-    /// [`crate::dht::AddressType::Unverified`] (flag unset, and no relay
-    /// available).
-    pub fn direct_reachability_observed(&self) -> bool {
-        self.direct_reachability_observed.load(Ordering::Acquire)
+    /// Per-address: one external's proof never promotes another. An
+    /// inbound on the v4 stack only credits v4 externals, and an inbound
+    /// from a peer behind the same NAT (sibling-hairpin) is rejected.
+    ///
+    /// Consumed by
+    /// [`crate::reachability::driver::AcquisitionDriver::publish_typed_set`]
+    /// to tag each address as
+    /// [`AddressType::Direct`](crate::dht::AddressType::Direct) (proven)
+    /// or [`AddressType::Unverified`](crate::dht::AddressType::Unverified)
+    /// (not yet proven, no relay held) — or to suppress unverified entries
+    /// entirely when a relay is held.
+    pub fn is_external_proven(&self, addr: SocketAddr) -> bool {
+        external_meets_proof_threshold(addr, &self.proven_externals)
     }
 
     /// Get the first listen address as a string.
@@ -496,17 +556,15 @@ impl TransportHandle {
     /// (preferred), then pinned direct addresses from bootstrap
     /// OBSERVED_ADDRESS frames.
     ///
-    /// If no addresses have been pinned yet (the brief ~1s window after
-    /// bootstrap connection before the first `ExternalAddressDiscovered`
-    /// event), falls back to the live observation from active connections.
+    /// Returns an empty vec if nothing has been pinned yet — the
+    /// `ExternalAddressDiscovered` events that drive pinning are
+    /// quorum-gated in saorsa-transport (≥ 2 distinct observers per
+    /// address), so any caller that wants to publish or otherwise act on
+    /// these addresses gets only the quorum-cleared set. There is no
+    /// live-observation fallback: a single peer's unconfirmed
+    /// `OBSERVED_ADDRESS` is not strong enough evidence to advertise.
     pub fn observed_external_addresses(&self) -> Vec<SocketAddr> {
-        let pinned = self.external_addresses.lock().all_addresses();
-        if !pinned.is_empty() {
-            return pinned;
-        }
-        // Brief-window fallback: before the forwarder has pinned any
-        // address, try the live query on active connections.
-        self.dual_node.get_observed_external_addresses()
+        self.external_addresses.lock().all_addresses()
     }
 
     /// Return only the pinned **direct** external addresses (no relay).
@@ -514,12 +572,12 @@ impl TransportHandle {
     /// Used by callers that tag addresses by type (e.g. the relay driver's
     /// `publish_typed_set`) to avoid double-tagging the relay address as
     /// both Direct and Relay.
+    ///
+    /// Same quorum guarantee as
+    /// [`Self::observed_external_addresses`]: only addresses cleared by
+    /// saorsa-transport's `MIN_OBSERVERS_FOR_QUORUM` gate are returned.
     pub fn direct_external_addresses(&self) -> Vec<SocketAddr> {
-        let pinned = self.external_addresses.lock().direct_addresses();
-        if !pinned.is_empty() {
-            return pinned;
-        }
-        self.dual_node.get_observed_external_addresses()
+        self.external_addresses.lock().direct_addresses()
     }
 
     /// Store the relay-allocated address so it is included (first) in
@@ -874,10 +932,17 @@ impl TransportHandle {
         // passive reachability classifier can distinguish simultaneous-open
         // replies from genuinely unsolicited inbounds. The set is
         // monotonic; we do not remove entries on disconnect.
-        self.dialed_addrs
-            .insert(saorsa_transport::shared::normalize_socket_addr(
-                normalized_addr,
-            ));
+        let dial_target_normalized =
+            saorsa_transport::shared::normalize_socket_addr(normalized_addr);
+        self.dialed_addrs.insert(dial_target_normalized);
+        // Also record the dial target's IP in `known_peer_ips` so that an
+        // inbound from this peer through a NAT-remapped source port — same
+        // IP, different port, missed by the SocketAddr-keyed `dialed_addrs`
+        // — is correctly recognised as not source-disjoint by the
+        // reachability classifier.
+        self.known_peer_ips.insert(crate::security::canonicalize_ip(
+            dial_target_normalized.ip(),
+        ));
 
         let peer_id = match tokio::time::timeout(
             self.connection_timeout,
@@ -2339,5 +2404,115 @@ impl RelaySessionEstablisher for Arc<TransportHandle> {
         relay_addr: SocketAddr,
     ) -> std::result::Result<SocketAddr, RelaySessionEstablishError> {
         self.setup_proactive_relay_session(relay_addr).await
+    }
+}
+
+#[cfg(test)]
+mod proven_externals_tests {
+    use super::*;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().expect("test IP")
+    }
+
+    fn sa(s: &str) -> SocketAddr {
+        s.parse().expect("test socket addr")
+    }
+
+    fn seed_observer(
+        proven: &DashMap<SocketAddr, HashSet<IpAddr>>,
+        external: SocketAddr,
+        observer: IpAddr,
+    ) {
+        let normalized = saorsa_transport::shared::normalize_socket_addr(external);
+        proven.entry(normalized).or_default().insert(observer);
+    }
+
+    #[test]
+    fn external_with_no_observers_is_not_proven() {
+        let proven = DashMap::new();
+        assert!(!external_meets_proof_threshold(
+            sa("198.51.100.1:10000"),
+            &proven
+        ));
+    }
+
+    #[test]
+    fn external_with_one_observer_is_not_proven() {
+        let proven = DashMap::new();
+        let ext = sa("198.51.100.1:10000");
+        seed_observer(&proven, ext, ip("203.0.113.1"));
+        assert!(!external_meets_proof_threshold(ext, &proven));
+    }
+
+    #[test]
+    fn external_with_two_distinct_observers_is_proven() {
+        let proven = DashMap::new();
+        let ext = sa("198.51.100.1:10000");
+        seed_observer(&proven, ext, ip("203.0.113.1"));
+        seed_observer(&proven, ext, ip("203.0.113.2"));
+        assert!(external_meets_proof_threshold(ext, &proven));
+    }
+
+    #[test]
+    fn duplicate_observer_does_not_count_twice() {
+        let proven = DashMap::new();
+        let ext = sa("198.51.100.1:10000");
+        seed_observer(&proven, ext, ip("203.0.113.1"));
+        seed_observer(&proven, ext, ip("203.0.113.1"));
+        assert!(
+            !external_meets_proof_threshold(ext, &proven),
+            "the same observer reporting twice must not satisfy the distinct-observer quorum"
+        );
+    }
+
+    #[test]
+    fn one_externals_proof_does_not_promote_another() {
+        let proven = DashMap::new();
+        let ext_a = sa("198.51.100.1:10000");
+        let ext_b = sa("198.51.100.2:10000");
+        seed_observer(&proven, ext_a, ip("203.0.113.1"));
+        seed_observer(&proven, ext_a, ip("203.0.113.2"));
+        assert!(external_meets_proof_threshold(ext_a, &proven));
+        assert!(
+            !external_meets_proof_threshold(ext_b, &proven),
+            "B has no observers; A's proof must not leak across externals"
+        );
+    }
+
+    #[test]
+    fn v4_external_proof_does_not_promote_v6_external() {
+        let proven = DashMap::new();
+        let v4 = sa("198.51.100.1:10000");
+        let v6 = sa("[2001:db8::1]:10000");
+        seed_observer(&proven, v4, ip("203.0.113.1"));
+        seed_observer(&proven, v4, ip("203.0.113.2"));
+        assert!(external_meets_proof_threshold(v4, &proven));
+        assert!(
+            !external_meets_proof_threshold(v6, &proven),
+            "different family: v4 proof must not leak to a v6 external"
+        );
+    }
+
+    #[test]
+    fn lookup_normalises_v4_mapped_v6() {
+        // External pinned in plain v4 form; caller queries via
+        // IPv4-mapped IPv6 (`::ffff:198.51.100.1`). Both must hit the
+        // same entry after normalisation; otherwise the publisher's
+        // per-address tag computation can disagree with what the
+        // classifier wrote, and an address would be tagged Unverified
+        // despite having reached its observer quorum.
+        let proven = DashMap::new();
+        let v4 = sa("198.51.100.1:10000");
+        seed_observer(&proven, v4, ip("203.0.113.1"));
+        seed_observer(&proven, v4, ip("203.0.113.2"));
+
+        let mapped: SocketAddr = "[::ffff:198.51.100.1]:10000"
+            .parse()
+            .expect("test mapped addr");
+        assert!(
+            external_meets_proof_threshold(mapped, &proven),
+            "lookup via IPv4-mapped IPv6 must normalize to the v4 entry"
+        );
     }
 }

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -251,6 +251,15 @@ pub struct TransportHandle {
     /// Bounded mpsc with the same drop semantics as
     /// `peer_address_update_rx`.
     relay_lost_rx: tokio::sync::Mutex<tokio::sync::mpsc::Receiver<SocketAddr>>,
+    /// Direct address promotion events — received when the passive
+    /// reachability classifier proves one of this node's pinned external
+    /// addresses is cold-dialable. Drained by the reachability driver while
+    /// holding a relay so it can republish `Relay + Direct` instead of
+    /// leaving peers with the older `Relay + Unverified` self-record.
+    ///
+    /// Bounded mpsc with the same drop semantics as
+    /// `peer_address_update_rx`.
+    direct_address_promoted_rx: tokio::sync::Mutex<tokio::sync::mpsc::Receiver<SocketAddr>>,
     /// Pinned external addresses: direct addresses observed from QUIC
     /// `OBSERVED_ADDRESS` frames during bootstrap, plus the relay-allocated
     /// address when a MASQUE relay is held. Populated by the address-update
@@ -425,15 +434,20 @@ impl TransportHandle {
         //   - PeerAddressUpdated → mpsc, drained by the DHT bridge
         //   - RelayEstablished → mpsc, drained by the DHT bridge
         //   - RelayLost → mpsc, drained by the reachability driver
+        //   - DirectAddressPromoted → mpsc, drained by the reachability driver
         //   - ExternalAddressDiscovered → pinned into external_addresses
         //     and triggers a back-fill of any earlier observations now
         //     that the address is known.
+        let (direct_promoted_tx, direct_address_promoted_rx) = tokio::sync::mpsc::channel(
+            crate::transport::saorsa_transport_adapter::ADDRESS_EVENT_CHANNEL_CAPACITY,
+        );
         let (peer_addr_update_rx, relay_established_rx, relay_lost_rx) = dual_node
             .spawn_peer_address_update_forwarder(
                 Arc::clone(&external_addresses),
                 Arc::clone(&peer_observations),
                 Arc::clone(&proof_eligible_peers),
                 Arc::clone(&proven_externals),
+                direct_promoted_tx.clone(),
             );
 
         dual_node.spawn_direct_reachability_classifier(
@@ -443,6 +457,7 @@ impl TransportHandle {
             Arc::clone(&external_addresses),
             Arc::clone(&peer_observations),
             Arc::clone(&proof_eligible_peers),
+            direct_promoted_tx,
         );
 
         // Subscribe to connection events BEFORE spawning the monitor task
@@ -499,6 +514,7 @@ impl TransportHandle {
             peer_address_update_rx: tokio::sync::Mutex::new(peer_addr_update_rx),
             relay_established_rx: tokio::sync::Mutex::new(relay_established_rx),
             relay_lost_rx: tokio::sync::Mutex::new(relay_lost_rx),
+            direct_address_promoted_rx: tokio::sync::Mutex::new(direct_address_promoted_rx),
             external_addresses,
             connection_timeout: config.connection_timeout,
             connection_monitor_handle,
@@ -584,6 +600,12 @@ impl TransportHandle {
                 );
                 tokio::sync::Mutex::new(rx)
             },
+            direct_address_promoted_rx: {
+                let (_tx, rx) = tokio::sync::mpsc::channel(
+                    crate::transport::saorsa_transport_adapter::ADDRESS_EVENT_CHANNEL_CAPACITY,
+                );
+                tokio::sync::Mutex::new(rx)
+            },
             external_addresses: Arc::new(parking_lot::Mutex::new(ExternalAddresses::new())),
             connection_timeout: Duration::from_secs(TEST_CONNECTION_TIMEOUT_SECS),
             connection_monitor_handle: Arc::new(RwLock::new(None)),
@@ -636,8 +658,7 @@ impl TransportHandle {
     /// to tag each address as
     /// [`AddressType::Direct`](crate::dht::AddressType::Direct) (proven)
     /// or [`AddressType::Unverified`](crate::dht::AddressType::Unverified)
-    /// (not yet proven, no relay held) — or to suppress unverified entries
-    /// entirely when a relay is held.
+    /// (not yet proven).
     pub fn is_external_proven(&self, addr: SocketAddr) -> bool {
         external_meets_proof_threshold(addr, &self.proven_externals)
     }
@@ -912,6 +933,13 @@ impl TransportHandle {
         rx.try_recv().ok()
     }
 
+    /// Drain any direct-address promotion events. Returns the address that
+    /// just crossed the proof threshold, if one is queued.
+    pub async fn drain_direct_address_promoted(&self) -> Option<SocketAddr> {
+        let mut rx = self.direct_address_promoted_rx.lock().await;
+        rx.try_recv().ok()
+    }
+
     /// Wait for the next relay-lost event.
     ///
     /// Resolves when a previously-advertised MASQUE relay address has
@@ -925,6 +953,17 @@ impl TransportHandle {
     /// dead relay address.
     pub async fn recv_relay_lost(&self) -> Option<SocketAddr> {
         let mut rx = self.relay_lost_rx.lock().await;
+        rx.recv().await
+    }
+
+    /// Wait for the next direct-address promotion event.
+    ///
+    /// Resolves when one of this node's pinned external addresses crosses
+    /// the passive proof threshold and should be republished as
+    /// [`AddressType::Direct`](crate::dht::AddressType::Direct), or `None`
+    /// if the underlying channel has closed.
+    pub async fn recv_direct_address_promoted(&self) -> Option<SocketAddr> {
+        let mut rx = self.direct_address_promoted_rx.lock().await;
         rx.recv().await
     }
 


### PR DESCRIPTION
## Summary

Hardens the relay/reachability path and tightens transport timeout + send-failure semantics on top of saorsa-transport 0.34.0.

**Reachability — per-address Direct attribution**
- Replace global `direct_reachability_observed` with a per-pinned-external proof set, source-disjoint over observer IPs. An address is `Direct` only after `MIN_DISTINCT_OBSERVERS_FOR_DIRECT=2` peers (none in `dialed_addrs`, none in `known_peer_ips`) attribute an unsolicited inbound to it. Closes the pinhole-self-fulfillment case where a bootstrap redial flipped the global flag.
- Per-address attribution sourced from peers' QUIC `OBSERVED_ADDRESS` frames (new `P2pEvent::PeerObservedExternal`) instead of the per-family shortcut.
- Drop the live-observation fallback — `{direct,observed}_external_addresses()` now return only pinned, quorum-cleared addresses.

**Self-publish + dial plan shape**
- Publish Relay first, then one best non-Relay address per IP family (V4 + V6); same family priority Direct > Unverified > NATted, observed externals win same-tier ties.
- `select_dial_candidates` mirrors the publish shape: Relay + best per family, capped at three attempts.
- Retain unverified single-peer OBSERVED_ADDRESS reports as fallback publish candidates so relay-only self-records can advertise a NAT-mapped direct address.
- Promotion plumbing: `direct_address_promoted` mpsc from passive classifier → driver triggers an immediate typed-record republish on threshold crossing.
- Dedup typed self-address-set publishes; routine refreshes are skipped when neither the address set nor K-closest peers changed. State transitions (relay acquired/lost) bypass the cache.

**Transport — timeouts + send classification**
- Unify direct connect timeout into a single `direct_connect_timeout`; introduce `DIRECT_HANDSHAKE_TIMEOUT` (4s) separate from `DIRECT_CONNECT_TIMEOUT` (1s).
- New `SendFailureKind` distinguishes stale-channel (safe to reconnect/retry) from active-send (must not retry — would duplicate partial writes). `send_message` only retries on stale-channel.
- Drop the application-layer `connection_timeout` wrapper; transport's own open-stream / write-progress timeouts now drive timeouts.
- `connect_peer_typed` plumbs `AddressType` through dials so success/failure/timeout logs carry a structured `kind` field (Direct/Relay/Unverified/NATted).
- Normalize peer mappings; drop same-IP updates.

## Breaking changes

- `TransportHandle::direct_reachability_observed() -> bool` removed; replaced by `is_external_proven(SocketAddr) -> bool`.
- `SendFailureKind::PeerStopped` and `SendFailureKind::Acknowledgement` removed (saorsa-transport no longer emits them).
- Internal: `spawn_direct_reachability_classifier` and `spawn_peer_address_update_forwarder` take additional `Arc` parameters.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --lib` (baseline 382 + 12 new = 394 expected)
- [ ] Manual: bootstrap redial against a node behind NAT does not flip `Direct` tag without two source-disjoint observers
- [ ] Manual: relay-only node publishes a NAT-mapped fallback once a peer reports it via `OBSERVED_ADDRESS`
- [ ] Manual: send during peer disconnect surfaces as active-send failure (no retry), stale-channel failure does retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the global `direct_reachability_observed: AtomicBool` with a per-address proof system (`proven_externals: DashMap<SocketAddr, HashSet<IpAddr>>`), requiring at least 2 source-disjoint `OBSERVED_ADDRESS` reports to tag an external as `Direct`. It also introduces `SendFailureKind` to distinguish stale-channel (safe-to-retry) from active-send failures (must not retry), and overhauls the relay-driver publish shape to emit relay first then one best non-relay address per IP family.

- **P1** — `drain_direct_address_promoted()` and `drain_self_address_updated()` share a `tokio::sync::Mutex` with their `recv_*` counterparts; when the reachability driver is blocking inside a `select!` on `recv_direct_address_promoted()`, the `MutexGuard` is held across the await suspension, causing any concurrent `drain_*` caller to block indefinitely rather than performing the expected non-blocking `try_recv`.
- The per-address proof classifier, back-fill logic, and `PublishedTypedSet` dedup cache are well-designed and comprehensively unit-tested.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — the drain/recv mutex contention is a latent blocking bug that will surface once drain_* methods are used concurrently with the driver.

One P1 (drain_*/recv_* mutex starvation) and two P2s (register_connection_peer_id dual-stack regression, resolve_dial_address unconditional DHT lookup). The core per-address proof logic is well-reasoned and heavily tested, but the P1 is a subtle async correctness issue that warrants a fix before merging.

src/transport_handle.rs (drain_*/recv_* mutex), src/transport/saorsa_transport_adapter.rs (register_connection_peer_id early return), src/network.rs (resolve_dial_address DHT pre-fetch)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/transport_handle.rs | Core reachability overhaul: replaces global AtomicBool with per-address proven_externals DashMap, adds known_peer_ips/peer_observations/proof_eligible_peers state, and wires two new mpsc channels for promotion/update events. The drain_*/recv_* sharing of a single tokio::sync::Mutex is a design flaw that can cause indefinite blocking. |
| src/transport/saorsa_transport_adapter.rs | Large refactor: adds handle_peer_connected_for_proof, handle_peer_observed_external, back_fill_proof_on_pin, and classify_send_error helpers extracted into free functions for testability. Changes register_connection_peer_id to register only with the first endpoint that has an active connection (drops dual-stack alternate), and updates DIRECT_CONNECT_TIMEOUT from 2s to 1s with a new separate DIRECT_HANDSHAKE_TIMEOUT of 4s. |
| src/reachability/driver.rs | Driver now subscribes to recv_direct_address_promoted and recv_self_address_updated in both hold_until_lost and wait_backoff_or_event select loops; dedup publish cache (PublishedTypedSet) avoids redundant republishes; build_typed_self_address_set correctly emits relay first then one best non-relay address per IP family. |
| src/transport/external_addresses.rs | Adds unverified Vec and record_unverified() method alongside pinned-direct list; pin_direct now returns bool and promotes from unverified; normalization applied consistently in set_relay. Well-tested. |
| src/error.rs | New SendFailureKind enum distinguishes stale-channel from active-send failures; TransportError::SendFailed replaces the prior generic stream error; P2PError::is_stale_channel_send_failure drives retry policy. Well-designed and well-tested. |
| src/dht_network_manager.rs | select_dial_candidates rewritten to select one best non-relay address per IP family (capped at 3 total); dial_candidate now takes AddressType for structured logging; removes the bare peer_addresses_for_dial wrapper. |
| src/network.rs | resolve_dial_address now returns (MultiAddr, AddressType) and always pre-fetches DHT typed addresses upfront; reconnect fast-path correctly gates on is_stale_channel_send_failure. Unconditional DHT lookup is a minor performance regression. |
| src/reachability/session.rs | Adds per-candidate debug logging during relay acquisition; comment updates reflect new publish shape. No logic changes. |
| src/adaptive/dht.rs | Renames peer_addresses_for_dial to peer_addresses_for_dial_typed to surface the AddressType tag; thin delegation to the manager layer. |
| src/dht/core_engine.rs | Doc comment update only: references updated method name peer_addresses_for_dial_typed. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PT as saorsa_transport
    participant AF as AddressForwarder
    participant RC as ReachabilityClassifier
    participant EA as ExternalAddresses
    participant PE as proven_externals
    participant AD as AcquisitionDriver

    PT->>RC: PeerConnected(addr, Side::Server)
    RC->>RC: source-disjoint / sibling-hairpin filters
    RC->>EA: direct_addresses() [for hairpin check]
    RC->>PE: credit_observation(peer_ip, ext) [if eligible]
    RC-->>AD: emit_direct_promotion(addr) [if threshold crossed]

    PT->>RC: PeerObservedExternal(peer_addr, observed_ext)
    RC->>EA: record_unverified(observed_ext)
    RC->>PE: credit_observation(peer_ip, observed_ext) [if eligible]
    RC-->>AD: emit_self_address_update(addr) [if new unverified]
    RC-->>AD: emit_direct_promotion(addr) [if threshold crossed]

    PT->>AF: ExternalAddressDiscovered(addr)
    AF->>EA: pin_direct(addr)
    AF->>PE: back_fill_proof_on_pin(addr, observations, eligible)
    AF-->>AD: emit_direct_promotion(addr) [if back-fill promotes]
    AF-->>AD: emit_self_address_update(addr) [if no promotion]

    AD->>AD: select recv_direct_address_promoted / recv_self_address_updated
    AD->>AD: publish_typed_set_with_policy(relay, force=false)
    AD->>AD: build_typed_self_address_set [Relay first, best per family]
    AD->>AD: dedup via PublishedTypedSet cache
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/transport_handle.rs`, line 1302-1313 ([link](https://github.com/saorsa-labs/saorsa-core/blob/9bcd4c85f181565d6982e5c6b5f7d0919b0484a7/src/transport_handle.rs#L1302-L1313)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`drain_*` methods block indefinitely when the driver holds the shared mutex**

   `drain_direct_address_promoted()` and `drain_self_address_updated()` share the same `tokio::sync::Mutex<mpsc::Receiver>` as their `recv_*` counterparts. When the reachability driver has `recv_direct_address_promoted()` inside a `select!`, the `MutexGuard` is held across the `rx.recv().await` suspension point. Any concurrent call to `drain_direct_address_promoted()` will block on `.lock().await` indefinitely — until a promotion event actually arrives and the driver releases the guard — despite the method using `try_recv()` internally and appearing to be a quick non-blocking poll. This contradicts the API contract implied by the "drain" name and can stall callers unexpectedly.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/transport_handle.rs
   Line: 1302-1313

   Comment:
   **`drain_*` methods block indefinitely when the driver holds the shared mutex**

   `drain_direct_address_promoted()` and `drain_self_address_updated()` share the same `tokio::sync::Mutex<mpsc::Receiver>` as their `recv_*` counterparts. When the reachability driver has `recv_direct_address_promoted()` inside a `select!`, the `MutexGuard` is held across the `rx.recv().await` suspension point. Any concurrent call to `drain_direct_address_promoted()` will block on `.lock().await` indefinitely — until a promotion event actually arrives and the driver releases the guard — despite the method using `try_recv()` internally and appearing to be a quick non-blocking poll. This contradicts the API contract implied by the "drain" name and can stall callers unexpectedly.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/transport/saorsa_transport_adapter.rs`, line 636-653 ([link](https://github.com/saorsa-labs/saorsa-core/blob/9bcd4c85f181565d6982e5c6b5f7d0919b0484a7/src/transport/saorsa_transport_adapter.rs#L636-L653)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Early `return` after first endpoint drops dual-stack peer ID registration**

   The new logic registers the peer ID only with the first endpoint that reports `has_active_connection`, then immediately returns. Previously, the peer ID was registered with **both** the v6 and v4 endpoints (plus the IPv4-mapped alternate form), which ensured PUNCH_ME_NOW relay messages arriving on either stack could locate the peer.

   On a dual-stack node: if a peer connects via IPv4 (registered with v4 endpoint only), a relay coordination message arriving on the v6 endpoint will fail to find the peer ID mapping, breaking PUNCH_ME_NOW routing for that peer. The race window where `has_active_connection` returns false on both stacks (connection just established) would silently swallow the registration entirely.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/transport/saorsa_transport_adapter.rs
   Line: 636-653

   Comment:
   **Early `return` after first endpoint drops dual-stack peer ID registration**

   The new logic registers the peer ID only with the first endpoint that reports `has_active_connection`, then immediately returns. Previously, the peer ID was registered with **both** the v6 and v4 endpoints (plus the IPv4-mapped alternate form), which ensured PUNCH_ME_NOW relay messages arriving on either stack could locate the peer.

   On a dual-stack node: if a peer connects via IPv4 (registered with v4 endpoint only), a relay coordination message arriving on the v6 endpoint will fail to find the peer ID mapping, breaking PUNCH_ME_NOW routing for that peer. The race window where `has_active_connection` returns false on both stacks (connection just established) would silently swallow the registration entirely.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `src/network.rs`, line 1622-1636 ([link](https://github.com/saorsa-labs/saorsa-core/blob/9bcd4c85f181565d6982e5c6b5f7d0919b0484a7/src/network.rs#L1622-L1636)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unconditional DHT lookup on every reconnect, even with caller-provided addresses**

   The old `resolve_dial_address` short-circuited immediately when caller-provided or saved addresses were available. The new version always fires `peer_addresses_for_dial_typed()` upfront to populate `dht_typed` for `lookup_kind`. For most reconnect flows (which have caller- or saved-addresses), this is an unnecessary async DHT round-trip on the critical reconnect path. Consider lazily fetching DHT results only when caller/saved addresses are exhausted, and defaulting the address type to `AddressType::Unverified` for non-DHT sources without querying the DHT first.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/network.rs
   Line: 1622-1636

   Comment:
   **Unconditional DHT lookup on every reconnect, even with caller-provided addresses**

   The old `resolve_dial_address` short-circuited immediately when caller-provided or saved addresses were available. The new version always fires `peer_addresses_for_dial_typed()` upfront to populate `dht_typed` for `lookup_kind`. For most reconnect flows (which have caller- or saved-addresses), this is an unnecessary async DHT round-trip on the critical reconnect path. Consider lazily fetching DHT results only when caller/saved addresses are exhausted, and defaulting the address type to `AddressType::Unverified` for non-DHT sources without querying the DHT first.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/transport_handle.rs:1302-1313
**`drain_*` methods block indefinitely when the driver holds the shared mutex**

`drain_direct_address_promoted()` and `drain_self_address_updated()` share the same `tokio::sync::Mutex<mpsc::Receiver>` as their `recv_*` counterparts. When the reachability driver has `recv_direct_address_promoted()` inside a `select!`, the `MutexGuard` is held across the `rx.recv().await` suspension point. Any concurrent call to `drain_direct_address_promoted()` will block on `.lock().await` indefinitely — until a promotion event actually arrives and the driver releases the guard — despite the method using `try_recv()` internally and appearing to be a quick non-blocking poll. This contradicts the API contract implied by the "drain" name and can stall callers unexpectedly.

### Issue 2 of 3
src/transport/saorsa_transport_adapter.rs:636-653
**Early `return` after first endpoint drops dual-stack peer ID registration**

The new logic registers the peer ID only with the first endpoint that reports `has_active_connection`, then immediately returns. Previously, the peer ID was registered with **both** the v6 and v4 endpoints (plus the IPv4-mapped alternate form), which ensured PUNCH_ME_NOW relay messages arriving on either stack could locate the peer.

On a dual-stack node: if a peer connects via IPv4 (registered with v4 endpoint only), a relay coordination message arriving on the v6 endpoint will fail to find the peer ID mapping, breaking PUNCH_ME_NOW routing for that peer. The race window where `has_active_connection` returns false on both stacks (connection just established) would silently swallow the registration entirely.

### Issue 3 of 3
src/network.rs:1622-1636
**Unconditional DHT lookup on every reconnect, even with caller-provided addresses**

The old `resolve_dial_address` short-circuited immediately when caller-provided or saved addresses were available. The new version always fires `peer_addresses_for_dial_typed()` upfront to populate `dht_typed` for `lookup_kind`. For most reconnect flows (which have caller- or saved-addresses), this is an unnecessary async DHT round-trip on the critical reconnect path. Consider lazily fetching DHT results only when caller/saved addresses are exhausted, and defaulting the address type to `AddressType::Unverified` for non-DHT sources without querying the DHT first.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(reachability): dedup typed self add..."](https://github.com/saorsa-labs/saorsa-core/commit/9bcd4c85f181565d6982e5c6b5f7d0919b0484a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30695790)</sub>

<!-- /greptile_comment -->