### PR TITLE
feat(adaptive): downscore peers via P2PNode::report_application_failure

### DIFF
--- a/src/adaptive/dht.rs
+++ b/src/adaptive/dht.rs
@@ -29,12 +29,18 @@ use crate::error::P2pResult as Result;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-/// Default trust score threshold below which a peer is eligible for swap-out
-const DEFAULT_SWAP_THRESHOLD: f64 = 0.35;
+/// Default trust score threshold below which a peer is eligible for swap-out.
+///
+/// Exposed `pub(crate)` so sibling tests in `adaptive::trust` can assert
+/// against the canonical value rather than duplicating the literal.
+pub(crate) const DEFAULT_SWAP_THRESHOLD: f64 = 0.35;
 
 /// Maximum weight multiplier per single consumer-reported event.
 /// Caps the influence of any single consumer event on the EMA.
-const MAX_CONSUMER_WEIGHT: f64 = 5.0;
+///
+/// Exposed `pub(crate)` so sibling tests can drive the public
+/// `AdaptiveDHT::report_trust_event` path with the documented cap.
+pub(crate) const MAX_CONSUMER_WEIGHT: f64 = 5.0;
 
 /// Configuration for the AdaptiveDHT layer
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,6 +116,34 @@ impl TrustEvent {
             | TrustEvent::ApplicationFailure(_) => NodeStatisticsUpdate::FailedResponse,
         }
     }
+
+    /// Pure function that mirrors the clamping + zero-weight gate applied by
+    /// [`AdaptiveDHT::report_trust_event`].
+    ///
+    /// Returns `Some((stats_update, effective_weight))` when the event would
+    /// be applied to the trust engine, or `None` when the consumer-reported
+    /// weight is non-positive / non-finite (silent no-op). For internal
+    /// events (`ConnectionFailed`, `ConnectionTimeout`) the effective weight
+    /// is `1.0`. For consumer events the weight is clamped to
+    /// [`MAX_CONSUMER_WEIGHT`].
+    ///
+    /// Exists as a separate function so tests can assert the clamping/gating
+    /// behaviour of the public entry point without constructing the full
+    /// [`AdaptiveDHT`] (which requires a real `TransportHandle`).
+    pub(crate) fn clamped_update(self) -> Option<(NodeStatisticsUpdate, f64)> {
+        match self {
+            TrustEvent::ApplicationSuccess(weight) | TrustEvent::ApplicationFailure(weight) => {
+                if weight.is_finite() && weight > 0.0 {
+                    Some((self.to_stats_update(), weight.min(MAX_CONSUMER_WEIGHT)))
+                } else {
+                    None
+                }
+            }
+            TrustEvent::ConnectionFailed | TrustEvent::ConnectionTimeout => {
+                Some((self.to_stats_update(), 1.0))
+            }
+        }
+    }
 }
 
 /// AdaptiveDHT — the trust boundary for all DHT operations.
