### PR TITLE
feat(transport): add delivery-ack send variant through P2PNode and TransportHandle

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -1505,6 +1505,31 @@ impl P2PNode {
         data: Vec<u8>,
         addrs: &[MultiAddr],
     ) -> Result<()> {
+        self.send_message_inner(peer_id, protocol, data, addrs, false)
+            .await
+    }
+
+    /// Send a message to an authenticated peer and wait until QUIC confirms
+    /// the remote endpoint received the full stream before returning.
+    pub async fn send_message_with_delivery_ack(
+        &self,
+        peer_id: &PeerId,
+        protocol: &str,
+        data: Vec<u8>,
+        addrs: &[MultiAddr],
+    ) -> Result<()> {
+        self.send_message_inner(peer_id, protocol, data, addrs, true)
+            .await
+    }
+
+    async fn send_message_inner(
+        &self,
+        peer_id: &PeerId,
+        protocol: &str,
+        data: Vec<u8>,
+        addrs: &[MultiAddr],
+        wait_for_delivery_ack: bool,
+    ) -> Result<()> {
         // Snapshot channel IDs before the send attempt — transport.send_message
         // prunes dead channels from bookkeeping but does NOT close the
         // underlying QUIC connection.  We need the original IDs for
@@ -1519,11 +1544,21 @@ impl P2PNode {
 
             // Another sender may have connected while we waited for the lock.
             if self.transport.is_peer_connected(peer_id).await {
-                return self.transport.send_message(peer_id, protocol, data).await;
+                return self
+                    .transport_send_message(peer_id, protocol, data, wait_for_delivery_ack)
+                    .await;
             }
 
             return self
-                .reconnect_and_send(peer_id, protocol, data, addrs, &[], &[])
+                .reconnect_and_send(
+                    peer_id,
+                    protocol,
+                    data,
+                    addrs,
+                    &[],
+                    &[],
+                    wait_for_delivery_ack,
+                )
                 .await;
         }
 
@@ -1541,7 +1576,10 @@ impl P2PNode {
         let retry_data = data.clone();
 
         // Fast path: try existing connection.
-        match self.transport.send_message(peer_id, protocol, data).await {
+        let send_result = self
+            .transport_send_message(peer_id, protocol, data, wait_for_delivery_ack)
+            .await;
+        match send_result {
             Ok(()) => return Ok(()),
             Err(e) => {
                 if !e.is_stale_channel_send_failure() {
@@ -1575,8 +1613,7 @@ impl P2PNode {
                 self.transport.disconnect_channel(channel_id).await;
             }
             return self
-                .transport
-                .send_message(peer_id, protocol, retry_data)
+                .transport_send_message(peer_id, protocol, retry_data, wait_for_delivery_ack)
                 .await;
         }
 
@@ -1587,6 +1624,7 @@ impl P2PNode {
             addrs,
             &saved_addrs,
             &existing_channels,
+            wait_for_delivery_ack,
         )
         .await
     }
@@ -1600,6 +1638,7 @@ impl P2PNode {
         addrs: &[MultiAddr],
         saved_addrs: &[MultiAddr],
         stale_channels: &[String],
+        wait_for_delivery_ack: bool,
     ) -> Result<()> {
         // Resolve a dial address: caller-provided > saved > DHT.
         let (address, kind) = self
@@ -1646,7 +1685,24 @@ impl P2PNode {
         }
 
         // Send on the fresh connection.
-        self.transport.send_message(peer_id, protocol, data).await
+        self.transport_send_message(peer_id, protocol, data, wait_for_delivery_ack)
+            .await
+    }
+
+    async fn transport_send_message(
+        &self,
+        peer_id: &PeerId,
+        protocol: &str,
+        data: Vec<u8>,
+        wait_for_delivery_ack: bool,
+    ) -> Result<()> {
+        if wait_for_delivery_ack {
+            self.transport
+                .send_message_with_delivery_ack(peer_id, protocol, data)
+                .await
+        } else {
+            self.transport.send_message(peer_id, protocol, data).await
+        }
     }
 
     /// Resolve a dial address for `peer_id`, preferring caller-provided

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -597,6 +597,30 @@ impl P2PNetworkNode<P2pLinkTransport> {
             .with_context(|| format!("QUIC send to {} ({} bytes) failed", addr, data.len()))
     }
 
+    /// Send data to a peer and wait for QUIC to acknowledge peer receipt of the full stream.
+    pub async fn send_to_peer_optimized_with_delivery_ack(
+        &self,
+        addr: &SocketAddr,
+        data: &[u8],
+    ) -> Result<()> {
+        trace!(
+            "[QUIC SEND] endpoint().send_with_delivery_ack() to {} ({} bytes)",
+            addr,
+            data.len()
+        );
+        self.transport
+            .endpoint()
+            .send_with_delivery_ack(addr, data)
+            .await
+            .with_context(|| {
+                format!(
+                    "QUIC delivery-ack send to {} ({} bytes) failed",
+                    addr,
+                    data.len()
+                )
+            })
+    }
+
     /// Disconnect a specific peer, closing the underlying QUIC connection.
     ///
     /// Calls `P2pEndpoint::disconnect()` to tear down the QUIC connection
@@ -1907,6 +1931,43 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         // correctly-configured dual-stack node but guarded for safety.
         Err(anyhow::anyhow!(
             "send_to_peer_optimized to {}: no compatible stack bound (v4={}, v6={})",
+            addr,
+            self.v4.is_some(),
+            self.v6.is_some()
+        ))
+    }
+
+    /// Send to peer using P2pEndpoint's optimized send method, waiting until
+    /// QUIC confirms the peer received the full stream.
+    pub async fn send_to_peer_optimized_with_delivery_ack(
+        &self,
+        addr: &SocketAddr,
+        data: &[u8],
+    ) -> Result<()> {
+        if addr.is_ipv4()
+            && let Some(v4) = &self.v4
+        {
+            return v4
+                .send_to_peer_optimized_with_delivery_ack(addr, data)
+                .await
+                .map_err(|e| e.context(format!("IPv4 delivery-ack send to {} failed", addr)));
+        }
+
+        if let Some(v6) = &self.v6 {
+            let wire_addr = self.to_mapped_if_needed(addr);
+            return v6
+                .send_to_peer_optimized_with_delivery_ack(&wire_addr, data)
+                .await
+                .map_err(|e| {
+                    e.context(format!(
+                        "IPv6 delivery-ack send to {} (wire {}) failed",
+                        addr, wire_addr
+                    ))
+                });
+        }
+
+        Err(anyhow::anyhow!(
+            "send_to_peer_optimized_with_delivery_ack to {}: no compatible stack bound (v4={}, v6={})",
             addr,
             self.v4.is_some(),
             self.v6.is_some()

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -145,6 +145,8 @@ fn classify_transport_send_stage(stage: saorsa_transport::SendFailureStage) -> S
         }
         saorsa_transport::SendFailureStage::Write => SendFailureKind::StreamWrite,
         saorsa_transport::SendFailureStage::Finish => SendFailureKind::StreamFinish,
+        saorsa_transport::SendFailureStage::DeliveryAck
+        | saorsa_transport::SendFailureStage::DeliveryAckTimeout => SendFailureKind::StreamFinish,
     }
 }
 
@@ -1502,6 +1504,28 @@ impl TransportHandle {
         protocol: &str,
         data: Vec<u8>,
     ) -> Result<()> {
+        self.send_message_inner(peer_id, protocol, data, false)
+            .await
+    }
+
+    /// Send a message to an authenticated peer, waiting until QUIC confirms
+    /// the remote endpoint received the full stream before returning.
+    pub async fn send_message_with_delivery_ack(
+        &self,
+        peer_id: &PeerId,
+        protocol: &str,
+        data: Vec<u8>,
+    ) -> Result<()> {
+        self.send_message_inner(peer_id, protocol, data, true).await
+    }
+
+    async fn send_message_inner(
+        &self,
+        peer_id: &PeerId,
+        protocol: &str,
+        data: Vec<u8>,
+        wait_for_delivery_ack: bool,
+    ) -> Result<()> {
         let peer_hex = peer_id.to_hex();
         let channels: Vec<String> = self
             .peer_to_channel
@@ -1518,7 +1542,7 @@ impl TransportHandle {
         let mut last_err = None;
         for channel_id in &channels {
             match self
-                .send_on_channel(channel_id, protocol, data.clone())
+                .send_on_channel_inner(channel_id, protocol, data.clone(), wait_for_delivery_ack)
                 .await
             {
                 Ok(()) => return Ok(()),
@@ -1562,6 +1586,17 @@ impl TransportHandle {
         channel_id: &str,
         protocol: &str,
         data: Vec<u8>,
+    ) -> Result<()> {
+        self.send_on_channel_inner(channel_id, protocol, data, false)
+            .await
+    }
+
+    async fn send_on_channel_inner(
+        &self,
+        channel_id: &str,
+        protocol: &str,
+        data: Vec<u8>,
+        wait_for_delivery_ack: bool,
     ) -> Result<()> {
         debug!(
             "Sending message to channel {} on protocol {}",
@@ -1616,11 +1651,12 @@ impl TransportHandle {
         let raw_data_len = data.len();
         let message_data = self.create_protocol_message(protocol, data)?;
         debug!(
-            "Sending {} bytes to channel {} on protocol {} (raw data: {} bytes)",
+            "Sending {} bytes to channel {} on protocol {} (raw data: {} bytes, wait_for_delivery_ack={})",
             message_data.len(),
             channel_id,
             protocol,
-            raw_data_len
+            raw_data_len,
+            wait_for_delivery_ack
         );
 
         let addr: SocketAddr = channel_id.parse().map_err(|e: std::net::AddrParseError| {
@@ -1628,17 +1664,22 @@ impl TransportHandle {
                 format!("Invalid channel ID address: {e}").into(),
             ))
         })?;
-        let result = self
-            .dual_node
-            .send_to_peer_optimized(&addr, &message_data)
-            .await
-            .map_err(|e| {
-                let kind = classify_send_error(&e);
-                P2PError::Transport(TransportError::SendFailed {
-                    kind,
-                    reason: e.to_string().into(),
-                })
-            });
+        let send_result = if wait_for_delivery_ack {
+            self.dual_node
+                .send_to_peer_optimized_with_delivery_ack(&addr, &message_data)
+                .await
+        } else {
+            self.dual_node
+                .send_to_peer_optimized(&addr, &message_data)
+                .await
+        };
+        let result = send_result.map_err(|e| {
+            let kind = classify_send_error(&e);
+            P2PError::Transport(TransportError::SendFailed {
+                kind,
+                reason: e.to_string().into(),
+            })
+        });
 
         if result.is_ok() {
             debug!(


### PR DESCRIPTION
## Summary
- Adds `send_message_with_delivery_ack` variants on `P2PNode`, `TransportHandle`, and the `saorsa-transport` adapter that mirror the existing `send_message` paths.
- Lets callers wait for QUIC to confirm the peer received the full stream before returning, instead of returning as soon as the transport accepts the bytes.
- Maps the new `DeliveryAck` and `DeliveryAckTimeout` `SendFailureStage` variants to `SendFailureKind::StreamFinish` so existing failure plumbing keeps working.

## Test plan
- [ ] `cargo build --all-features`
- [ ] `cargo test --lib`
- [ ] `cargo clippy -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `send_message_with_delivery_ack` variants across `P2PNode`, `TransportHandle`, and the `saorsa-transport` adapter, mirroring the existing `send_message` paths with a boolean flag that routes sends through `endpoint.send_with_delivery_ack` instead of the fire-and-forget path.

- **`P2PNode` and `TransportHandle`** are refactored into `_inner` functions with a `wait_for_delivery_ack: bool` parameter, keeping all retry, reconnect, and stale-channel logic working for both variants.
- **`DualStackNetworkNode`** gets a `send_to_peer_optimized_with_delivery_ack` method that mirrors the existing IPv4/IPv6 routing logic.
- **`classify_transport_send_stage`** maps `DeliveryAck` and `DeliveryAckTimeout` to `SendFailureKind::StreamFinish`, which preserves existing failure plumbing but collapses two semantically distinct outcomes into one kind, causing channel removal even when only the delivery confirmation timed out (not the connection itself).

<h3>Confidence Score: 4/5</h3>

The change is safe to merge with a known trade-off in how delivery-ack timeouts are surfaced.

The flag-threading approach is clean and the reconnect/retry paths all correctly propagate `wait_for_delivery_ack`. The one area worth watching is the error-classification decision: mapping `DeliveryAckTimeout` to `StreamFinish` means a timeout-on-an-otherwise-healthy-connection will remove the channel from bookkeeping and potentially emit a spurious `PeerDisconnected` event. The underlying QUIC connection stays alive, so the next send will either re-resolve bookkeeping or trigger an unnecessary reconnect attempt.

src/transport_handle.rs — specifically the `classify_transport_send_stage` function and the non-stale branch in `send_on_channel_inner` that removes channels on any `StreamFinish`-classified error.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/transport_handle.rs | Refactors `send_message` and `send_on_channel` into `_inner` variants with a `wait_for_delivery_ack` bool; maps `DeliveryAck`/`DeliveryAckTimeout` to `StreamFinish` in the failure classifier — collapsing two semantically distinct failure causes and causing channel removal even when the QUIC connection is still alive. |
| src/network.rs | Adds `send_message_with_delivery_ack` on `P2PNode` by threading a `wait_for_delivery_ack` bool through `send_message_inner`, `reconnect_and_send`, and the new `transport_send_message` helper; reconnect and retry paths correctly propagate the flag. |
| src/transport/saorsa_transport_adapter.rs | Adds `send_to_peer_optimized_with_delivery_ack` on both `P2PNetworkNode` and `DualStackNetworkNode` following the same IPv4/IPv6 routing pattern as the existing optimized send; missing the routing-rationale doc comment present on the parallel method. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant P2PNode
    participant TransportHandle
    participant DualStackNetworkNode
    participant QUIC as QUIC Endpoint

    Caller->>P2PNode: send_message_with_delivery_ack(peer, protocol, data, addrs)
    P2PNode->>P2PNode: send_message_inner(wait_for_delivery_ack=true)

    alt Existing connection
        P2PNode->>TransportHandle: send_message_with_delivery_ack(peer, protocol, data)
        TransportHandle->>TransportHandle: send_on_channel_inner(channel, protocol, data, true)
        TransportHandle->>DualStackNetworkNode: send_to_peer_optimized_with_delivery_ack(addr, data)
        DualStackNetworkNode->>QUIC: endpoint.send_with_delivery_ack(addr, data)
        QUIC-->>DualStackNetworkNode: Ok / DeliveryAckTimeout
        DualStackNetworkNode-->>TransportHandle: Result
        TransportHandle-->>P2PNode: Result
        P2PNode-->>Caller: Result
    else No existing connection or stale
        P2PNode->>P2PNode: reconnect_and_send(wait_for_delivery_ack=true)
        P2PNode->>TransportHandle: send_message_with_delivery_ack(peer, protocol, data)
        TransportHandle->>DualStackNetworkNode: send_to_peer_optimized_with_delivery_ack(addr, data)
        DualStackNetworkNode->>QUIC: endpoint.send_with_delivery_ack(addr, data)
        QUIC-->>DualStackNetworkNode: Ok / DeliveryAckTimeout
        DualStackNetworkNode-->>TransportHandle: Result
        TransportHandle-->>P2PNode: Result
        P2PNode-->>Caller: Result
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/transport_handle.rs:148-149
**`DeliveryAckTimeout` collapses into `StreamFinish`, causing premature channel removal**

`StreamFinish` is treated as a non-stale active-send failure in `send_on_channel_inner`, so a `DeliveryAckTimeout` triggers `remove_channel` on the channel — even though the QUIC connection is still alive (the stream was fully written; only the high-level acknowledgement timed out). This means `PeerDisconnected` events can fire for peers that remain connected at the transport layer, and the next send will need to re-establish bookkeeping (or trigger a full reconnect via `P2PNode`). Adding a dedicated `SendFailureKind::DeliveryAckTimeout` variant that `is_stale_channel()` returns `false` for (same as now) but that the send-failure branch in `send_on_channel_inner` treats as a non-channel-removing transient failure would prevent the spurious disconnect. The PR description acknowledges the collapsed mapping as intentional, but the channel-removal side-effect is worth reconsidering.

### Issue 2 of 2
src/transport/saorsa_transport_adapter.rs:1940-1975
**Missing routing-rationale doc comment on `send_to_peer_optimized_with_delivery_ack`**

The existing `send_to_peer_optimized` carries a detailed doc comment explaining why cross-address-family fallback is intentionally NOT attempted (lines 1890–1904). The new `send_to_peer_optimized_with_delivery_ack` applies the identical routing logic but ships without that explanation, making it harder for future maintainers to understand why there's no v4→v6 fallback here either. Consider copying the routing rationale from `send_to_peer_optimized`'s doc block.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(transport): add delivery-ack send v..."](https://github.com/saorsa-labs/saorsa-core/commit/c6013f44f5ef0d472b02d3fcc4cfdefdbc257f5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30864118)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->