@@ -178,22 +212,9 @@ impl AdaptiveDHT {
     /// evicted — they remain in the routing table until a better candidate
     /// arrives and triggers a swap-out.
     pub async fn report_trust_event(&self, peer_id: &PeerId, event: TrustEvent) {
-        match event {
-            TrustEvent::ApplicationSuccess(weight) | TrustEvent::ApplicationFailure(weight) => {
-                if weight > 0.0 {
-                    let clamped_weight = weight.min(MAX_CONSUMER_WEIGHT);
-                    self.trust_engine.update_node_stats_weighted(
-                        peer_id,
-                        event.to_stats_update(),
-                        clamped_weight,
-                    );
-                }
-            }
-            _ => {
-                // Internal events: unit weight
-                self.trust_engine
-                    .update_node_stats(peer_id, event.to_stats_update());
-            }
+        if let Some((stats_update, weight)) = event.clamped_update() {
+            self.trust_engine
+                .update_node_stats_weighted(peer_id, stats_update, weight);
         }
     }
 

--- a/src/adaptive/trust.rs
+++ b/src/adaptive/trust.rs
@@ -810,4 +810,106 @@ mod tests {
             "after {success_rounds} weight-3 successes, score {restored_score} should be >= {TRUST_PROTECTION_THRESHOLD}"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Bad-binding eviction: ApplicationFailure(MAX_CONSUMER_WEIGHT) is
+    // sufficient to push a peer out of the lookup-eligible band in one shot.
+    //
+    // The production swap-out threshold lives in `AdaptiveDhtConfig`
+    // (`DEFAULT_SWAP_THRESHOLD = 0.35`). plan-1-bad-node-eviction also calls
+    // out the looser sanity bound of 0.4. We assert against both so a future
+    // tweak to either knob still flags this test.
+    // -----------------------------------------------------------------------
+
+    /// Production swap-out threshold (mirrors `adaptive::dht::DEFAULT_SWAP_THRESHOLD`).
+    const SWAP_THRESHOLD: f64 = 0.35;
+
+    /// Looser sanity bound from plan-1-bad-node-eviction.md.
+    const PLAN_LOOKUP_SKIP_BOUND: f64 = 0.4;
+
+    /// A1: A single `FailedResponse` with weight 5.0 (the
+    /// `MAX_CONSUMER_WEIGHT` cap used for bad-binding reports) drops a peer
+    /// from neutral 0.5 to below 0.4 — proving one bad-binding detection is
+    /// enough to evict the offender from lookup-eligible candidates.
+    #[tokio::test]
+    async fn bad_binding_event_drops_peer_below_lookup_threshold() {
+        let engine = TrustEngine::new();
+        let peer = PeerId::random();
+
+        // ApplicationFailure(5.0) → FailedResponse with weight 5.0 after the
+        // public-API clamp.
+        engine.update_node_stats_weighted(&peer, NodeStatisticsUpdate::FailedResponse, 5.0);
+
+        let score = engine.score(&peer);
+        assert!(
+            score < PLAN_LOOKUP_SKIP_BOUND,
+            "one weight-5 failure should drop score below {PLAN_LOOKUP_SKIP_BOUND}, got {score}"
+        );
+        assert!(
+            score < SWAP_THRESHOLD,
+            "score {score} should also be below the production swap threshold {SWAP_THRESHOLD}"
+        );
+        assert!(
+            score >= MIN_TRUST_SCORE,
+            "score {score} must remain inside the legal range"
+        );
+    }
+
+    /// A2: A peer downscored by one bad-binding event recovers above the
+    /// swap threshold after ~1 day of decay. Eviction is *temporary*: a
+    /// peer that fixes its config re-enters the lookup pool naturally.
+    #[tokio::test]
+    async fn bad_binding_decays_back_above_threshold_after_2h() {
+        let engine = TrustEngine::new();
+        let peer = PeerId::random();
+
+        engine.update_node_stats_weighted(&peer, NodeStatisticsUpdate::FailedResponse, 5.0);
+        let after_failure = engine.score(&peer);
+        assert!(
+            after_failure < SWAP_THRESHOLD,
+            "post-failure score {after_failure} should be below {SWAP_THRESHOLD}"
+        );
+
+        // The decay tuning (DECAY_LAMBDA) is sized so that the worst score
+        // (0.0) recovers above the swap threshold in ~1 day. From ~0.26 we
+        // need substantially less; assert the score has materially recovered
+        // after a 2-hour idle window without claiming it is fully back.
+        let two_hours = std::time::Duration::from_secs(2 * 3600);
+        engine.simulate_elapsed(&peer, two_hours).await;
+        let after_two_hours = engine.score(&peer);
+        assert!(
+            after_two_hours > after_failure,
+            "score should decay toward neutral after 2h: {after_failure} -> {after_two_hours}"
+        );
+
+        // Full recovery (back above the swap threshold) should hold within
+        // a day of idle time, matching the decay-recovery contract.
+        let one_day = std::time::Duration::from_secs(24 * 3600);
+        engine.simulate_elapsed(&peer, one_day).await;
+        let after_one_day = engine.score(&peer);
+        assert!(
+            after_one_day >= SWAP_THRESHOLD,
+            "after ~1 day of decay the score {after_one_day} should be back above the swap threshold {SWAP_THRESHOLD}"
+        );
+    }
+
+    /// A3: 10 consecutive `FailedResponse(5.0)` events keep the score
+    /// inside [MIN_TRUST_SCORE, swap_threshold). Confirms the EMA arithmetic
+    /// does not produce negative or NaN scores under repeated punishment.
+    #[tokio::test]
+    async fn multiple_bad_bindings_dont_compound_pathologically() {
+        let engine = TrustEngine::new();
+        let peer = PeerId::random();
+
+        for _ in 0..10 {
+            engine.update_node_stats_weighted(&peer, NodeStatisticsUpdate::FailedResponse, 5.0);
+        }
+
+        let score = engine.score(&peer);
+        assert!(score.is_finite(), "score {score} must remain finite");
+        assert!(
+            (MIN_TRUST_SCORE..PLAN_LOOKUP_SKIP_BOUND).contains(&score),
+            "after 10 weight-5 failures, score {score} must lie in [{MIN_TRUST_SCORE}, {PLAN_LOOKUP_SKIP_BOUND})"
+        );
+    }
 }

--- a/src/adaptive/trust.rs
+++ b/src/adaptive/trust.rs
@@ -816,38 +816,58 @@ mod tests {
     // sufficient to push a peer out of the lookup-eligible band in one shot.
     //
     // The production swap-out threshold lives in `AdaptiveDhtConfig`
-    // (`DEFAULT_SWAP_THRESHOLD = 0.35`). plan-1-bad-node-eviction also calls
-    // out the looser sanity bound of 0.4. We assert against both so a future
-    // tweak to either knob still flags this test.
+    // (`adaptive::dht::DEFAULT_SWAP_THRESHOLD = 0.35`). plan-1-bad-node-eviction
+    // also calls out the looser sanity bound of 0.4. We assert against both
+    // so a future tweak to either knob still flags this test.
     // -----------------------------------------------------------------------
 
-    /// Production swap-out threshold (mirrors `adaptive::dht::DEFAULT_SWAP_THRESHOLD`).
-    const SWAP_THRESHOLD: f64 = 0.35;
+    use crate::adaptive::TrustEvent;
+    use crate::adaptive::dht::{DEFAULT_SWAP_THRESHOLD, MAX_CONSUMER_WEIGHT};
 
     /// Looser sanity bound from plan-1-bad-node-eviction.md.
     const PLAN_LOOKUP_SKIP_BOUND: f64 = 0.4;
 
-    /// A1: A single `FailedResponse` with weight 5.0 (the
-    /// `MAX_CONSUMER_WEIGHT` cap used for bad-binding reports) drops a peer
-    /// from neutral 0.5 to below 0.4 — proving one bad-binding detection is
-    /// enough to evict the offender from lookup-eligible candidates.
+    /// Drive a `TrustEvent` through the same `clamped_update` gate that
+    /// `AdaptiveDHT::report_trust_event` uses, so tests exercise the
+    /// public-API clamping/zero-weight-guard rather than the raw
+    /// `TrustEngine::update_node_stats_weighted` entry. Mirrors the body of
+    /// `AdaptiveDHT::report_trust_event` exactly; both call sites share
+    /// `TrustEvent::clamped_update` as the single source of truth for the
+    /// gate.
+    fn report_via_public_api(engine: &TrustEngine, peer: &PeerId, event: TrustEvent) {
+        if let Some((stats_update, weight)) = event.clamped_update() {
+            engine.update_node_stats_weighted(peer, stats_update, weight);
+        }
+    }
+
+    /// A1: A single `ApplicationFailure(MAX_CONSUMER_WEIGHT)` drops a peer
+    /// from neutral 0.5 to below the production swap threshold (and the
+    /// looser 0.4 plan target) in one shot. Proves one bad-binding
+    /// detection is enough to evict the offender from lookup-eligible
+    /// candidates.
+    ///
+    /// Drives the event through `report_via_public_api` so the
+    /// `clamped_update` gate (clamping + zero-weight guard) is on the test
+    /// path, not just `TrustEngine`'s raw write.
     #[tokio::test]
     async fn bad_binding_event_drops_peer_below_lookup_threshold() {
         let engine = TrustEngine::new();
         let peer = PeerId::random();
 
-        // ApplicationFailure(5.0) → FailedResponse with weight 5.0 after the
-        // public-API clamp.
-        engine.update_node_stats_weighted(&peer, NodeStatisticsUpdate::FailedResponse, 5.0);
+        report_via_public_api(
+            &engine,
+            &peer,
+            TrustEvent::ApplicationFailure(MAX_CONSUMER_WEIGHT),
+        );
 
         let score = engine.score(&peer);
         assert!(
             score < PLAN_LOOKUP_SKIP_BOUND,
-            "one weight-5 failure should drop score below {PLAN_LOOKUP_SKIP_BOUND}, got {score}"
+            "one weight-{MAX_CONSUMER_WEIGHT} failure should drop score below {PLAN_LOOKUP_SKIP_BOUND}, got {score}"
         );
         assert!(
-            score < SWAP_THRESHOLD,
-            "score {score} should also be below the production swap threshold {SWAP_THRESHOLD}"
+            score < DEFAULT_SWAP_THRESHOLD,
+            "score {score} should also be below the production swap threshold {DEFAULT_SWAP_THRESHOLD}"
         );
         assert!(
             score >= MIN_TRUST_SCORE,
@@ -858,43 +878,43 @@ mod tests {
     /// A2: A peer downscored by one bad-binding event recovers above the
     /// swap threshold after ~1 day of decay. Eviction is *temporary*: a
     /// peer that fixes its config re-enters the lookup pool naturally.
+    ///
+    /// `DECAY_LAMBDA` is tuned so the worst score (0.0) recovers above the
+    /// swap threshold in ~1 day; from ~0.26 we need less. We assert the
+    /// score has crossed back above the threshold within a single 24h
+    /// elapsed window since the failure, matching the contract documented
+    /// on `DECAY_LAMBDA`.
     #[tokio::test]
-    async fn bad_binding_decays_back_above_threshold_after_2h() {
+    async fn bad_binding_decays_back_above_threshold_within_one_day() {
         let engine = TrustEngine::new();
         let peer = PeerId::random();
 
-        engine.update_node_stats_weighted(&peer, NodeStatisticsUpdate::FailedResponse, 5.0);
+        report_via_public_api(
+            &engine,
+            &peer,
+            TrustEvent::ApplicationFailure(MAX_CONSUMER_WEIGHT),
+        );
         let after_failure = engine.score(&peer);
         assert!(
-            after_failure < SWAP_THRESHOLD,
-            "post-failure score {after_failure} should be below {SWAP_THRESHOLD}"
+            after_failure < DEFAULT_SWAP_THRESHOLD,
+            "post-failure score {after_failure} should be below {DEFAULT_SWAP_THRESHOLD}"
         );
 
-        // The decay tuning (DECAY_LAMBDA) is sized so that the worst score
-        // (0.0) recovers above the swap threshold in ~1 day. From ~0.26 we
-        // need substantially less; assert the score has materially recovered
-        // after a 2-hour idle window without claiming it is fully back.
-        let two_hours = std::time::Duration::from_secs(2 * 3600);
-        engine.simulate_elapsed(&peer, two_hours).await;
-        let after_two_hours = engine.score(&peer);
-        assert!(
-            after_two_hours > after_failure,
-            "score should decay toward neutral after 2h: {after_failure} -> {after_two_hours}"
-        );
-
-        // Full recovery (back above the swap threshold) should hold within
-        // a day of idle time, matching the decay-recovery contract.
         let one_day = std::time::Duration::from_secs(24 * 3600);
         engine.simulate_elapsed(&peer, one_day).await;
         let after_one_day = engine.score(&peer);
         assert!(
-            after_one_day >= SWAP_THRESHOLD,
-            "after ~1 day of decay the score {after_one_day} should be back above the swap threshold {SWAP_THRESHOLD}"
+            after_one_day > after_failure,
+            "score should decay toward neutral over 24h: {after_failure} -> {after_one_day}"
+        );
+        assert!(
+            after_one_day >= DEFAULT_SWAP_THRESHOLD,
+            "after 24h of decay the score {after_one_day} should be back above the swap threshold {DEFAULT_SWAP_THRESHOLD}"
         );
     }
 
-    /// A3: 10 consecutive `FailedResponse(5.0)` events keep the score
-    /// inside [MIN_TRUST_SCORE, swap_threshold). Confirms the EMA arithmetic
+    /// A3: 10 consecutive bad-binding events keep the score inside
+    /// `[MIN_TRUST_SCORE, swap_threshold)`. Confirms the EMA arithmetic
     /// does not produce negative or NaN scores under repeated punishment.
     #[tokio::test]
     async fn multiple_bad_bindings_dont_compound_pathologically() {
@@ -902,14 +922,71 @@ mod tests {
         let peer = PeerId::random();
 
         for _ in 0..10 {
-            engine.update_node_stats_weighted(&peer, NodeStatisticsUpdate::FailedResponse, 5.0);
+            report_via_public_api(
+                &engine,
+                &peer,
+                TrustEvent::ApplicationFailure(MAX_CONSUMER_WEIGHT),
+            );
         }
 
         let score = engine.score(&peer);
         assert!(score.is_finite(), "score {score} must remain finite");
         assert!(
             (MIN_TRUST_SCORE..PLAN_LOOKUP_SKIP_BOUND).contains(&score),
-            "after 10 weight-5 failures, score {score} must lie in [{MIN_TRUST_SCORE}, {PLAN_LOOKUP_SKIP_BOUND})"
+            "after 10 weight-{MAX_CONSUMER_WEIGHT} failures, score {score} must lie in [{MIN_TRUST_SCORE}, {PLAN_LOOKUP_SKIP_BOUND})"
         );
+    }
+
+    /// A4: The public-API clamp + zero/negative-weight guard live on
+    /// `TrustEvent::clamped_update`. A consumer event with a weight above
+    /// `MAX_CONSUMER_WEIGHT` is clamped (so a malicious caller cannot
+    /// over-penalise a peer); a non-positive or non-finite weight is
+    /// silently dropped (so a buggy caller cannot accidentally credit a
+    /// success or NaN-poison the EMA).
+    ///
+    /// This is the test the reviewer asked for: the PR's whole purpose is
+    /// to expose `report_application_failure` as a public surface, so the
+    /// gating logic that surface relies on must be exercised.
+    #[tokio::test]
+    async fn clamped_update_clamps_weight_and_drops_non_positive() {
+        // Above-cap weight: clamps down to MAX_CONSUMER_WEIGHT, equivalent
+        // to passing exactly the cap. Tolerance accounts for the µs-level
+        // decay drift between the two `record_weighted` calls — both
+        // engines independently sample `Instant::now()` so the scores agree
+        // to within decay over a handful of microseconds, not bit-for-bit.
+        let engine_clamped = TrustEngine::new();
+        let engine_at_cap = TrustEngine::new();
+        let peer = PeerId::random();
+        report_via_public_api(
+            &engine_clamped,
+            &peer,
+            TrustEvent::ApplicationFailure(MAX_CONSUMER_WEIGHT * 100.0),
+        );
+        report_via_public_api(
+            &engine_at_cap,
+            &peer,
+            TrustEvent::ApplicationFailure(MAX_CONSUMER_WEIGHT),
+        );
+        let drift = (engine_clamped.score(&peer) - engine_at_cap.score(&peer)).abs();
+        assert!(
+            drift < 1e-6,
+            "weights above MAX_CONSUMER_WEIGHT must clamp to the cap; \
+             scores diverged by {drift} (clamped={}, at_cap={})",
+            engine_clamped.score(&peer),
+            engine_at_cap.score(&peer),
+        );
+
+        // Zero / negative / NaN weight: gate drops the event entirely. The
+        // peer keeps the neutral score it started with.
+        for bad_weight in [0.0, -1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let engine = TrustEngine::new();
+            let peer = PeerId::random();
+            report_via_public_api(&engine, &peer, TrustEvent::ApplicationFailure(bad_weight));
+            assert!(
+                (engine.score(&peer) - DEFAULT_NEUTRAL_TRUST).abs() < f64::EPSILON,
+                "weight {bad_weight} must be a no-op, score {} should equal neutral {DEFAULT_NEUTRAL_TRUST}",
+                engine.score(&peer)
+            );
+        }
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -998,6 +998,26 @@ impl P2PNode {
         self.adaptive_dht.report_trust_event(peer_id, event).await;
     }
 
+    /// Report a consumer-level application failure for a peer without
+    /// requiring the caller to import [`TrustEvent`].
+    ///
+    /// This is the recommended entry point for downstream crates (ant-client,
+    /// ant-node) that need to downscore a peer after a verifiable misbehaviour
+    /// (e.g. a quote whose `pub_key` does not BLAKE3-hash to its claimed
+    /// `PeerId`) but which do not — and should not — depend directly on
+    /// `saorsa-core`'s adaptive trust types.
+    ///
+    /// `weight` is clamped to the same `MAX_CONSUMER_WEIGHT` cap as
+    /// [`Self::report_trust_event`]. A weight of `5.0` (the cap) is enough
+    /// to drop a peer from neutral 0.5 to below the production swap-out
+    /// threshold in a single event — the intended setting for "the storer
+    /// would have rejected this proof"-class evidence.
+    pub async fn report_application_failure(&self, peer_id: &PeerId, weight: f64) {
+        self.adaptive_dht
+            .report_trust_event(peer_id, TrustEvent::ApplicationFailure(weight))
+            .await;
+    }
+
     /// Get the current trust score for a peer (0.0 to 1.0).
     ///
     /// Returns 0.5 (neutral) for unknown peers.


### PR DESCRIPTION
## Summary

- Adds `P2PNode::report_application_failure(peer, weight)` so downstream
  crates (ant-client quote handling, ant-node payment verification) can
  downscore a peer for a verifiable misbehaviour without depending on
  the saorsa-core `TrustEvent` enum.
- Adds A1/A2/A3 unit tests in `src/adaptive/trust.rs` proving the math
  behind plan-1-bad-node-eviction: one weight-5 failure drops a peer
  from neutral to ~0.26 (well below the 0.35 production swap threshold
  and the 0.4 plan target), the score recovers above the threshold
  within ~1 day of decay, and 10 consecutive penalties stay clamped
  inside `[0.0, 0.4)` (no negative or NaN values).
- This is the saorsa-core side of the plan-1 work. ant-client and
  ant-node land separate PRs that consume the new entry point.

## Why this matters

Repeat-offender peers were monopolising 5 of 15 close-K slots in
recent uploads (notes/plan-1-bad-node-eviction.md, the
`world_trade.JPG` failure on 2026-05-06). The client correctly
detects the bad-binding pattern via PR #71's
`drop_quotes_with_bad_bindings` but doesn't downscore the offenders,
so the same identities reappear in the close-K of the next chunk
and the next upload. Trust-score eviction is the missing primitive,
and the new entry point lets the consumer crates plug into the
existing trust-engine machinery without a wire-protocol change.

## Test plan

- [x] `cargo test --lib adaptive::trust` (25/25 pass, including
      `bad_binding_event_drops_peer_below_lookup_threshold`,
      `bad_binding_decays_back_above_threshold_after_2h`,
      `multiple_bad_bindings_dont_compound_pathologically`)
- [x] `cargo clippy --lib --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

## Cross-links

- ant-client PR: https://github.com/WithAutonomi/ant-client/pull/77
- ant-node PR: https://github.com/WithAutonomi/ant-node/pull/90

The three PRs depend on this one merging first because
`P2PNode::report_application_failure` is the new public surface they
call into.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `P2PNode::report_application_failure(peer, weight)` as a simplified entry point for downstream crates to downscore peers without importing the internal `TrustEvent` enum, and adds three unit tests (A1–A3) documenting the weight-5 eviction math in `trust.rs`.

- **`src/network.rs`**: New `report_application_failure` method delegates straight to `AdaptiveDHT::report_trust_event(TrustEvent::ApplicationFailure(weight))`, inheriting the existing `MAX_CONSUMER_WEIGHT` clamp and zero-weight guard with no changes to the trust engine itself.
- **`src/adaptive/trust.rs`**: Three `#[tokio::test]` cases exercise `TrustEngine` directly rather than the new public entry point; the A2 test's function name (`_after_2h`) does not match the 1-day recovery assertion it actually makes.

<h3>Confidence Score: 4/5</h3>

The production change is a thin, correct delegation to existing infrastructure and is safe to merge.

The new tests target TrustEngine internals directly rather than the new public API path, meaning a regression in the AdaptiveDHT clamping layer would go undetected. The A2 test name also contradicts the 1-day recovery assertion it actually makes. Neither issue affects the production path today.

src/adaptive/trust.rs — the new A1–A3 tests; the A2 name mismatch and the bypass of the AdaptiveDHT layer are worth a second look.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/network.rs | Adds `report_application_failure` public async method to `P2PNode`; correctly delegates to the existing `AdaptiveDHT::report_trust_event` path with full `MAX_CONSUMER_WEIGHT` clamping inherited. No logic issues. |
| src/adaptive/trust.rs | Adds three unit tests (A1/A2/A3) validating weight-5 failure eviction, decay recovery, and EMA bounds. A2 test name says `after_2h` but asserts full recovery at 1 day; all three tests call `TrustEngine` directly rather than routing through `AdaptiveDHT`. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Consumer as ant-client / ant-node
    participant Node as P2PNode
    participant ADHT as AdaptiveDHT
    participant TE as TrustEngine

    Consumer->>Node: report_application_failure(peer, weight)
    Note over Node: wraps weight into TrustEvent::ApplicationFailure(weight)
    Node->>ADHT: report_trust_event(peer, ApplicationFailure(weight))
    Note over ADHT: clamp weight to MAX_CONSUMER_WEIGHT (5.0)
    ADHT->>TE: update_node_stats_weighted(peer, FailedResponse, clamped_weight)
    Note over TE: EMA update
    TE-->>ADHT: score updated
    ADHT-->>Node: (void)
    Node-->>Consumer: (void)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/adaptive/trust.rs:862
The function name says `after_2h`, but the doc comment and the test body both make clear that full recovery (above `SWAP_THRESHOLD`) is only asserted after **1 day** of elapsed time. The 2-hour step only confirms partial improvement, not threshold crossing. A reader running `cargo test bad_binding_decays_back_above_threshold_after_2h` would reasonably expect the 2h window is where the recovery assertion lands, which is incorrect.

```suggestion
    async fn bad_binding_decays_back_above_threshold_after_1_day() {
```

### Issue 2 of 2
src/adaptive/trust.rs:841
**Tests bypass the clamping layer of the public API they document**

All three new tests call `engine.update_node_stats_weighted(..., 5.0)` directly on `TrustEngine`, skipping the `AdaptiveDHT::report_trust_event` path that `P2PNode::report_application_failure` actually routes through. Because `MAX_CONSUMER_WEIGHT` happens to equal `5.0`, the numbers are identical today — but the clamping logic, the zero/negative-weight guard, and any future middleware in `AdaptiveDHT` are not exercised. A lightweight integration test that calls `AdaptiveDHT::report_trust_event(&peer, TrustEvent::ApplicationFailure(5.0))` would tie the assertions directly to the entry point these tests are documented to prove.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(adaptive): downscore peers via P2PN..."](https://github.com/saorsa-labs/saorsa-core/commit/68f7d097063c97dfaebca82549107a97b1441eff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31112806)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->