### PR TITLE
Stabilize DHT lookups and transport sends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,9 +307,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1142,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -1469,7 +1469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1587,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2628,8 +2628,7 @@ dependencies = [
 [[package]]
 name = "saorsa-transport"
 version = "0.34.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ebc09fb51e2c325e61ff09892f1256c60ef4f3beb881fd2980befe3e53e9bc"
+source = "git+https://github.com/saorsa-labs/saorsa-transport?branch=fix%2Fstability-improvements#55f423ca5e3312e31ba22475b68a76f4ffd50285"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3118,9 +3117,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3185,9 +3184,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3434,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3447,9 +3446,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3457,9 +3456,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3467,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3480,9 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3523,9 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ once_cell = "1.21"
 dashmap = "6"
 
 # Networking
-saorsa-transport = "0.34.1"
+saorsa-transport = { git = "https://github.com/saorsa-labs/saorsa-transport", branch = "fix/stability-improvements" }
 
 # Core-specific dependencies
 dirs = "6.0"

--- a/docs/examples/saorsa-node-trust-integration.md
+++ b/docs/examples/saorsa-node-trust-integration.md
@@ -298,7 +298,7 @@ impl SaorsaNode {
 
         loop {
             match events.recv().await {
-                Ok(P2PEvent::Message { source, topic, data }) => {
+                Ok(P2PEvent::Message { source, topic, data, .. }) => {
                     match self.handle_message(&source, &topic, &data).await {
                         Ok(()) => {
                             // Message handled successfully

--- a/src/address.rs
+++ b/src/address.rs
@@ -47,19 +47,28 @@ use crate::identity::peer_id::PeerId;
 #[must_use]
 pub(crate) fn is_lan_ip(ip: IpAddr) -> bool {
     match ip {
-        IpAddr::V4(ip) => {
-            ip.is_loopback()
-                || ip.is_private()
-                || ip.is_link_local()
-                || (ip.octets()[0] == 100 && (ip.octets()[1] & 0b1100_0000) == 64)
-        }
+        IpAddr::V4(ip) => is_lan_ipv4(ip),
         IpAddr::V6(ip) => {
-            let octets = ip.octets();
-            ip.is_loopback()
-                || (octets[0] & 0xfe) == 0xfc
-                || (octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80)
+            if let Some(ip) = ip.to_ipv4_mapped() {
+                return is_lan_ipv4(ip);
+            }
+            is_lan_ipv6(ip)
         }
     }
+}
+
+fn is_lan_ipv4(ip: Ipv4Addr) -> bool {
+    ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local()
+        || (ip.octets()[0] == 100 && (ip.octets()[1] & 0b1100_0000) == 64)
+}
+
+fn is_lan_ipv6(ip: Ipv6Addr) -> bool {
+    let octets = ip.octets();
+    ip.is_loopback()
+        || (octets[0] & 0xfe) == 0xfc
+        || (octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80)
 }
 
 /// Composable, self-describing network address with an optional [`PeerId`]
@@ -331,6 +340,28 @@ mod tests {
 
         let public_addr = MultiAddr::from_ipv4(Ipv4Addr::new(8, 8, 8, 8), 53);
         assert!(!public_addr.is_private());
+    }
+
+    #[test]
+    fn test_ipv4_mapped_lan_address_detection() {
+        let mapped_private: IpAddr = "::ffff:192.168.1.10".parse().unwrap();
+        let mapped_loopback: IpAddr = "::ffff:127.0.0.1".parse().unwrap();
+        let mapped_link_local: IpAddr = "::ffff:169.254.1.10".parse().unwrap();
+        let mapped_cgnat: IpAddr = "::ffff:100.64.0.1".parse().unwrap();
+        let mapped_public: IpAddr = "::ffff:8.8.8.8".parse().unwrap();
+
+        assert!(is_lan_ip(mapped_private));
+        assert!(is_lan_ip(mapped_loopback));
+        assert!(is_lan_ip(mapped_link_local));
+        assert!(is_lan_ip(mapped_cgnat));
+        assert!(!is_lan_ip(mapped_public));
+    }
+
+    #[test]
+    fn test_ipv4_mapped_private_multiaddr_detection() {
+        let addr: MultiAddr = "/ip6/::ffff:192.168.1.10/udp/9000/quic".parse().unwrap();
+
+        assert!(addr.is_private());
     }
 
     #[test]

--- a/src/address.rs
+++ b/src/address.rs
@@ -42,6 +42,26 @@ pub use saorsa_transport::transport::TransportAddr;
 
 use crate::identity::peer_id::PeerId;
 
+/// Return true for IP addresses that should only be advertised for local
+/// reachability.
+#[must_use]
+pub(crate) fn is_lan_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            ip.is_loopback()
+                || ip.is_private()
+                || ip.is_link_local()
+                || (ip.octets()[0] == 100 && (ip.octets()[1] & 0b1100_0000) == 64)
+        }
+        IpAddr::V6(ip) => {
+            let octets = ip.octets();
+            ip.is_loopback()
+                || (octets[0] & 0xfe) == 0xfc
+                || (octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80)
+        }
+    }
+}
+
 /// Composable, self-describing network address with an optional [`PeerId`]
 /// suffix.
 ///
@@ -179,17 +199,10 @@ impl MultiAddr {
         self.ip().is_some_and(|ip| ip.is_loopback())
     }
 
-    /// `true` if this is an IP-based private/link-local address, `false`
+    /// `true` if this is an IP-based local-scope address, `false`
     /// otherwise.
     pub fn is_private(&self) -> bool {
-        match self.ip() {
-            Some(IpAddr::V4(ip)) => ip.is_private(),
-            Some(IpAddr::V6(ip)) => {
-                let octets = ip.octets();
-                (octets[0] & 0xfe) == 0xfc
-            }
-            None => false,
-        }
+        self.ip().is_some_and(is_lan_ip)
     }
 }
 

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -422,6 +422,23 @@ struct KBucket {
     last_refreshed: Instant,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum AddressReplaceMode {
+    /// The subject peer sent the address set over an authenticated channel.
+    /// This proves liveness, so the peer and bucket recency are refreshed.
+    AuthenticatedSelfPublish,
+    /// A third party repeated a sequence-bearing address set in FIND_NODE
+    /// gossip. The record may be fresh, but it is not evidence that the
+    /// subject peer is alive from our point of view.
+    GossipedRecord,
+}
+
+impl AddressReplaceMode {
+    const fn refreshes_liveness(self) -> bool {
+        matches!(self, Self::AuthenticatedSelfPublish)
+    }
+}
+
 impl KBucket {
     fn new(max_size: usize) -> Self {
         Self {
@@ -662,6 +679,33 @@ impl KBucket {
         node_id: &PeerId,
         typed_addresses: Vec<(MultiAddr, AddressType)>,
     ) -> bool {
+        self.replace_node_addresses_with_mode(
+            node_id,
+            typed_addresses,
+            AddressReplaceMode::AuthenticatedSelfPublish,
+        )
+    }
+
+    /// Overwrite a peer's address list from a sequence-bearing FIND_NODE
+    /// gossip record without updating peer liveness or bucket recency.
+    fn replace_node_addresses_from_gossip(
+        &mut self,
+        node_id: &PeerId,
+        typed_addresses: Vec<(MultiAddr, AddressType)>,
+    ) -> bool {
+        self.replace_node_addresses_with_mode(
+            node_id,
+            typed_addresses,
+            AddressReplaceMode::GossipedRecord,
+        )
+    }
+
+    fn replace_node_addresses_with_mode(
+        &mut self,
+        node_id: &PeerId,
+        typed_addresses: Vec<(MultiAddr, AddressType)>,
+        mode: AddressReplaceMode,
+    ) -> bool {
         let Some(pos) = self.nodes.iter().position(|n| &n.id == node_id) else {
             return false;
         };
@@ -681,13 +725,16 @@ impl KBucket {
             // per family, but a misbehaving sender could try to exceed
             // that. The cap enforces the invariant regardless.
             node.enforce_per_ip_family_cap();
-            node.last_seen.store_now();
         }
 
-        // Move to tail (most recently seen).
-        let node = self.nodes.remove(pos);
-        self.nodes.push(node);
-        self.last_refreshed = Instant::now();
+        if mode.refreshes_liveness() {
+            self.nodes[pos].last_seen.store_now();
+            // Move to tail (most recently seen).
+            let node = self.nodes.remove(pos);
+            self.nodes.push(node);
+            self.last_refreshed = Instant::now();
+        }
+
         true
     }
 }
@@ -733,6 +780,10 @@ impl KademliaRoutingTable {
         self.last_publish_seqs.remove(node_id);
     }
 
+    fn publish_seq_for(&self, node_id: &PeerId) -> u64 {
+        self.last_publish_seqs.get(node_id).copied().unwrap_or(0)
+    }
+
     /// Replace a peer's advertised address list under a monotonic sender
     /// sequence check.
     ///
@@ -752,6 +803,35 @@ impl KademliaRoutingTable {
         typed_addresses: Vec<(MultiAddr, AddressType)>,
         seq: u64,
     ) -> bool {
+        self.replace_node_addresses_with_mode(
+            node_id,
+            typed_addresses,
+            seq,
+            AddressReplaceMode::AuthenticatedSelfPublish,
+        )
+    }
+
+    fn replace_node_addresses_from_gossip(
+        &mut self,
+        node_id: &PeerId,
+        typed_addresses: Vec<(MultiAddr, AddressType)>,
+        seq: u64,
+    ) -> bool {
+        self.replace_node_addresses_with_mode(
+            node_id,
+            typed_addresses,
+            seq,
+            AddressReplaceMode::GossipedRecord,
+        )
+    }
+
+    fn replace_node_addresses_with_mode(
+        &mut self,
+        node_id: &PeerId,
+        typed_addresses: Vec<(MultiAddr, AddressType)>,
+        seq: u64,
+        mode: AddressReplaceMode,
+    ) -> bool {
         if let Some(&stored) = self.last_publish_seqs.get(node_id)
             && seq <= stored
         {
@@ -762,7 +842,13 @@ impl KademliaRoutingTable {
             return false;
         };
 
-        let applied = self.buckets[bucket_index].replace_node_addresses(node_id, typed_addresses);
+        let applied = match mode {
+            AddressReplaceMode::AuthenticatedSelfPublish => {
+                self.buckets[bucket_index].replace_node_addresses(node_id, typed_addresses)
+            }
+            AddressReplaceMode::GossipedRecord => self.buckets[bucket_index]
+                .replace_node_addresses_from_gossip(node_id, typed_addresses),
+        };
         if applied {
             self.last_publish_seqs.insert(*node_id, seq);
         }
@@ -854,6 +940,20 @@ impl KademliaRoutingTable {
             .collect()
     }
 
+    fn find_closest_nodes_with_publish_seq(
+        &self,
+        key: &DhtKey,
+        count: usize,
+    ) -> Vec<(NodeInfo, u64)> {
+        self.find_closest_nodes(key, count)
+            .into_iter()
+            .map(|node| {
+                let seq = self.publish_seq_for(&node.id);
+                (node, seq)
+            })
+            .collect()
+    }
+
     /// Returns the k-bucket index for a key, or `None` when the key equals
     /// the local node ID (XOR distance is zero — no valid bucket exists).
     fn get_bucket_index_for_key(&self, key: &DhtKey) -> Option<usize> {
@@ -891,6 +991,16 @@ impl KademliaRoutingTable {
         self.buckets
             .iter()
             .flat_map(|b| b.get_nodes().iter().cloned())
+            .collect()
+    }
+
+    fn all_nodes_with_publish_seq(&self) -> Vec<(NodeInfo, u64)> {
+        self.all_nodes()
+            .into_iter()
+            .map(|node| {
+                let seq = self.publish_seq_for(&node.id);
+                (node, seq)
+            })
             .collect()
     }
 
@@ -1225,6 +1335,17 @@ impl DhtCoreEngine {
         Ok(routing.find_closest_nodes(key, count))
     }
 
+    /// Find nodes closest to a key and include the latest authoritative
+    /// `PublishAddressSet` sequence known for each returned record.
+    pub async fn find_nodes_with_publish_seq(
+        &self,
+        key: &DhtKey,
+        count: usize,
+    ) -> Result<Vec<(NodeInfo, u64)>> {
+        let routing = self.routing_table.read().await;
+        Ok(routing.find_closest_nodes_with_publish_seq(key, count))
+    }
+
     /// Find nodes closest to a key, including self as a candidate.
     /// Used by consumers for storage responsibility determination.
     #[allow(dead_code)]
@@ -1309,8 +1430,13 @@ impl DhtCoreEngine {
     ///
     /// The routing table holds at most `256 * k_value` entries, so
     /// collecting them is inexpensive.
+    #[allow(dead_code)]
     pub async fn all_nodes(&self) -> Vec<NodeInfo> {
         self.routing_table.read().await.all_nodes()
+    }
+
+    pub async fn all_nodes_with_publish_seq(&self) -> Vec<(NodeInfo, u64)> {
+        self.routing_table.read().await.all_nodes_with_publish_seq()
     }
 
     /// Build diagnostic statistics for the routing table.
@@ -1444,9 +1570,10 @@ impl DhtCoreEngine {
     ///
     /// Implements the receive side of the `PublishAddressSet` wire op: the
     /// sender is authoritative about its own reachable addresses and the
-    /// receiver drops any address the sender omits. This is the only path
-    /// by which a stale relay entry can be removed from a peer's routing
-    /// record when the relay session dies.
+    /// receiver drops any address the sender omits. This authenticated path is
+    /// the source of fresh address records; later FIND_NODE gossip may propagate
+    /// the same replacement through [`Self::replace_node_addresses_from_gossip`]
+    /// without refreshing liveness.
     ///
     /// - Loopback entries are filtered out unless [`Self::allow_loopback`]
     ///   is set (devnets/tests), matching the loopback-injection guard in
@@ -1465,8 +1592,40 @@ impl DhtCoreEngine {
         typed_addresses: Vec<(MultiAddr, AddressType)>,
         seq: u64,
     ) -> bool {
-        if typed_addresses.is_empty() {
+        let Some(filtered) = self.filter_publish_address_set(typed_addresses) else {
             return false;
+        };
+        let mut routing = self.routing_table.write().await;
+        routing.replace_node_addresses(node_id, filtered, seq)
+    }
+
+    /// Replace a peer's advertised address list from sequence-bearing gossip
+    /// without refreshing liveness.
+    ///
+    /// Uses the same filtering and monotonic-sequence guard as
+    /// [`Self::replace_node_addresses`], but does not update `last_seen`,
+    /// bucket MRU order, or bucket refresh timestamps. A third-party
+    /// FIND_NODE response can propagate a newer address record, but only
+    /// direct authenticated traffic from the subject peer proves liveness.
+    pub(crate) async fn replace_node_addresses_from_gossip(
+        &self,
+        node_id: &PeerId,
+        typed_addresses: Vec<(MultiAddr, AddressType)>,
+        seq: u64,
+    ) -> bool {
+        let Some(filtered) = self.filter_publish_address_set(typed_addresses) else {
+            return false;
+        };
+        let mut routing = self.routing_table.write().await;
+        routing.replace_node_addresses_from_gossip(node_id, filtered, seq)
+    }
+
+    fn filter_publish_address_set(
+        &self,
+        typed_addresses: Vec<(MultiAddr, AddressType)>,
+    ) -> Option<Vec<(MultiAddr, AddressType)>> {
+        if typed_addresses.is_empty() {
+            return None;
         }
 
         let allow_loopback = self.allow_loopback;
@@ -1482,12 +1641,7 @@ impl DhtCoreEngine {
             })
             .collect();
 
-        if filtered.is_empty() {
-            return false;
-        }
-
-        let mut routing = self.routing_table.write().await;
-        routing.replace_node_addresses(node_id, filtered, seq)
+        (!filtered.is_empty()).then_some(filtered)
     }
 
     /// Add a node to the DHT with security checks.
@@ -2539,6 +2693,52 @@ mod tests {
             node.addresses,
             vec!["/ip4/3.3.3.3/udp/9000/quic".parse::<MultiAddr>().unwrap()]
         );
+    }
+
+    #[test]
+    fn replace_addresses_from_gossip_does_not_refresh_liveness() {
+        let local_id = PeerId::from_bytes([0u8; 32]);
+        let mut table = KademliaRoutingTable::new(local_id, 8);
+        let peer = PeerId::from_bytes([1u8; 32]);
+        table
+            .add_node(NodeInfo {
+                id: peer,
+                addresses: vec!["/ip4/1.1.1.1/udp/9000/quic".parse().unwrap()],
+                address_types: vec![AddressType::Direct],
+                last_seen: AtomicInstant::now(),
+            })
+            .unwrap();
+
+        let bucket_index = table.get_bucket_index(&peer).unwrap();
+        let before_last_seen = table.buckets[bucket_index]
+            .find_node(&peer)
+            .unwrap()
+            .last_seen
+            .load();
+        let before_last_refreshed = table.buckets[bucket_index].last_refreshed;
+
+        let gossiped: Vec<(MultiAddr, AddressType)> = vec![(
+            "/ip4/2.2.2.2/udp/9000/quic".parse().unwrap(),
+            AddressType::Relay,
+        )];
+        assert!(table.replace_node_addresses_from_gossip(&peer, gossiped, 10));
+
+        let node = table.buckets[bucket_index].find_node(&peer).unwrap();
+        assert_eq!(
+            node.addresses,
+            vec!["/ip4/2.2.2.2/udp/9000/quic".parse::<MultiAddr>().unwrap()]
+        );
+        assert_eq!(node.address_types, vec![AddressType::Relay]);
+        assert_eq!(
+            node.last_seen.load(),
+            before_last_seen,
+            "third-party gossip must not prove subject-peer liveness"
+        );
+        assert_eq!(
+            table.buckets[bucket_index].last_refreshed, before_last_refreshed,
+            "third-party gossip must not count as bucket discovery activity"
+        );
+        assert_eq!(table.publish_seq_for(&peer), 10);
     }
 
     #[test]

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -784,6 +784,24 @@ impl KademliaRoutingTable {
         self.last_publish_seqs.get(node_id).copied().unwrap_or(0)
     }
 
+    /// Merge a legacy relay hint only while the peer has no authoritative
+    /// `PublishAddressSet` record.
+    ///
+    /// Once a publish sequence has been observed, the stored address list is
+    /// the owner's complete self-record for that sequence. Allowing legacy
+    /// ADD_ADDRESS hints to mutate it would let stale relay allocations
+    /// reappear after a newer direct-only publish removed them.
+    fn touch_legacy_relay_hint_if_unsequenced(
+        &mut self,
+        node_id: &PeerId,
+        address: &MultiAddr,
+    ) -> bool {
+        if self.publish_seq_for(node_id) != 0 {
+            return false;
+        }
+        self.touch_node(node_id, Some(address), AddressType::Relay)
+    }
+
     /// Replace a peer's advertised address list under a monotonic sender
     /// sequence check.
     ///
@@ -1522,6 +1540,21 @@ impl DhtCoreEngine {
         // Slow path: address merge or re-classification needed, take write lock.
         let mut routing = self.routing_table.write().await;
         routing.touch_node(node_id, address, addr_type)
+    }
+
+    /// Merge a peer-advertised relay hint only if the peer has never sent an
+    /// authoritative `PublishAddressSet`.
+    ///
+    /// Legacy ADD_ADDRESS frames remain useful for peers that predate typed
+    /// self-record publishing. After any publish sequence has been stored for
+    /// the peer, only a newer `PublishAddressSet` may change its address list.
+    pub async fn touch_legacy_relay_hint_if_unsequenced(
+        &self,
+        node_id: &PeerId,
+        address: &MultiAddr,
+    ) -> bool {
+        let mut routing = self.routing_table.write().await;
+        routing.touch_legacy_relay_hint_if_unsequenced(node_id, address)
     }
 
     /// Merge `address` (with `addr_type`) into an existing peer's record
@@ -2693,6 +2726,71 @@ mod tests {
             node.addresses,
             vec!["/ip4/3.3.3.3/udp/9000/quic".parse::<MultiAddr>().unwrap()]
         );
+    }
+
+    #[test]
+    fn legacy_relay_hint_updates_unsequenced_record() {
+        let local_id = PeerId::from_bytes([0u8; 32]);
+        let mut table = KademliaRoutingTable::new(local_id, 8);
+        let peer = PeerId::from_bytes([1u8; 32]);
+        table
+            .add_node(NodeInfo {
+                id: peer,
+                addresses: vec!["/ip4/1.1.1.1/udp/9000/quic".parse().unwrap()],
+                address_types: vec![AddressType::Unverified],
+                last_seen: AtomicInstant::now(),
+            })
+            .unwrap();
+
+        let relay = "/ip4/198.51.100.7/udp/46973/quic"
+            .parse::<MultiAddr>()
+            .unwrap();
+        assert!(table.touch_legacy_relay_hint_if_unsequenced(&peer, &relay));
+
+        let bucket_index = table.get_bucket_index(&peer).unwrap();
+        let node = table.buckets[bucket_index].find_node(&peer).unwrap();
+        assert_eq!(node.addresses[0], relay);
+        assert_eq!(node.address_types[0], AddressType::Relay);
+        assert_eq!(table.publish_seq_for(&peer), 0);
+    }
+
+    #[test]
+    fn legacy_relay_hint_does_not_mutate_sequenced_record() {
+        let local_id = PeerId::from_bytes([0u8; 32]);
+        let mut table = KademliaRoutingTable::new(local_id, 8);
+        let peer = PeerId::from_bytes([1u8; 32]);
+        table
+            .add_node(NodeInfo {
+                id: peer,
+                addresses: vec!["/ip4/1.1.1.1/udp/9000/quic".parse().unwrap()],
+                address_types: vec![AddressType::Unverified],
+                last_seen: AtomicInstant::now(),
+            })
+            .unwrap();
+
+        let direct_only: Vec<(MultiAddr, AddressType)> = vec![(
+            "/ip4/203.0.113.9/udp/60488/quic".parse().unwrap(),
+            AddressType::Direct,
+        )];
+        assert!(table.replace_node_addresses(&peer, direct_only.clone(), 20));
+
+        let stale_relay = "/ip4/198.51.100.7/udp/46973/quic"
+            .parse::<MultiAddr>()
+            .unwrap();
+        assert!(!table.touch_legacy_relay_hint_if_unsequenced(&peer, &stale_relay));
+
+        let bucket_index = table.get_bucket_index(&peer).unwrap();
+        let node = table.buckets[bucket_index].find_node(&peer).unwrap();
+        assert_eq!(
+            node.addresses,
+            vec![
+                "/ip4/203.0.113.9/udp/60488/quic"
+                    .parse::<MultiAddr>()
+                    .unwrap()
+            ]
+        );
+        assert_eq!(node.address_types, vec![AddressType::Direct]);
+        assert_eq!(table.publish_seq_for(&peer), 20);
     }
 
     #[test]

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -4573,6 +4573,37 @@ mod tests {
     }
 
     #[test]
+    fn mapped_local_scope_address_type_is_canonicalized_to_lan() {
+        let cases = [
+            (
+                "/ip6/::ffff:192.168.1.10/udp/9000/quic",
+                AddressType::Direct,
+            ),
+            (
+                "/ip6/::ffff:127.0.0.1/udp/9001/quic",
+                AddressType::Unverified,
+            ),
+            ("/ip6/::ffff:100.64.0.1/udp/9002/quic", AddressType::Relay),
+        ];
+
+        for (idx, (addr, advertised)) in cases.into_iter().enumerate() {
+            let mut node = NodeInfo {
+                id: PeerId::from_bytes([idx as u8; 32]),
+                addresses: Vec::new(),
+                address_types: Vec::new(),
+                last_seen: AtomicInstant::now(),
+            };
+            let addr: MultiAddr = addr.parse().unwrap();
+
+            node.merge_typed_address(addr.clone(), advertised);
+
+            assert_eq!(node.addresses, vec![addr], "case {idx}");
+            assert_eq!(node.address_types, vec![AddressType::Lan], "case {idx}");
+            assert_eq!(node.address_type_at(0), AddressType::Lan, "case {idx}");
+        }
+    }
+
+    #[test]
     fn merge_same_family_keeps_relay_best_wan_and_lan() {
         // Under the per-IP-family cap: at most 1 Relay + 1 WAN
         // non-Relay (Direct/Unverified) + 1 Lan per family. Direct is the

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -1661,15 +1661,15 @@ impl DhtCoreEngine {
     /// - Loopback entries are filtered out unless [`Self::allow_loopback`]
     ///   is set (devnets/tests), matching the loopback-injection guard in
     ///   [`KBucket::touch_node_typed`].
-    /// - Empty address lists (after filtering) are rejected — the sender
-    ///   must have at least one valid address or the receiver would be
-    ///   left with an unreachable entry.
+    /// - Empty input address lists are rejected. If filtering strips every
+    ///   supplied address, the empty set is still applied so stale addresses
+    ///   from an older publish cannot survive a newer full replacement.
     /// - `seq` must be non-zero and strictly exceed the last sequence
     ///   observed from `node_id`; zero, older, or duplicate sequences are
     ///   ignored.
     ///
     /// Returns `true` when the peer's addresses were replaced, `false`
-    /// otherwise (peer absent, stale sequence, or empty filtered list).
+    /// otherwise (peer absent, stale sequence, or empty input list).
     pub async fn replace_node_addresses(
         &self,
         node_id: &PeerId,
@@ -1729,7 +1729,7 @@ impl DhtCoreEngine {
             })
             .collect();
 
-        (!filtered.is_empty()).then_some(filtered)
+        Some(filtered)
     }
 
     /// Add a node to the DHT with security checks.
@@ -3170,6 +3170,23 @@ mod tests {
             "non-loopback should be accepted: {:?}",
             result
         );
+    }
+
+    #[tokio::test]
+    async fn replace_addresses_applies_empty_set_after_filtering_all_entries() {
+        let mut dht = DhtCoreEngine::new_for_tests(PeerId::from_bytes([0u8; 32])).unwrap();
+        let peer = PeerId::from_bytes([1u8; 32]);
+        dht.add_node_no_trust(make_node(1, "/ip4/198.51.100.1/udp/9000/quic"))
+            .await
+            .unwrap();
+
+        let loopback_only = vec![(
+            "/ip4/127.0.0.1/udp/9001/quic".parse().unwrap(),
+            AddressType::Direct,
+        )];
+
+        assert!(dht.replace_node_addresses(&peer, loopback_only, 1).await);
+        assert!(dht.get_node_addresses(&peer).await.is_empty());
     }
 
     // -----------------------------------------------------------------------

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -805,16 +805,18 @@ impl KademliaRoutingTable {
     /// Replace a peer's advertised address list under a monotonic sender
     /// sequence check.
     ///
-    /// Stale republishes (`seq <= stored seq for this peer`) are discarded.
-    /// When `seq` is strictly greater than any previously observed sequence
-    /// from `node_id`, the peer's bucket entry is rewritten via
+    /// Sequence `0` is reserved as the "no sequence observed" sentinel and is
+    /// discarded. Stale republishes (`seq <= stored seq for this peer`) are
+    /// also discarded. When `seq` is strictly greater than any previously
+    /// observed sequence from `node_id`, the peer's bucket entry is rewritten via
     /// [`KBucket::replace_node_addresses`] and the stored sequence is
     /// advanced. The whole check-and-apply runs under the caller's write
     /// lock on the routing table, so concurrent republishes from the same
     /// sender are serialised.
     ///
     /// Returns `true` when addresses were replaced; `false` when the peer
-    /// is absent from the routing table or the message was stale.
+    /// is absent from the routing table or the message had an invalid/stale
+    /// sequence.
     fn replace_node_addresses(
         &mut self,
         node_id: &PeerId,
@@ -850,6 +852,10 @@ impl KademliaRoutingTable {
         seq: u64,
         mode: AddressReplaceMode,
     ) -> bool {
+        if seq == 0 {
+            return false;
+        }
+
         if let Some(&stored) = self.last_publish_seqs.get(node_id)
             && seq <= stored
         {
@@ -1614,8 +1620,9 @@ impl DhtCoreEngine {
     /// - Empty address lists (after filtering) are rejected — the sender
     ///   must have at least one valid address or the receiver would be
     ///   left with an unreachable entry.
-    /// - `seq` must strictly exceed the last sequence observed from
-    ///   `node_id`; older or duplicate sequences are ignored.
+    /// - `seq` must be non-zero and strictly exceed the last sequence
+    ///   observed from `node_id`; zero, older, or duplicate sequences are
+    ///   ignored.
     ///
     /// Returns `true` when the peer's addresses were replaced, `false`
     /// otherwise (peer absent, stale sequence, or empty filtered list).
@@ -2726,6 +2733,35 @@ mod tests {
             node.addresses,
             vec!["/ip4/3.3.3.3/udp/9000/quic".parse::<MultiAddr>().unwrap()]
         );
+    }
+
+    #[test]
+    fn replace_addresses_rejects_zero_publish_seq() {
+        let local_id = PeerId::from_bytes([0u8; 32]);
+        let mut table = KademliaRoutingTable::new(local_id, 8);
+        let peer = PeerId::from_bytes([1u8; 32]);
+        let initial_addr = "/ip4/1.1.1.1/udp/9000/quic".parse::<MultiAddr>().unwrap();
+        table
+            .add_node(NodeInfo {
+                id: peer,
+                addresses: vec![initial_addr.clone()],
+                address_types: vec![AddressType::Unverified],
+                last_seen: AtomicInstant::now(),
+            })
+            .unwrap();
+
+        let zero_publish: Vec<(MultiAddr, AddressType)> = vec![(
+            "/ip4/2.2.2.2/udp/9000/quic".parse().unwrap(),
+            AddressType::Direct,
+        )];
+        assert!(!table.replace_node_addresses(&peer, zero_publish.clone(), 0));
+        assert!(!table.replace_node_addresses_from_gossip(&peer, zero_publish, 0));
+        assert_eq!(table.publish_seq_for(&peer), 0);
+
+        let bucket_index = table.get_bucket_index(&peer).unwrap();
+        let node = table.buckets[bucket_index].find_node(&peer).unwrap();
+        assert_eq!(node.addresses, vec![initial_addr]);
+        assert_eq!(node.address_types, vec![AddressType::Unverified]);
     }
 
     #[test]

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -4,7 +4,7 @@
 //! trust-weighted peer selection, and security-hardened maintenance tasks.
 
 use crate::PeerId;
-use crate::address::MultiAddr;
+use crate::address::{MultiAddr, is_lan_ip};
 use crate::security::{IP_EXACT_LIMIT, IPDiversityConfig, canonicalize_ip, ip_subnet_limit};
 use anyhow::{Result, anyhow};
 use parking_lot::Mutex as PlMutex;
@@ -110,9 +110,9 @@ const MAX_ADDRESSES_PER_NODE: usize = 8;
 
 /// Address classification for priority ordering and staleness eviction.
 ///
-/// Priority: Relay > Direct > Unverified > NATted. The `merge_typed_address`
+/// Priority: Relay > Direct > Unverified > Lan. The `merge_typed_address`
 /// method uses this for insertion ordering and the eviction of excess
-/// `NATted` / `Unverified` entries.
+/// `Lan` / `Unverified` entries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AddressType {
     /// Address through a MASQUE relay server (always reachable)
@@ -122,17 +122,20 @@ pub enum AddressType {
     /// Self-published observed external address whose reachability has not
     /// been confirmed by the local classifier. Published by cold-start nodes
     /// that have not yet accepted an unsolicited inbound handshake and have
-    /// not yet acquired a relay. Dialers try these last (before `NATted`)
+    /// not yet acquired a relay. Dialers try these after Relay/Direct and
+    /// before LAN-only fallback
     /// and must accept the possibility of a timeout.
     Unverified,
-    /// NATted address (ephemeral, typically unreachable from outside)
-    NATted,
+    /// LAN or other local-scope address. This reuses the old `NATted`
+    /// variant slot for wire compatibility with older nodes.
+    #[serde(alias = "NATted")]
+    Lan,
 }
 
 impl AddressType {
     /// Priority index for ordering addresses by type. Lower is preferred.
     ///
-    /// Relay (0) → Direct (1) → Unverified (2) → NATted (3).
+    /// Relay (0) → Direct (1) → Unverified (2) → Lan (3).
     ///
     /// Used by [`NodeInfo::merge_typed_address`], [`KBucket::replace_node_addresses`],
     /// [`DHTNode::addresses_by_priority`], and [`DhtNetworkManager::dialable_addresses_typed`]
@@ -142,7 +145,20 @@ impl AddressType {
             Self::Relay => 0,
             Self::Direct => 1,
             Self::Unverified => 2,
-            Self::NATted => 3,
+            Self::Lan => 3,
+        }
+    }
+
+    /// Canonicalize an advertised type against the address itself.
+    ///
+    /// A local-scope IP address is never accepted as Relay, Direct, or
+    /// Unverified, even if that is what a peer advertised. It may still be
+    /// stored as [`AddressType::Lan`] so same-LAN/same-WAN peers can use it.
+    pub(crate) fn for_advertised_address(addr: &MultiAddr, advertised: Self) -> Self {
+        if addr.ip().is_some_and(is_lan_ip) {
+            Self::Lan
+        } else {
+            advertised
         }
     }
 }
@@ -170,7 +186,7 @@ pub struct NodeInfo {
     pub addresses: Vec<MultiAddr>,
     /// Type tag for each address, parallel to `addresses` by index.
     /// Defaults to empty on deserialization (legacy nodes); callers treat
-    /// untagged addresses as `Direct`.
+    /// untagged addresses as `Unverified`.
     #[serde(default)]
     pub address_types: Vec<AddressType>,
     /// Monotonic timestamp of last successful interaction.
@@ -217,11 +233,13 @@ impl NodeInfo {
     /// Merge a new address with an explicit type tag.
     ///
     /// Insertion position depends on type priority: Relay → Direct →
-    /// Unverified → NATted. Relay addresses always go to the front. After
+    /// Unverified → Lan. Relay addresses always go to the front. After
     /// insertion, [`Self::enforce_per_ip_family_cap`] prunes the list so
-    /// the "at most 1 Relay + 1 non-Relay per IP family, Direct dominates
-    /// Unverified dominates NATted" invariant holds.
+    /// the "at most 1 Relay + 1 WAN non-Relay + 1 LAN per IP family"
+    /// invariant holds.
     pub fn merge_typed_address(&mut self, addr: MultiAddr, addr_type: AddressType) {
+        let addr_type = AddressType::for_advertised_address(&addr, addr_type);
+
         // Ensure address_types is in sync with addresses (legacy compat).
         // Trailing untagged entries are padded with `Unverified` so we do not
         // claim direct-reachability for addresses whose publisher never
@@ -241,8 +259,8 @@ impl NodeInfo {
         // Insert based on type priority. Insertion order is what the cap
         // uses to break "newest wins" ties: Relay / Direct / Unverified
         // insert at the front of their tier so the newest sits at the
-        // lowest index among same-tier entries; NATted appends so the
-        // newest sits at the highest index.
+        // lowest index among same-tier entries; Lan appends so the newest
+        // sits at the highest index.
         match addr_type {
             AddressType::Relay => {
                 self.addresses.insert(0, addr);
@@ -266,9 +284,9 @@ impl NodeInfo {
                 self.addresses.insert(pos, addr);
                 self.address_types.insert(pos, AddressType::Unverified);
             }
-            AddressType::NATted => {
+            AddressType::Lan => {
                 self.addresses.push(addr);
-                self.address_types.push(AddressType::NATted);
+                self.address_types.push(AddressType::Lan);
             }
         }
 
@@ -276,18 +294,25 @@ impl NodeInfo {
 
         // Last-line guard for non-IP transports (outside the per-family cap).
         self.addresses.truncate(MAX_ADDRESSES_PER_NODE);
-        self.address_types.truncate(MAX_ADDRESSES_PER_NODE);
+        self.address_types.truncate(self.addresses.len());
     }
 
-    /// Get the address type at the given index. Returns `Unverified` for
-    /// untagged addresses — legacy records that predate ADR-014 never
-    /// asserted reachability for their entries, so the conservative default
-    /// is "publisher did not claim this is directly dialable."
+    /// Get the address type at the given index.
+    ///
+    /// Local-scope IP addresses always return [`AddressType::Lan`], even if
+    /// the stored or legacy-advertised tag says otherwise. Other untagged
+    /// addresses return [`AddressType::Unverified`] because legacy records
+    /// that predate ADR-014 never asserted direct reachability.
     pub fn address_type_at(&self, index: usize) -> AddressType {
-        self.address_types
+        let advertised = self
+            .address_types
             .get(index)
             .copied()
-            .unwrap_or(AddressType::Unverified)
+            .unwrap_or(AddressType::Unverified);
+        self.addresses
+            .get(index)
+            .map(|addr| AddressType::for_advertised_address(addr, advertised))
+            .unwrap_or(advertised)
     }
 
     /// Enforce the per-IP-family address cap for an external peer.
@@ -296,16 +321,16 @@ impl NodeInfo {
     /// to IPv4 so it is counted against the IPv4 slot), keep at most:
     ///
     /// - 1 [`AddressType::Relay`] (newest wins)
-    /// - 1 of {[`AddressType::Direct`], [`AddressType::Unverified`],
-    ///   [`AddressType::NATted`]} — the entry with the highest priority
-    ///   tier present in that family wins, newer entries within a tier
-    ///   win over older ones
+    /// - 1 of {[`AddressType::Direct`], [`AddressType::Unverified`]} — the
+    ///   entry with the highest priority tier present in that family wins,
+    ///   newer entries within a tier win over older ones
+    /// - 1 [`AddressType::Lan`] address for same-LAN/same-WAN peers
     ///
-    /// That yields the invariant: at most 2 addresses per IP family, and
-    /// weaker tiers (Unverified, NATted) never coexist with a stronger
-    /// same-family tier (Direct) — they add no useful dial option once
+    /// That yields the invariant: at most 3 addresses per IP family, and
+    /// weaker WAN tiers (Unverified) never coexist with a stronger
+    /// same-family tier (Direct) — they add no useful WAN dial option once
     /// the stronger one is known. A dual-stack peer may therefore hold
-    /// up to 4 IP addresses (2 per family).
+    /// up to 6 IP addresses (3 per family).
     ///
     /// Non-IP transport addresses (Bluetooth, LoRa) are left alone — they
     /// have no IP family and are governed only by [`MAX_ADDRESSES_PER_NODE`].
@@ -313,7 +338,7 @@ impl NodeInfo {
     /// "Newest wins" is encoded by the insertion positions in
     /// [`Self::merge_typed_address`]: Relay, Direct, and Unverified insert
     /// at the front of their tier, so the newest entry has the lowest
-    /// index; NATted appends, so the newest has the highest index.
+    /// index; Lan appends, so the newest has the highest index.
     ///
     /// This enforces the invariant for *external peers*. The routing
     /// table never stores `NodeInfo` for self (admission rejects
@@ -323,6 +348,7 @@ impl NodeInfo {
         while self.address_types.len() < self.addresses.len() {
             self.address_types.push(AddressType::Unverified);
         }
+        self.address_types.truncate(self.addresses.len());
 
         // Non-IP addresses are exempt from the per-family cap.
         let mut keep: Vec<bool> = self.addresses.iter().map(|a| a.ip().is_none()).collect();
@@ -348,28 +374,30 @@ impl NodeInfo {
                 keep[i] = true;
             }
 
-            // Slot 2: the single highest-priority non-Relay entry for the
-            // family. Precedence is Direct > Unverified > NATted. Within
-            // Direct/Unverified, newer is at the lowest index; within
-            // NATted, newer is at the highest (append ordering).
-            let best_non_relay = [
-                AddressType::Direct,
-                AddressType::Unverified,
-                AddressType::NATted,
-            ]
-            .iter()
-            .find_map(|t| match t {
-                AddressType::NATted => family
-                    .iter()
-                    .rev()
-                    .find(|&&i| self.address_types[i] == AddressType::NATted)
-                    .copied(),
-                tier => family
-                    .iter()
-                    .find(|&&i| self.address_types[i] == *tier)
-                    .copied(),
-            });
-            if let Some(i) = best_non_relay {
+            // Slot 2: the single highest-priority WAN entry for the family.
+            // Precedence is Direct > Unverified. Within each tier, newer is
+            // at the lowest index.
+            let best_wan = [AddressType::Direct, AddressType::Unverified]
+                .iter()
+                .find_map(|tier| {
+                    family
+                        .iter()
+                        .find(|&&i| self.address_types[i] == *tier)
+                        .copied()
+                });
+            if let Some(i) = best_wan {
+                keep[i] = true;
+            }
+
+            // Slot 3: newest LAN address for peers that can use a
+            // local-scope route. LAN addresses are independent from WAN
+            // Direct/Unverified addresses; otherwise hybrid deployments
+            // would drop the local path that same-WAN peers need.
+            if let Some(&i) = family
+                .iter()
+                .rev()
+                .find(|&&i| self.address_types[i] == AddressType::Lan)
+            {
                 keep[i] = true;
             }
         }
@@ -402,6 +430,7 @@ impl NodeInfo {
         addr: MultiAddr,
         addr_type: AddressType,
     ) -> bool {
+        let addr_type = AddressType::for_advertised_address(&addr, addr_type);
         if let Some(pos) = self.addresses.iter().position(|a| a == &addr) {
             let existing = self.address_type_at(pos);
             if existing.priority() <= addr_type.priority() {
@@ -458,7 +487,20 @@ impl KBucket {
         // Cap addresses to prevent memory exhaustion from oversized lists
         // arriving via deserialization or direct construction.
         node.addresses.truncate(MAX_ADDRESSES_PER_NODE);
-        node.address_types.truncate(MAX_ADDRESSES_PER_NODE);
+        node.address_types.truncate(node.addresses.len());
+        for (i, addr) in node.addresses.iter().enumerate() {
+            let advertised = node
+                .address_types
+                .get(i)
+                .copied()
+                .unwrap_or(AddressType::Unverified);
+            if i < node.address_types.len() {
+                node.address_types[i] = AddressType::for_advertised_address(addr, advertised);
+            } else {
+                node.address_types
+                    .push(AddressType::for_advertised_address(addr, advertised));
+            }
+        }
 
         // If the node is already in this bucket, merge addresses using
         // type-aware merge so relay addresses stay at the front and
@@ -623,6 +665,7 @@ impl KBucket {
         let merge_is_noop = match address {
             None => true,
             Some(addr) => {
+                let addr_type = AddressType::for_advertised_address(addr, addr_type);
                 // Already in the list → merge would reinsert at the same
                 // position, which is a no-op only if the existing entry
                 // has the same type classification. If the type differs
@@ -668,7 +711,7 @@ impl KBucket {
     /// drops any state the sender omits (e.g., a stale relay address after
     /// the relay session closes).
     ///
-    /// The new list is sorted by [`type_priority`] (Relay → Direct → NATted)
+    /// The new list is sorted by [`type_priority`] (Relay → Direct → Lan)
     /// to preserve the same ordering invariant that [`NodeInfo::merge_typed_address`]
     /// maintains, then truncated to [`MAX_ADDRESSES_PER_NODE`].
     ///
@@ -710,7 +753,13 @@ impl KBucket {
             return false;
         };
 
-        let mut typed = typed_addresses;
+        let mut typed: Vec<(MultiAddr, AddressType)> = typed_addresses
+            .into_iter()
+            .map(|(addr, ty)| {
+                let ty = AddressType::for_advertised_address(&addr, ty);
+                (addr, ty)
+            })
+            .collect();
         typed.sort_by_key(|(_, t)| type_priority(*t));
         typed.truncate(MAX_ADDRESSES_PER_NODE);
 
@@ -721,9 +770,10 @@ impl KBucket {
             node.addresses = addresses;
             node.address_types = address_types;
             // Apply the per-IP-family cap on the incoming publish set: a
-            // peer is not expected to publish more than Relay+{one other}
-            // per family, but a misbehaving sender could try to exceed
-            // that. The cap enforces the invariant regardless.
+            // peer is not expected to publish more than Relay + one WAN
+            // address + one LAN address per family, but a misbehaving sender
+            // could try to exceed that. The cap enforces the invariant
+            // regardless.
             node.enforce_per_ip_family_cap();
         }
 
@@ -1431,14 +1481,7 @@ impl DhtCoreEngine {
                 n.addresses
                     .iter()
                     .enumerate()
-                    .map(|(i, addr)| {
-                        let addr_type = n
-                            .address_types
-                            .get(i)
-                            .copied()
-                            .unwrap_or(AddressType::Unverified);
-                        (addr.clone(), addr_type)
-                    })
+                    .map(|(i, addr)| (addr.clone(), n.address_type_at(i)))
                     .collect()
             })
             .unwrap_or_default()
@@ -1495,11 +1538,12 @@ impl DhtCoreEngine {
     /// Passing the current address ensures stale addresses are replaced when a
     /// peer reconnects from a different endpoint.
     ///
-    /// Any address passed here is classified [`AddressType::Unverified`]: a
-    /// successful RPC with us proves reachability from *us* to the peer
-    /// (possibly through a NAT mapping we opened), not public
-    /// cold-dialability. Callers with authoritative type information must use
-    /// [`Self::touch_node_typed`].
+    /// Non-local addresses passed here are classified
+    /// [`AddressType::Unverified`]: a successful RPC with us proves
+    /// reachability from *us* to the peer (possibly through a NAT mapping we
+    /// opened), not public cold-dialability. Local-scope addresses are
+    /// canonicalized to [`AddressType::Lan`] by the typed merge path. Callers
+    /// with authoritative type information must use [`Self::touch_node_typed`].
     pub async fn touch_node(&self, node_id: &PeerId, address: Option<&MultiAddr>) -> bool {
         let mut routing = self.routing_table.write().await;
         routing.touch_node(node_id, address, AddressType::Unverified)
@@ -1678,6 +1722,10 @@ impl DhtCoreEngine {
                 !addr
                     .ip()
                     .is_some_and(|ip| canonicalize_ip(ip).is_loopback())
+            })
+            .map(|(addr, ty)| {
+                let ty = AddressType::for_advertised_address(&addr, ty);
+                (addr, ty)
             })
             .collect();
 
@@ -2652,6 +2700,23 @@ mod tests {
     }
 
     #[test]
+    fn replace_addresses_canonicalizes_local_scope_direct_to_lan() {
+        let k = 8;
+        let mut bucket = KBucket::new(k);
+        bucket
+            .add_node(make_node(1, "/ip4/1.1.1.1/udp/9000/quic"))
+            .unwrap();
+
+        let private: MultiAddr = "/ip4/192.168.1.10/udp/9001/quic".parse().unwrap();
+        let typed = vec![(private.clone(), AddressType::Direct)];
+        assert!(bucket.replace_node_addresses(&PeerId::from_bytes([1u8; 32]), typed));
+
+        let node = bucket.find_node(&PeerId::from_bytes([1u8; 32])).unwrap();
+        assert_eq!(node.addresses, vec![private]);
+        assert_eq!(node.address_types, vec![AddressType::Lan]);
+    }
+
+    #[test]
     fn replace_addresses_missing_peer_returns_false() {
         let k = 8;
         let mut bucket = KBucket::new(k);
@@ -2681,7 +2746,9 @@ mod tests {
         let typed: Vec<(MultiAddr, AddressType)> = (0..12)
             .map(|i| {
                 (
-                    format!("/ip4/10.0.0.{}/udp/9000/quic", i).parse().unwrap(),
+                    format!("/ip4/203.0.113.{}/udp/9000/quic", i + 1)
+                        .parse()
+                        .unwrap(),
                     AddressType::Direct,
                 )
             })
@@ -3193,7 +3260,11 @@ mod tests {
         // `merge_typed_address`, and the per-IP-family cap keeps exactly
         // one Direct per family.
         let addresses: Vec<MultiAddr> = (1..=MAX_ADDRESSES_PER_NODE + 4)
-            .map(|i| format!("/ip4/10.0.0.{}/udp/9000/quic", i).parse().unwrap())
+            .map(|i| {
+                format!("/ip4/203.0.113.{}/udp/9000/quic", i)
+                    .parse()
+                    .unwrap()
+            })
             .collect();
         let address_types = vec![AddressType::Direct; addresses.len()];
         let replacement = NodeInfo {
@@ -4473,33 +4544,55 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn address_type_priority_is_relay_direct_unverified_natted() {
+    fn address_type_priority_is_relay_direct_unverified_lan() {
         assert!(AddressType::Relay.priority() < AddressType::Direct.priority());
         assert!(AddressType::Direct.priority() < AddressType::Unverified.priority());
-        assert!(AddressType::Unverified.priority() < AddressType::NATted.priority());
+        assert!(AddressType::Unverified.priority() < AddressType::Lan.priority());
     }
 
     #[test]
-    fn merge_same_family_keeps_relay_and_best_non_relay() {
-        // Under the per-IP-family cap: at most 1 Relay + 1 of {Direct,
-        // Unverified, NATted} per family. Direct is the strongest
-        // non-Relay tier, so when all four tiers are fed into the same
-        // IPv4 family, only Relay+Direct survive.
-        let mut node = make_node(1, "/ip4/10.0.0.1/udp/9000/quic");
-        let direct = node.addresses[0].clone();
-        let relay: MultiAddr = "/ip4/10.0.0.2/udp/9000/quic".parse().unwrap();
-        let unverified: MultiAddr = "/ip4/10.0.0.3/udp/9000/quic".parse().unwrap();
-        let natted: MultiAddr = "/ip4/10.0.0.4/udp/9000/quic".parse().unwrap();
+    fn address_type_accepts_legacy_natted_name_as_lan() {
+        let decoded: AddressType = serde_json::from_str("\"NATted\"").unwrap();
+        assert_eq!(decoded, AddressType::Lan);
+    }
 
-        node.merge_typed_address(natted, AddressType::NATted);
+    #[test]
+    fn local_scope_address_type_is_canonicalized_to_lan() {
+        let mut node = NodeInfo {
+            id: PeerId::from_bytes([1u8; 32]),
+            addresses: Vec::new(),
+            address_types: Vec::new(),
+            last_seen: AtomicInstant::now(),
+        };
+        let private: MultiAddr = "/ip4/192.168.1.10/udp/9000/quic".parse().unwrap();
+
+        node.merge_typed_address(private.clone(), AddressType::Direct);
+        assert_eq!(node.addresses, vec![private]);
+        assert_eq!(node.address_types, vec![AddressType::Lan]);
+        assert_eq!(node.address_type_at(0), AddressType::Lan);
+    }
+
+    #[test]
+    fn merge_same_family_keeps_relay_best_wan_and_lan() {
+        // Under the per-IP-family cap: at most 1 Relay + 1 WAN
+        // non-Relay (Direct/Unverified) + 1 Lan per family. Direct is the
+        // strongest WAN tier, but it must not evict the local path that
+        // same-WAN peers can use.
+        let mut node = make_node(1, "/ip4/203.0.113.1/udp/9000/quic");
+        let direct = node.addresses[0].clone();
+        let relay: MultiAddr = "/ip4/198.51.100.1/udp/9000/quic".parse().unwrap();
+        let unverified: MultiAddr = "/ip4/203.0.113.2/udp/9000/quic".parse().unwrap();
+        let lan: MultiAddr = "/ip4/192.168.1.4/udp/9000/quic".parse().unwrap();
+
+        node.merge_typed_address(lan.clone(), AddressType::Lan);
         node.merge_typed_address(unverified, AddressType::Unverified);
         node.merge_typed_address(relay.clone(), AddressType::Relay);
 
         assert_eq!(
             node.address_types,
-            vec![AddressType::Relay, AddressType::Direct]
+            vec![AddressType::Relay, AddressType::Direct, AddressType::Lan]
         );
-        assert_eq!(node.addresses, vec![relay, direct]);
+        assert_eq!(node.addresses, vec![relay, direct, lan]);
     }
 
     #[test]
@@ -4573,23 +4666,29 @@ mod tests {
     }
 
     #[test]
-    fn cap_direct_dominates_natted_same_family() {
+    fn cap_direct_preserves_lan_same_family() {
         let mut node = node_with(vec![
             ("/ip4/1.1.1.1/udp/9000/quic", AddressType::Direct),
-            ("/ip4/2.2.2.2/udp/9000/quic", AddressType::NATted),
+            ("/ip4/192.168.1.20/udp/9000/quic", AddressType::Lan),
         ]);
         node.enforce_per_ip_family_cap();
-        assert_eq!(node.address_types, vec![AddressType::Direct]);
+        assert_eq!(
+            node.address_types,
+            vec![AddressType::Direct, AddressType::Lan]
+        );
     }
 
     #[test]
-    fn cap_unverified_dominates_natted_same_family() {
+    fn cap_unverified_preserves_lan_same_family() {
         let mut node = node_with(vec![
             ("/ip4/2.2.2.2/udp/9000/quic", AddressType::Unverified),
-            ("/ip4/3.3.3.3/udp/9000/quic", AddressType::NATted),
+            ("/ip4/192.168.1.30/udp/9000/quic", AddressType::Lan),
         ]);
         node.enforce_per_ip_family_cap();
-        assert_eq!(node.address_types, vec![AddressType::Unverified]);
+        assert_eq!(
+            node.address_types,
+            vec![AddressType::Unverified, AddressType::Lan]
+        );
     }
 
     #[test]
@@ -4619,39 +4718,51 @@ mod tests {
     }
 
     #[test]
-    fn cap_merge_direct_then_natted_drops_natted() {
+    fn cap_merge_direct_then_lan_keeps_both() {
         let mut node = node_with(vec![("/ip4/1.1.1.1/udp/9000/quic", AddressType::Direct)]);
         node.merge_typed_address(
-            "/ip4/2.2.2.2/udp/9000/quic".parse().unwrap(),
-            AddressType::NATted,
+            "/ip4/192.168.1.20/udp/9000/quic".parse().unwrap(),
+            AddressType::Lan,
         );
-        assert_eq!(node.address_types, vec![AddressType::Direct]);
+        assert_eq!(
+            node.address_types,
+            vec![AddressType::Direct, AddressType::Lan]
+        );
     }
 
     #[test]
-    fn cap_merge_natted_then_direct_drops_natted() {
-        let mut node = node_with(vec![("/ip4/2.2.2.2/udp/9000/quic", AddressType::NATted)]);
+    fn cap_merge_lan_then_direct_keeps_both() {
+        let mut node = node_with(vec![("/ip4/192.168.1.20/udp/9000/quic", AddressType::Lan)]);
         node.merge_typed_address(
             "/ip4/1.1.1.1/udp/9000/quic".parse().unwrap(),
             AddressType::Direct,
         );
-        assert_eq!(node.address_types, vec![AddressType::Direct]);
+        assert_eq!(
+            node.address_types,
+            vec![AddressType::Direct, AddressType::Lan]
+        );
         assert_eq!(
             node.addresses,
-            vec!["/ip4/1.1.1.1/udp/9000/quic".parse().unwrap()]
+            vec![
+                "/ip4/1.1.1.1/udp/9000/quic".parse().unwrap(),
+                "/ip4/192.168.1.20/udp/9000/quic".parse().unwrap()
+            ]
         );
     }
 
     #[test]
     fn cap_newest_relay_replaces_stale_same_family_relay() {
-        let mut node = node_with(vec![("/ip4/10.0.0.1/udp/9000/quic", AddressType::Relay)]);
+        let mut node = node_with(vec![(
+            "/ip4/198.51.100.1/udp/9000/quic",
+            AddressType::Relay,
+        )]);
         node.merge_typed_address(
-            "/ip4/10.0.0.2/udp/9000/quic".parse().unwrap(),
+            "/ip4/198.51.100.2/udp/9000/quic".parse().unwrap(),
             AddressType::Relay,
         );
         assert_eq!(
             node.addresses,
-            vec!["/ip4/10.0.0.2/udp/9000/quic".parse().unwrap()]
+            vec!["/ip4/198.51.100.2/udp/9000/quic".parse().unwrap()]
         );
         assert_eq!(node.address_types, vec![AddressType::Relay]);
     }
@@ -4660,7 +4771,7 @@ mod tests {
     fn cap_newest_relay_preserves_different_family_relay() {
         let mut node = node_with(vec![("/ip6/2001:db8::1/udp/9000/quic", AddressType::Relay)]);
         node.merge_typed_address(
-            "/ip4/10.0.0.1/udp/9000/quic".parse().unwrap(),
+            "/ip4/198.51.100.1/udp/9000/quic".parse().unwrap(),
             AddressType::Relay,
         );
         let mut relays: Vec<_> = node
@@ -4674,7 +4785,7 @@ mod tests {
         assert_eq!(
             relays,
             vec![
-                "/ip4/10.0.0.1/udp/9000/quic".to_string(),
+                "/ip4/198.51.100.1/udp/9000/quic".to_string(),
                 "/ip6/2001:db8::1/udp/9000/quic".to_string(),
             ]
         );
@@ -4698,8 +4809,8 @@ mod tests {
         let node = NodeInfo {
             id: PeerId::from_bytes([1u8; 32]),
             addresses: vec![
-                "/ip4/10.0.0.1/udp/9000/quic".parse().unwrap(),
-                "/ip4/10.0.0.2/udp/9000/quic".parse().unwrap(),
+                "/ip4/203.0.113.10/udp/9000/quic".parse().unwrap(),
+                "/ip4/203.0.113.11/udp/9000/quic".parse().unwrap(),
             ],
             address_types: vec![], // legacy: no tags at all
             last_seen: AtomicInstant::now(),
@@ -4710,7 +4821,7 @@ mod tests {
 
     #[test]
     fn merge_typed_address_upgrade_only_promotes_unverified_to_direct() {
-        let addr: MultiAddr = "/ip4/10.0.0.1/udp/9000/quic".parse().unwrap();
+        let addr: MultiAddr = "/ip4/203.0.113.10/udp/9000/quic".parse().unwrap();
         let mut node = NodeInfo {
             id: PeerId::from_bytes([1u8; 32]),
             addresses: vec![addr.clone()],
@@ -4726,7 +4837,7 @@ mod tests {
     fn merge_typed_address_upgrade_only_refuses_to_demote() {
         // Existing Relay must not be demoted by incoming Unverified/Direct
         // arriving out of order via FIND_NODE gossip.
-        let addr: MultiAddr = "/ip4/10.0.0.1/udp/9000/quic".parse().unwrap();
+        let addr: MultiAddr = "/ip4/203.0.113.10/udp/9000/quic".parse().unwrap();
         for incoming in [AddressType::Unverified, AddressType::Direct] {
             let mut node = NodeInfo {
                 id: PeerId::from_bytes([1u8; 32]),
@@ -4746,7 +4857,7 @@ mod tests {
         // A new address is always added, regardless of tag — this is how a
         // peer XOR-far from every PublishAddressSet source learns about
         // its neighbours' Relay/Direct addresses via gossip.
-        let existing: MultiAddr = "/ip4/10.0.0.1/udp/9000/quic".parse().unwrap();
+        let existing: MultiAddr = "/ip4/203.0.113.10/udp/9000/quic".parse().unwrap();
         let new_relay: MultiAddr = "/ip4/192.0.2.7/udp/44100/quic".parse().unwrap();
         let mut node = NodeInfo {
             id: PeerId::from_bytes([1u8; 32]),
@@ -4764,7 +4875,7 @@ mod tests {
 
     #[test]
     fn merge_typed_address_upgrade_only_idempotent_on_same_tag() {
-        let addr: MultiAddr = "/ip4/10.0.0.1/udp/9000/quic".parse().unwrap();
+        let addr: MultiAddr = "/ip4/203.0.113.10/udp/9000/quic".parse().unwrap();
         let mut node = NodeInfo {
             id: PeerId::from_bytes([1u8; 32]),
             addresses: vec![addr.clone()],

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -3336,8 +3336,7 @@ impl DhtNetworkManager {
         wan.sort_by_key(|(index, _, _)| *index);
 
         let has_wan_or_relay = relay.is_some() || !wan.is_empty();
-        let lan_is_reachable = lan.iter().any(|(_, score, _, _)| *score <= 1);
-        let prefer_lan = !lan.is_empty() && (lan_is_reachable || context.peer_shares_wan(typed));
+        let prefer_lan = !lan.is_empty() && context.peer_shares_wan(typed);
 
         if prefer_lan {
             out.extend(lan.iter().map(|(_, _, addr, ty)| (addr.clone(), *ty)));
@@ -5580,7 +5579,7 @@ mod tests {
     }
 
     #[test]
-    fn select_dial_candidates_prefers_lan_for_same_lan_prefix() {
+    fn select_dial_candidates_does_not_prefer_lan_for_private_prefix_only() {
         let addrs = typed(vec![
             ("/ip4/198.51.100.1/udp/9000/quic", AddressType::Relay),
             ("/ip4/192.168.1.30/udp/9001/quic", AddressType::Lan),
@@ -5592,9 +5591,8 @@ mod tests {
         );
 
         let picks = DhtNetworkManager::select_dial_candidates_with_context(&addrs, &context);
-        assert_eq!(picks.len(), 2);
-        assert_eq!(picks[0].1, AddressType::Lan);
-        assert_eq!(picks[1].1, AddressType::Relay);
+        assert_eq!(picks.len(), 1);
+        assert_eq!(picks[0].1, AddressType::Relay);
     }
 
     #[test]

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -259,6 +259,9 @@ pub struct DHTNode {
     /// peers returned by `find_closest_nodes_local()`.
     #[serde(default)]
     pub address_types: Vec<AddressType>,
+    /// Optional per-record metadata. In current DHT responses this may carry
+    /// a marker-encoded `PublishAddressSet` sequence so newer nodes can prefer
+    /// fresher address records without changing the wire shape for older nodes.
     pub distance: Option<Vec<u8>>,
     pub reliability: f64,
 }
@@ -360,7 +363,37 @@ impl DHTNode {
         if other.reliability > self.reliability {
             self.reliability = other.reliability;
         }
+        let publish_seq = dht_node_publish_seq(self).max(dht_node_publish_seq(&other));
+        if publish_seq != 0 {
+            self.distance = encode_publish_seq_distance(publish_seq);
+        }
     }
+}
+
+const PUBLISH_SEQ_DISTANCE_MARKER: &[u8; 8] = b"PUBSEQ01";
+
+fn encode_publish_seq_distance(seq: u64) -> Option<Vec<u8>> {
+    if seq == 0 {
+        return None;
+    }
+    let mut encoded = Vec::with_capacity(PUBLISH_SEQ_DISTANCE_MARKER.len() + 8);
+    encoded.extend_from_slice(PUBLISH_SEQ_DISTANCE_MARKER);
+    encoded.extend_from_slice(&seq.to_be_bytes());
+    Some(encoded)
+}
+
+fn dht_node_publish_seq(node: &DHTNode) -> u64 {
+    let Some(distance) = node.distance.as_deref() else {
+        return 0;
+    };
+    if distance.len() != PUBLISH_SEQ_DISTANCE_MARKER.len() + 8
+        || &distance[..PUBLISH_SEQ_DISTANCE_MARKER.len()] != PUBLISH_SEQ_DISTANCE_MARKER
+    {
+        return 0;
+    }
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&distance[PUBLISH_SEQ_DISTANCE_MARKER.len()..]);
+    u64::from_be_bytes(bytes)
 }
 
 /// Alias for serialization compatibility
@@ -990,12 +1023,16 @@ fn report_signature(node: &DHTNode) -> Vec<(MultiAddr, u8)> {
 ///
 ///   1. **Self-report** — if the subject peer itself responded, its
 ///      report is authoritative.
-///   2. **Quorum** — among the top `QUORUM_TOP_N` closest-XOR
+///   2. **Newest publish** — any report carrying the highest non-zero
+///      `PublishAddressSet` sequence wins. That sequence originated from
+///      the subject peer's authenticated publish path and lets a newer
+///      direct-only or re-relayed record displace stale relay gossip.
+///   3. **Quorum** — among the top `QUORUM_TOP_N` closest-XOR
 ///      responders, if `QUORUM_THRESHOLD`+ agree on the address set
 ///      (same [`report_signature`]), their consensus wins. One close
 ///      adversary cannot poison the result when 2+ honest neighbours
 ///      agree.
-///   3. **Fallback** — the closest-XOR responder wins. On an XOR tie
+///   4. **Fallback** — the closest-XOR responder wins. On an XOR tie
 ///      the one whose best tag tier is stronger breaks it.
 ///
 /// Returns `None` only when `reports` is empty.
@@ -1027,7 +1064,23 @@ fn compute_winner<'a>(
         .collect();
     by_dist.sort_by(|a, b| a.2.cmp(&b.2).then(a.3.cmp(&b.3)));
 
-    // Rule 2: quorum among top-N.
+    // Rule 2: newest authoritative publish sequence wins. This keeps stale
+    // third-party relay records from beating a newer direct-only or re-relayed
+    // self-record during an iterative lookup.
+    if let Some((rid, node, _, _)) = by_dist
+        .iter()
+        .filter(|(_, node, _, _)| dht_node_publish_seq(node) != 0)
+        .max_by(|a, b| {
+            dht_node_publish_seq(a.1)
+                .cmp(&dht_node_publish_seq(b.1))
+                .then_with(|| b.2.cmp(&a.2))
+                .then_with(|| b.3.cmp(&a.3))
+        })
+    {
+        return Some((*rid, *node));
+    }
+
+    // Rule 3: quorum among top-N.
     let top_n = &by_dist[..by_dist.len().min(QUORUM_TOP_N)];
     if top_n.len() >= QUORUM_THRESHOLD {
         let mut buckets: HashMap<Vec<(MultiAddr, u8)>, Vec<PeerId>> = HashMap::new();
@@ -1051,7 +1104,7 @@ fn compute_winner<'a>(
         }
     }
 
-    // Rule 3: fallback — closest-XOR (then strongest-tier) responder.
+    // Rule 4: fallback — closest-XOR (then strongest-tier) responder.
     let (rid, node, _, _) = by_dist.first()?;
     Some((*rid, *node))
 }
@@ -1632,15 +1685,18 @@ impl DhtNetworkManager {
         );
 
         let dht_guard = self.dht.read().await;
-        match dht_guard.find_nodes(&DhtKey::from_bytes(*key), count).await {
+        match dht_guard
+            .find_nodes_with_publish_seq(&DhtKey::from_bytes(*key), count)
+            .await
+        {
             Ok(nodes) => nodes
                 .into_iter()
-                .filter(|node| !self.is_local_peer_id(&node.id))
-                .map(|node| DHTNode {
+                .filter(|(node, _)| !self.is_local_peer_id(&node.id))
+                .map(|(node, publish_seq)| DHTNode {
                     peer_id: node.id,
                     address_types: node.address_types,
                     addresses: node.addresses,
-                    distance: None,
+                    distance: encode_publish_seq_distance(publish_seq),
                     reliability: SELF_RELIABILITY_SCORE,
                 })
                 .collect(),
@@ -3924,15 +3980,20 @@ impl DhtNetworkManager {
     }
 
     /// Ingest a peer's typed address set from a FIND_NODE gossip response
-    /// into the local routing table, upgrading tags only.
+    /// into the local routing table.
     ///
-    /// For each `(addr, ty)` pair in `node`, if the peer is already in the
-    /// routing table, either add the new address or promote the existing
-    /// entry — but never demote a higher-priority tag already held (which
-    /// typically came from the peer's own `PublishAddressSet` or from our
-    /// own classifier). Peers absent from the routing table are left alone;
-    /// we don't accept *new* peer identities from untrusted gossip, only
-    /// additional information about peers we already know.
+    /// If the report carries a marker-encoded publish sequence in its existing
+    /// `distance` metadata slot, it is a propagated `PublishAddressSet` view
+    /// and the sequence guard decides whether to replace our local record
+    /// wholesale. Older sequence-bearing reports are ignored instead of being
+    /// merged, which prevents stale relay addresses from being reintroduced
+    /// after the publisher has republished a newer direct-only or re-relayed
+    /// set. Legacy reports without a sequence keep the old upgrade-only
+    /// behavior: add a new address or promote the existing entry, but never
+    /// demote a higher-priority tag already held. Peers absent from the routing
+    /// table are left alone; we don't accept *new* peer identities from
+    /// untrusted gossip, only additional information about peers we already
+    /// know.
     ///
     /// This closes the hole where a NAT'd peer XOR-far from every open
     /// node could never land in anyone's K-closest for `PublishAddressSet`
@@ -3951,6 +4012,17 @@ impl DhtNetworkManager {
     /// authenticated neighbour keeps mentioning them.
     pub async fn merge_gossiped_typed_addresses(&self, node: &DHTNode) {
         let dht = self.dht.read().await;
+        let publish_seq = dht_node_publish_seq(node);
+        if publish_seq != 0 {
+            let _ = dht
+                .replace_node_addresses_from_gossip(
+                    &node.peer_id,
+                    node.typed_addresses(),
+                    publish_seq,
+                )
+                .await;
+            return;
+        }
         for (addr, ty) in node.typed_addresses() {
             dht.merge_typed_address_upgrade_only(&node.peer_id, &addr, ty)
                 .await;
@@ -4007,11 +4079,11 @@ impl DhtNetworkManager {
     /// collecting them is inexpensive.
     pub async fn routing_table_peers(&self) -> Vec<DHTNode> {
         let dht_guard = self.dht.read().await;
-        let nodes = dht_guard.all_nodes().await;
+        let nodes = dht_guard.all_nodes_with_publish_seq().await;
         drop(dht_guard);
         nodes
             .into_iter()
-            .map(|node| {
+            .map(|(node, publish_seq)| {
                 let reliability = self
                     .trust_engine
                     .as_ref()
@@ -4021,7 +4093,7 @@ impl DhtNetworkManager {
                     peer_id: node.id,
                     address_types: node.address_types,
                     addresses: node.addresses,
-                    distance: None,
+                    distance: encode_publish_seq_distance(publish_seq),
                     reliability,
                 }
             })
@@ -4368,8 +4440,8 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // FIND_NODE aggregator selection rule — closest-XOR-responder wins with
-    // self-report lock-in and tier tie-break.
+    // FIND_NODE aggregator selection rule — self-report and publish-sequence
+    // freshness win before quorum / closest-XOR fallback.
     // -----------------------------------------------------------------------
 
     /// Build a synthetic PeerId with `byte` in position 0 and zeros
@@ -4383,11 +4455,20 @@ mod tests {
 
     /// Minimal synthetic `DHTNode` with a single address at the given tier.
     fn report(subject_byte: u8, addr_str: &str, ty: AddressType) -> DHTNode {
+        report_with_seq(subject_byte, addr_str, ty, 0)
+    }
+
+    fn report_with_seq(
+        subject_byte: u8,
+        addr_str: &str,
+        ty: AddressType,
+        publish_seq: u64,
+    ) -> DHTNode {
         DHTNode {
             peer_id: peer_with_leading(subject_byte),
             addresses: vec![addr_str.parse().unwrap()],
             address_types: vec![ty],
-            distance: None,
+            distance: encode_publish_seq_distance(publish_seq),
             reliability: 1.0,
         }
     }
@@ -4460,6 +4541,36 @@ mod tests {
         assert_eq!(
             winner_node.addresses[0],
             consensus_addr.parse::<MultiAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn winner_newer_publish_seq_beats_closer_stale_report() {
+        // The stale relay report is XOR-closer to the subject, but a newer
+        // PublishAddressSet sequence must win so lookups stop dialing dead
+        // relay allocations after the publisher republishes/rebinds.
+        let subject = peer_with_leading(0xF0);
+        let stale_responder = peer_with_leading(0xF1);
+        let fresh_responder = peer_with_leading(0xFA);
+
+        let stale_relay = "/ip4/198.51.100.7/udp/46973/quic";
+        let fresh_relay = "/ip4/203.0.113.9/udp/60488/quic";
+
+        let mut reports = SubjectReports::new();
+        reports.insert(
+            stale_responder,
+            report_with_seq(0xF0, stale_relay, AddressType::Relay, 10),
+        );
+        reports.insert(
+            fresh_responder,
+            report_with_seq(0xF0, fresh_relay, AddressType::Relay, 20),
+        );
+
+        let (winner_rid, winner_node) = compute_winner(&subject, &reports).unwrap();
+        assert_eq!(winner_rid, fresh_responder);
+        assert_eq!(
+            winner_node.addresses[0],
+            fresh_relay.parse::<MultiAddr>().unwrap()
         );
     }
 

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -915,7 +915,7 @@ struct DhtOperationContext {
     contacted_nodes: Vec<PeerId>,
     /// Oneshot sender for delivering the response
     /// None if response already sent (channel consumed)
-    response_tx: Option<oneshot::Sender<(PeerId, DhtNetworkResult)>>,
+    response_tx: Option<oneshot::Sender<DhtResponseEnvelope>>,
 }
 
 impl std::fmt::Debug for DhtOperationContext {
@@ -929,6 +929,12 @@ impl std::fmt::Debug for DhtOperationContext {
             .field("response_tx", &self.response_tx.is_some())
             .finish()
     }
+}
+
+#[derive(Debug)]
+struct DhtResponseEnvelope {
+    result: DhtNetworkResult,
+    transport_source: Option<MultiAddr>,
 }
 
 /// DHT network events
@@ -1654,16 +1660,29 @@ impl DhtNetworkManager {
         let mut to_dial: Vec<(PeerId, Vec<(MultiAddr, AddressType)>)> = Vec::new();
         for peer_id in peers {
             let op = DhtNetworkOperation::FindNode { key };
-            match self.send_dht_request(peer_id, op, None).await {
-                Ok(DhtNetworkResult::NodesFound { nodes, .. }) => {
+            match self
+                .send_dht_request_with_response_context(peer_id, op, None)
+                .await
+            {
+                Ok(DhtResponseEnvelope {
+                    result: DhtNetworkResult::NodesFound { nodes, .. },
+                    transport_source,
+                    ..
+                }) => {
                     for node in &nodes {
-                        let typed = node.typed_addresses();
+                        let trusted_node = self
+                            .gossiped_node_with_trusted_addresses(
+                                node.clone(),
+                                transport_source.as_ref(),
+                            )
+                            .await;
+                        let typed = trusted_node.typed_addresses();
                         let dialable_count =
                             typed.iter().filter(|(a, _)| Self::is_dialable(a)).count();
                         debug!(
                             "DHT bootstrap: peer={} num_addresses={} dialable={}",
-                            node.peer_id.to_hex(),
-                            node.addresses.len(),
+                            trusted_node.peer_id.to_hex(),
+                            trusted_node.addresses.len(),
                             dialable_count
                         );
                         // Ingest the responder's typed view of this peer so
@@ -1672,9 +1691,10 @@ impl DhtNetworkManager {
                         // landing in our own K-closest PublishAddressSet
                         // fan-out. No-op when the peer isn't already in the
                         // routing table; upgrade-only on existing entries.
-                        self.merge_gossiped_typed_addresses(node).await;
-                        if seen.insert(node.peer_id) && dialable_count > 0 {
-                            to_dial.push((node.peer_id, typed));
+                        self.merge_trusted_gossiped_typed_addresses(&trusted_node)
+                            .await;
+                        if seen.insert(trusted_node.peer_id) && dialable_count > 0 {
+                            to_dial.push((trusted_node.peer_id, typed));
                         }
                     }
                 }
@@ -2059,7 +2079,11 @@ impl DhtNetworkManager {
 
             for (peer_id, result) in results {
                 match result {
-                    Ok(DhtNetworkResult::NodesFound { mut nodes, .. }) => {
+                    Ok(DhtResponseEnvelope {
+                        result: DhtNetworkResult::NodesFound { mut nodes, .. },
+                        transport_source,
+                        ..
+                    }) => {
                         peer_states.mark_succeeded(peer_id);
                         // Add successful node to best_nodes
                         if let Some(queried_node) = batch.iter().find(|n| n.peer_id == peer_id) {
@@ -2072,6 +2096,12 @@ impl DhtNetworkManager {
                         nodes.sort_by(|a, b| Self::compare_node_distance(a, b, key));
                         nodes.truncate(self.k_value());
                         for node in nodes {
+                            let node = self
+                                .gossiped_node_with_trusted_addresses(
+                                    node,
+                                    transport_source.as_ref(),
+                                )
+                                .await;
                             if !peer_states.is_contactable(&node.peer_id)
                                 || self.is_local_peer_id(&node.peer_id)
                             {
@@ -2094,7 +2124,7 @@ impl DhtNetworkManager {
                             // never learns which of its neighbours expose
                             // a dialable Direct address and fails relay
                             // acquisition.
-                            self.merge_gossiped_typed_addresses(&node).await;
+                            self.merge_trusted_gossiped_typed_addresses(&node).await;
                             let subject_id = node.peer_id;
                             let dist = subject_id.distance(&target_key);
                             let cand_key = (dist, subject_id);
@@ -2145,7 +2175,10 @@ impl DhtNetworkManager {
                             candidates.insert(cand_key, winner_node);
                         }
                     }
-                    Ok(DhtNetworkResult::PeerRejected) => {
+                    Ok(DhtResponseEnvelope {
+                        result: DhtNetworkResult::PeerRejected,
+                        ..
+                    }) => {
                         peer_states.mark_failed(peer_id);
                         // Remote peer rejected us (e.g. older node with blocking) —
                         // remove them from our routing table (no point retrying) but
@@ -2243,7 +2276,7 @@ impl DhtNetworkManager {
         typed: Vec<(MultiAddr, AddressType)>,
         key: Key,
         failure_rx: broadcast::Receiver<PeerId>,
-    ) -> (PeerId, Result<DhtNetworkResult>) {
+    ) -> (PeerId, Result<DhtResponseEnvelope>) {
         let request = async {
             // Pass the same typed candidate list to both ensure_peer_channel
             // and send_dht_request so the request path doesn't pay a redundant
@@ -2255,7 +2288,7 @@ impl DhtNetworkManager {
             // the peer-dial coordinator, so concurrent iterative lookups that
             // happen to batch the same peer join this dial rather than racing it.
             self.ensure_peer_channel(&peer_id, &typed).await?;
-            self.send_dht_request(
+            self.send_dht_request_with_response_context(
                 &peer_id,
                 DhtNetworkOperation::FindNode { key },
                 Some(&typed),
@@ -2329,9 +2362,11 @@ impl DhtNetworkManager {
     /// queries up to `ITERATION_GRACE_TIMEOUT_SECS` to finish before giving
     /// up on them and returning whatever has arrived. Any still-pending
     /// futures are dropped (and cancelled) when the stream is returned.
-    async fn collect_iteration_results<S>(mut stream: S) -> Vec<(PeerId, Result<DhtNetworkResult>)>
+    async fn collect_iteration_results<S>(
+        mut stream: S,
+    ) -> Vec<(PeerId, Result<DhtResponseEnvelope>)>
     where
-        S: futures::Stream<Item = (PeerId, Result<DhtNetworkResult>)> + Unpin,
+        S: futures::Stream<Item = (PeerId, Result<DhtResponseEnvelope>)> + Unpin,
     {
         let mut results = Vec::new();
 
@@ -2618,6 +2653,45 @@ impl DhtNetworkManager {
         let external = self.transport.non_relay_external_addresses();
         let listen = self.transport.listen_addrs().await;
         DialAddressContext::from_parts(external, listen, self.config.node_config.allow_loopback)
+    }
+
+    async fn filter_lan_addresses_for_store(
+        &self,
+        typed_addresses: Vec<(MultiAddr, AddressType)>,
+        transport_source: Option<&MultiAddr>,
+    ) -> Vec<(MultiAddr, AddressType)> {
+        let context = self.local_dial_address_context().await;
+        Self::filter_lan_addresses_for_store_with_context(
+            typed_addresses,
+            transport_source,
+            &context,
+        )
+    }
+
+    fn filter_lan_addresses_for_store_with_context(
+        typed_addresses: Vec<(MultiAddr, AddressType)>,
+        transport_source: Option<&MultiAddr>,
+        context: &DialAddressContext,
+    ) -> Vec<(MultiAddr, AddressType)> {
+        let canonical: Vec<_> = typed_addresses
+            .into_iter()
+            .map(|(addr, ty)| {
+                let ty = AddressType::for_advertised_address(&addr, ty);
+                (addr, ty)
+            })
+            .collect();
+
+        let arrived_over_lan = transport_source
+            .and_then(MultiAddr::ip)
+            .is_some_and(is_lan_ip);
+        if arrived_over_lan || context.peer_shares_wan(&canonical) {
+            return canonical;
+        }
+
+        canonical
+            .into_iter()
+            .filter(|(_, ty)| *ty != AddressType::Lan)
+            .collect()
     }
 
     async fn contextual_dial_plan(
@@ -2933,6 +3007,18 @@ impl DhtNetworkManager {
         operation: DhtNetworkOperation,
         candidates: Option<&[(MultiAddr, AddressType)]>,
     ) -> Result<DhtNetworkResult> {
+        Ok(self
+            .send_dht_request_with_response_context(peer_id, operation, candidates)
+            .await?
+            .result)
+    }
+
+    async fn send_dht_request_with_response_context(
+        &self,
+        peer_id: &PeerId,
+        operation: DhtNetworkOperation,
+        candidates: Option<&[(MultiAddr, AddressType)]>,
+    ) -> Result<DhtResponseEnvelope> {
         // Sweep stale entries left by dropped futures before adding a new one
         self.sweep_expired_operations();
 
@@ -3055,7 +3141,7 @@ impl DhtNetworkManager {
                         "[STEP 6] {} <- {}: Got response: {:?}",
                         self.config.peer_id.to_hex(),
                         peer_id.to_hex(),
-                        std::mem::discriminant(r)
+                        std::mem::discriminant(&r.result)
                     ),
                     Err(e) => warn!(
                         "[STEP 6 FAILED] {} <- {}: Response error: {}",
@@ -3366,14 +3452,14 @@ impl DhtNetworkManager {
     async fn wait_for_response(
         &self,
         _message_id: &str,
-        response_rx: oneshot::Receiver<(PeerId, DhtNetworkResult)>,
+        response_rx: oneshot::Receiver<DhtResponseEnvelope>,
         _peer_id: &PeerId,
-    ) -> Result<DhtNetworkResult> {
+    ) -> Result<DhtResponseEnvelope> {
         let response_timeout = self.config.request_timeout;
 
         // Wait for response with timeout - no polling, no TOCTOU race
         match tokio::time::timeout(response_timeout, response_rx).await {
-            Ok(Ok((_source, result))) => Ok(result),
+            Ok(Ok(response)) => Ok(response),
             Ok(Err(_recv_error)) => {
                 // Channel closed without response (sender dropped).
                 Err(P2PError::Network(NetworkError::ProtocolError(
@@ -3389,6 +3475,7 @@ impl DhtNetworkManager {
         &self,
         data: &[u8],
         sender: &PeerId,
+        transport_source: Option<&MultiAddr>,
     ) -> Result<Option<Vec<u8>>> {
         // SEC: Reject oversized messages before deserialization to prevent memory exhaustion
         if data.len() > MAX_MESSAGE_SIZE {
@@ -3428,7 +3515,9 @@ impl DhtNetworkManager {
                     message.payload,
                     sender
                 );
-                let result = self.handle_dht_request(&message, sender).await?;
+                let result = self
+                    .handle_dht_request(&message, sender, transport_source)
+                    .await?;
                 debug!(
                     "[STEP 4] {}: Sending response {:?} back to {} (msg_id: {})",
                     self.config.peer_id.to_hex(),
@@ -3448,7 +3537,8 @@ impl DhtNetworkManager {
                     sender,
                     message.message_id
                 );
-                self.handle_dht_response(&message, sender).await?;
+                self.handle_dht_response(&message, sender, transport_source)
+                    .await?;
                 Ok(None)
             }
             DhtMessageType::Broadcast => {
@@ -3471,6 +3561,7 @@ impl DhtNetworkManager {
         &self,
         message: &DhtNetworkMessage,
         authenticated_sender: &PeerId,
+        transport_source: Option<&MultiAddr>,
     ) -> Result<DhtNetworkResult> {
         match &message.payload {
             DhtNetworkOperation::FindNode { key } => {
@@ -3508,8 +3599,21 @@ impl DhtNetworkManager {
                     seq,
                     addresses.len()
                 );
+                let filtered_addresses = self
+                    .filter_lan_addresses_for_store(addresses.clone(), transport_source)
+                    .await;
+                let stripped = addresses.len().saturating_sub(filtered_addresses.len());
+                if stripped > 0 {
+                    debug!(
+                        peer = %authenticated_sender.to_hex(),
+                        seq,
+                        stripped,
+                        kept = filtered_addresses.len(),
+                        "stripped untrusted LAN address(es) from published address set",
+                    );
+                }
                 let dht = self.dht.read().await;
-                dht.replace_node_addresses(authenticated_sender, addresses.clone(), *seq)
+                dht.replace_node_addresses(authenticated_sender, filtered_addresses, *seq)
                     .await;
                 Ok(DhtNetworkResult::PublishAddressAck)
             }
@@ -3540,6 +3644,7 @@ impl DhtNetworkManager {
         &self,
         message: &DhtNetworkMessage,
         sender: &PeerId,
+        transport_source: Option<&MultiAddr>,
     ) -> Result<()> {
         let message_id = &message.message_id;
         debug!("Handling DHT response for message_id: {message_id}");
@@ -3596,9 +3701,11 @@ impl DhtNetworkManager {
                     self.config.peer_id.to_hex(),
                     message_id
                 );
-                // Send the transport-authenticated sender identity, not the
-                // self-reported message.source which could be spoofed.
-                if tx.send((sender_app_id, result)).is_err() {
+                let response = DhtResponseEnvelope {
+                    result,
+                    transport_source: transport_source.cloned(),
+                };
+                if tx.send(response).is_err() {
                     warn!(
                         "[STEP 5a FAILED] {}: Response channel closed for msg_id {} (receiver timed out)",
                         self.config.peer_id.to_hex(),
@@ -3965,6 +4072,7 @@ impl DhtNetworkManager {
                                 crate::network::P2PEvent::Message {
                                     topic,
                                     source,
+                                    transport_source,
                                     data,
                                 } => {
                                     trace!(
@@ -3997,7 +4105,11 @@ impl DhtNetworkManager {
                                             // This ensures permits are released even if a handler gets stuck
                                             match tokio::time::timeout(
                                                 REQUEST_TIMEOUT,
-                                                manager_clone.handle_dht_message(&data, &source_peer),
+                                                manager_clone.handle_dht_message(
+                                                    &data,
+                                                    &source_peer,
+                                                    transport_source.as_ref(),
+                                                ),
                                             )
                                             .await
                                             {
@@ -4372,19 +4484,46 @@ impl DhtNetworkManager {
     /// nodes whose identity exchange always times out) as long as some
     /// authenticated neighbour keeps mentioning them.
     pub async fn merge_gossiped_typed_addresses(&self, node: &DHTNode) {
+        self.merge_gossiped_typed_addresses_from_transport(node, None)
+            .await;
+    }
+
+    async fn merge_gossiped_typed_addresses_from_transport(
+        &self,
+        node: &DHTNode,
+        transport_source: Option<&MultiAddr>,
+    ) {
+        let node = self
+            .gossiped_node_with_trusted_addresses(node.clone(), transport_source)
+            .await;
+        self.merge_trusted_gossiped_typed_addresses(&node).await;
+    }
+
+    async fn gossiped_node_with_trusted_addresses(
+        &self,
+        mut node: DHTNode,
+        transport_source: Option<&MultiAddr>,
+    ) -> DHTNode {
+        let typed_addresses = self
+            .filter_lan_addresses_for_store(node.typed_addresses(), transport_source)
+            .await;
+        let (addresses, address_types): (Vec<_>, Vec<_>) = typed_addresses.into_iter().unzip();
+        node.addresses = addresses;
+        node.address_types = address_types;
+        node
+    }
+
+    async fn merge_trusted_gossiped_typed_addresses(&self, node: &DHTNode) {
+        let typed_addresses = node.typed_addresses();
         let dht = self.dht.read().await;
         let publish_seq = dht_node_publish_seq(node);
         if publish_seq != 0 {
             let _ = dht
-                .replace_node_addresses_from_gossip(
-                    &node.peer_id,
-                    node.typed_addresses(),
-                    publish_seq,
-                )
+                .replace_node_addresses_from_gossip(&node.peer_id, typed_addresses, publish_seq)
                 .await;
             return;
         }
-        for (addr, ty) in node.typed_addresses() {
+        for (addr, ty) in typed_addresses {
             dht.merge_typed_address_upgrade_only(&node.peer_id, &addr, ty)
                 .await;
         }
@@ -4775,6 +4914,125 @@ mod tests {
         let typed = node.typed_addresses();
         assert_eq!(typed.len(), 1);
         assert_eq!(typed[0].1, AddressType::Lan);
+    }
+
+    fn typed_addresses(entries: Vec<(&str, AddressType)>) -> Vec<(MultiAddr, AddressType)> {
+        entries
+            .into_iter()
+            .map(|(s, t)| (s.parse().unwrap(), t))
+            .collect()
+    }
+
+    #[test]
+    fn store_filter_strips_lan_without_lan_source_or_same_wan() {
+        let context = DialAddressContext::from_parts(
+            ["203.0.113.9:9000".parse::<SocketAddr>().unwrap()],
+            Vec::<MultiAddr>::new(),
+            false,
+        );
+        let addrs = typed_addresses(vec![
+            ("/ip4/192.168.10.179/udp/10449/quic", AddressType::Lan),
+            ("/ip4/198.51.100.8/udp/10449/quic", AddressType::Direct),
+        ]);
+
+        let filtered =
+            DhtNetworkManager::filter_lan_addresses_for_store_with_context(addrs, None, &context);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].1, AddressType::Direct);
+        assert_eq!(
+            filtered[0].0,
+            "/ip4/198.51.100.8/udp/10449/quic"
+                .parse::<MultiAddr>()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn store_filter_canonicalizes_untrusted_private_direct_to_stripped_lan() {
+        let context = DialAddressContext::from_parts(
+            ["203.0.113.9:9000".parse::<SocketAddr>().unwrap()],
+            Vec::<MultiAddr>::new(),
+            false,
+        );
+        let addrs = typed_addresses(vec![(
+            "/ip4/192.168.10.179/udp/10449/quic",
+            AddressType::Direct,
+        )]);
+
+        let filtered =
+            DhtNetworkManager::filter_lan_addresses_for_store_with_context(addrs, None, &context);
+
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn store_filter_keeps_lan_when_advertisement_arrived_over_lan() {
+        let context = DialAddressContext::from_parts(
+            Vec::<SocketAddr>::new(),
+            Vec::<MultiAddr>::new(),
+            false,
+        );
+        let source = "/ip4/192.168.1.2/udp/9000/quic"
+            .parse::<MultiAddr>()
+            .unwrap();
+        let addrs = typed_addresses(vec![(
+            "/ip4/192.168.10.179/udp/10449/quic",
+            AddressType::Direct,
+        )]);
+
+        let filtered = DhtNetworkManager::filter_lan_addresses_for_store_with_context(
+            addrs,
+            Some(&source),
+            &context,
+        );
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].1, AddressType::Lan);
+    }
+
+    #[test]
+    fn store_filter_keeps_lan_when_subject_shares_our_wan() {
+        let context = DialAddressContext::from_parts(
+            ["203.0.113.9:9000".parse::<SocketAddr>().unwrap()],
+            Vec::<MultiAddr>::new(),
+            false,
+        );
+        let addrs = typed_addresses(vec![
+            ("/ip4/192.168.10.179/udp/10449/quic", AddressType::Lan),
+            ("/ip4/203.0.113.9/udp/10449/quic", AddressType::Unverified),
+        ]);
+
+        let filtered =
+            DhtNetworkManager::filter_lan_addresses_for_store_with_context(addrs, None, &context);
+
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.iter().any(|(_, ty)| *ty == AddressType::Lan));
+        assert!(
+            filtered
+                .iter()
+                .any(|(addr, ty)| *ty == AddressType::Unverified
+                    && addr.ip() == Some("203.0.113.9".parse().unwrap()))
+        );
+    }
+
+    #[test]
+    fn store_filter_does_not_use_relay_as_same_wan_lan_proof() {
+        let context = DialAddressContext::from_parts(
+            ["203.0.113.9:9000".parse::<SocketAddr>().unwrap()],
+            Vec::<MultiAddr>::new(),
+            false,
+        );
+        let addrs = typed_addresses(vec![
+            ("/ip4/192.168.10.179/udp/10449/quic", AddressType::Lan),
+            ("/ip4/203.0.113.9/udp/10449/quic", AddressType::Relay),
+        ]);
+
+        let filtered =
+            DhtNetworkManager::filter_lan_addresses_for_store_with_context(addrs, None, &context);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].1, AddressType::Relay);
     }
 
     #[test]

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -27,7 +27,7 @@ use crate::{
     dht::{AdmissionResult, DhtCoreEngine, DhtKey, Key, RoutingTableEvent},
     error::{DhtError, IdentityError, NetworkError},
     network::{NodeConfig, NodeMode},
-    self_address::build_typed_self_address_set,
+    self_address::build_self_address_set,
 };
 use anyhow::Context as _;
 use dashmap::DashMap;
@@ -1991,11 +1991,10 @@ impl DhtNetworkManager {
         let observed = self.transport.non_relay_external_addresses();
         let listen = self.transport.listen_addrs().await;
         let relay = self.transport.relay_external_address();
-        let typed = build_typed_self_address_set(observed, listen, relay, |sa| {
+        let (addresses, address_types) = build_self_address_set(observed, listen, relay, |sa| {
             self.transport.is_external_proven(sa)
-        });
-        let (addresses, address_types): (Vec<MultiAddr>, Vec<AddressType>) =
-            typed.into_iter().unzip();
+        })
+        .into_parallel_vecs();
 
         DHTNode {
             peer_id: self.config.peer_id,

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -5195,6 +5195,19 @@ mod tests {
     }
 
     #[test]
+    fn first_direct_dialable_canonicalizes_mapped_local_scope_direct_to_lan() {
+        let node = dht_node(
+            1,
+            vec![(
+                "/ip6/::ffff:192.168.1.10/udp/9000/quic",
+                AddressType::Direct,
+            )],
+        );
+
+        assert_eq!(DhtNetworkManager::first_direct_dialable(&node), None);
+    }
+
+    #[test]
     fn first_direct_dialable_for_relay_skips_same_wan_candidate() {
         let node = dht_node(
             1,
@@ -5479,6 +5492,30 @@ mod tests {
 
         let local_only = typed(vec![(
             "/ip4/192.168.1.10/udp/9003/quic",
+            AddressType::Unverified,
+        )]);
+        let picks = DhtNetworkManager::select_dial_candidates(&local_only);
+        assert_eq!(picks.len(), 1);
+        assert_eq!(picks[0].1, AddressType::Lan);
+    }
+
+    #[test]
+    fn select_dial_candidates_canonicalizes_mapped_local_scope_to_lan() {
+        let addrs = typed(vec![
+            ("/ip4/198.51.100.1/udp/9000/quic", AddressType::Relay),
+            ("/ip6/::ffff:127.0.0.1/udp/9001/quic", AddressType::Direct),
+            (
+                "/ip6/::ffff:100.64.0.1/udp/9002/quic",
+                AddressType::Unverified,
+            ),
+        ]);
+
+        let picks = DhtNetworkManager::select_dial_candidates(&addrs);
+        assert_eq!(picks.len(), 1);
+        assert_eq!(picks[0].1, AddressType::Relay);
+
+        let local_only = typed(vec![(
+            "/ip6/::ffff:100.64.0.1/udp/9002/quic",
             AddressType::Unverified,
         )]);
         let picks = DhtNetworkManager::select_dial_candidates(&local_only);

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -1109,6 +1109,56 @@ fn compute_winner<'a>(
     Some((*rid, *node))
 }
 
+fn prefer_lookup_record(candidate: &DHTNode, existing: &DHTNode) -> bool {
+    let candidate_seq = dht_node_publish_seq(candidate);
+    let existing_seq = dht_node_publish_seq(existing);
+    candidate_seq > existing_seq
+        || (candidate_seq == existing_seq
+            && best_tier_priority(candidate) < best_tier_priority(existing))
+}
+
+/// Refresh final lookup results with the per-subject winners observed during
+/// the lookup.
+///
+/// `best_nodes` is built from the candidate that was queried at the time it
+/// entered an alpha batch. Later responses in the same lookup may carry a
+/// fresher sequence-bearing self-record for that same peer. Before returning
+/// results to callers, replace every returned peer with the current
+/// [`compute_winner`] output so a stale candidate copy cannot leak out to
+/// clients that discovered the peer purely through this lookup.
+fn apply_lookup_report_winners(
+    best_nodes: Vec<DHTNode>,
+    subject_reports: &HashMap<PeerId, SubjectReports>,
+    key: &Key,
+    count: usize,
+) -> Vec<DHTNode> {
+    let mut by_peer: HashMap<PeerId, DHTNode> = HashMap::new();
+
+    for node in best_nodes {
+        let node = subject_reports
+            .get(&node.peer_id)
+            .and_then(|reports| compute_winner(&node.peer_id, reports))
+            .map(|(_, winner)| winner.clone())
+            .unwrap_or(node);
+
+        match by_peer.entry(node.peer_id) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                if prefer_lookup_record(&node, entry.get()) {
+                    *entry.get_mut() = node;
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(node);
+            }
+        }
+    }
+
+    let mut refreshed: Vec<DHTNode> = by_peer.into_values().collect();
+    refreshed.sort_by(|a, b| DhtNetworkManager::compare_node_distance(a, b, key));
+    refreshed.truncate(count);
+    refreshed
+}
+
 impl DhtNetworkManager {
     fn new_from_components(
         transport: Arc<crate::transport_handle::TransportHandle>,
@@ -2048,9 +2098,7 @@ impl DhtNetworkManager {
             previous_top_k = current_top_k;
         }
 
-        best_nodes.sort_by(|a, b| Self::compare_node_distance(a, b, key));
-        best_nodes.dedup_by_key(|n| n.peer_id);
-        best_nodes.truncate(count);
+        best_nodes = apply_lookup_report_winners(best_nodes, &subject_reports, key, count);
 
         info!(
             "[NETWORK] Found {} closest nodes: {:?}",
@@ -4027,6 +4075,22 @@ impl DhtNetworkManager {
         dht.touch_node_typed(peer_id, address, addr_type).await
     }
 
+    /// Merge a legacy ADD_ADDRESS relay hint only while the peer has no
+    /// authoritative `PublishAddressSet` sequence.
+    ///
+    /// Sequence-bearing self-records are full replacements. Once we have one
+    /// for a peer, legacy relay hints must not mutate that record or they can
+    /// resurrect relay addresses the owner already removed.
+    pub async fn touch_legacy_relay_hint_if_unsequenced(
+        &self,
+        peer_id: &PeerId,
+        address: &MultiAddr,
+    ) -> bool {
+        let dht = self.dht.read().await;
+        dht.touch_legacy_relay_hint_if_unsequenced(peer_id, address)
+            .await
+    }
+
     /// Ingest a peer's typed address set from a FIND_NODE gossip response
     /// into the local routing table.
     ///
@@ -4620,6 +4684,70 @@ mod tests {
             winner_node.addresses[0],
             fresh_relay.parse::<MultiAddr>().unwrap()
         );
+    }
+
+    #[test]
+    fn winner_newer_direct_only_publish_removes_stale_relay() {
+        // A relay-lost republish is represented as a newer full address set
+        // that simply omits the old relay. The stale sequenced relay report
+        // must not survive aggregation.
+        let subject = peer_with_leading(0xF0);
+        let stale_responder = peer_with_leading(0xF1);
+        let fresh_responder = peer_with_leading(0xFA);
+
+        let stale_relay = "/ip4/198.51.100.7/udp/46973/quic";
+        let fresh_direct = "/ip4/203.0.113.9/udp/60488/quic";
+
+        let mut reports = SubjectReports::new();
+        reports.insert(
+            stale_responder,
+            report_with_seq(0xF0, stale_relay, AddressType::Relay, 10),
+        );
+        reports.insert(
+            fresh_responder,
+            report_with_seq(0xF0, fresh_direct, AddressType::Direct, 20),
+        );
+
+        let (winner_rid, winner_node) = compute_winner(&subject, &reports).unwrap();
+        assert_eq!(winner_rid, fresh_responder);
+        assert_eq!(
+            winner_node.addresses,
+            vec![fresh_direct.parse::<MultiAddr>().unwrap()]
+        );
+        assert_eq!(winner_node.address_types, vec![AddressType::Direct]);
+    }
+
+    #[test]
+    fn lookup_result_uses_per_peer_winner_not_stale_candidate_copy() {
+        // The queried candidate entered best_nodes with a stale relay record.
+        // A later response in the same lookup reported a newer direct-only
+        // publish for the same subject. The final result must be refreshed to
+        // the winner before clients receive it.
+        let subject = peer_with_leading(0xF0);
+        let stale_responder = peer_with_leading(0xF1);
+        let fresh_responder = peer_with_leading(0xFA);
+        let key = *subject.to_bytes();
+
+        let stale_relay = "/ip4/198.51.100.7/udp/46973/quic";
+        let fresh_direct = "/ip4/203.0.113.9/udp/60488/quic";
+        let stale_node = report_with_seq(0xF0, stale_relay, AddressType::Relay, 10);
+        let fresh_node = report_with_seq(0xF0, fresh_direct, AddressType::Direct, 20);
+
+        let mut reports = SubjectReports::new();
+        reports.insert(stale_responder, stale_node.clone());
+        reports.insert(fresh_responder, fresh_node);
+
+        let mut all_reports = HashMap::new();
+        all_reports.insert(subject, reports);
+
+        let results = apply_lookup_report_winners(vec![stale_node], &all_reports, &key, 1);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].peer_id, subject);
+        assert_eq!(
+            results[0].addresses,
+            vec![fresh_direct.parse::<MultiAddr>().unwrap()]
+        );
+        assert_eq!(results[0].address_types, vec![AddressType::Direct]);
     }
 
     #[test]

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -4224,7 +4224,7 @@ impl DhtNetworkManager {
     /// is authoritative — the receiver replaces any prior record wholesale,
     /// which is how stale relay addresses get dropped when a session closes.
     ///
-    /// `seq` is a per-call Unix-nanosecond timestamp from
+    /// `seq` is a non-zero per-call Unix-nanosecond timestamp from
     /// [`Self::next_publish_seq`], guaranteeing monotonicity across sends
     /// from the same node.
     pub async fn publish_address_set_to_peers(
@@ -4282,12 +4282,15 @@ impl DhtNetworkManager {
     ///
     /// NTP slews of a few seconds are harmless: the worst case is briefly
     /// rejecting a valid republish, which the driver's reactive triggers
-    /// will retry in short order.
+    /// will retry in short order. Always returns a non-zero value because
+    /// receivers reserve `0` as their "no sequence observed" sentinel.
     fn next_publish_seq() -> u64 {
-        SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map(|d| d.as_nanos() as u64)
-            .unwrap_or(0)
+        match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+            Ok(duration) => u64::try_from(duration.as_nanos())
+                .unwrap_or(u64::MAX)
+                .max(1),
+            Err(_) => 1,
+        }
     }
 
     /// Get the local listen address of this node's P2P network

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -1787,6 +1787,10 @@ impl DhtNetworkManager {
         let initial = self.find_closest_nodes_local(key, count).await;
         for node in initial {
             if peer_states.is_contactable(&node.peer_id) {
+                if self.lookup_candidate_dial_plan_is_exhausted(&node).await {
+                    peer_states.mark_failed(node.peer_id);
+                    continue;
+                }
                 let dist = node.peer_id.distance(&target_key);
                 candidates.entry((dist, node.peer_id)).or_insert(node);
             }
@@ -1816,6 +1820,14 @@ impl DhtNetworkManager {
                 };
                 let node = entry.remove();
                 if !peer_states.is_contactable(&node.peer_id) {
+                    continue;
+                }
+                if self.lookup_candidate_dial_plan_is_exhausted(&node).await {
+                    peer_states.mark_failed(node.peer_id);
+                    trace!(
+                        "[NETWORK] Skipping {}: all FIND_NODE dial candidates are in the failure cache",
+                        node.peer_id.to_hex()
+                    );
                     continue;
                 }
                 peer_states.mark_waiting(node.peer_id);
@@ -1898,6 +1910,14 @@ impl DhtNetworkManager {
                             if !peer_states.is_contactable(&node.peer_id)
                                 || self.is_local_peer_id(&node.peer_id)
                             {
+                                continue;
+                            }
+                            if self.lookup_candidate_dial_plan_is_exhausted(&node).await {
+                                peer_states.mark_failed(node.peer_id);
+                                trace!(
+                                    "[NETWORK] Skipping gossiped {}: all FIND_NODE dial candidates are in the failure cache",
+                                    node.peer_id.to_hex()
+                                );
                                 continue;
                             }
                             // Ingest the responder's typed view into our
@@ -2362,6 +2382,34 @@ impl DhtNetworkManager {
             skipped_cached
         );
         None
+    }
+
+    /// Return true when a FIND_NODE candidate has no useful dial attempt left
+    /// right now because every address in the dial plan is cooling down in the
+    /// shared failed-address cache.
+    ///
+    /// Already-connected peers are still queryable even if their advertised
+    /// addresses are cached as failed, because the request path can reuse the
+    /// open channel without dialing.
+    async fn lookup_candidate_dial_plan_is_exhausted(&self, node: &DHTNode) -> bool {
+        let typed = node.typed_addresses();
+        if !Self::dial_plan_fully_failed_in_cache(self.dial_failure_cache.as_ref(), &typed) {
+            return false;
+        }
+
+        !self.transport.is_peer_connected(&node.peer_id).await
+    }
+
+    fn dial_plan_fully_failed_in_cache(
+        cache: &DialFailureCache,
+        typed_addresses: &[(MultiAddr, AddressType)],
+    ) -> bool {
+        let plan = Self::select_dial_candidates(typed_addresses);
+        !plan.is_empty()
+            && plan.iter().all(|(addr, _)| {
+                addr.dialable_socket_addr()
+                    .is_some_and(|socket_addr| cache.is_failed(&socket_addr))
+            })
     }
 
     async fn record_peer_failure(&self, peer_id: &PeerId) {
@@ -4939,6 +4987,42 @@ mod tests {
         assert_eq!(picks.len(), 2);
         assert_eq!(picks[0].1, AddressType::Direct);
         assert_eq!(picks[1].1, AddressType::Unverified);
+    }
+
+    #[test]
+    fn dial_plan_fully_failed_in_cache_requires_every_planned_address() {
+        let cache = DialFailureCache::new();
+        let addrs = typed(vec![
+            ("/ip4/198.51.100.1/udp/9000/quic", AddressType::Relay),
+            ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
+        ]);
+        let plan = DhtNetworkManager::select_dial_candidates(&addrs);
+
+        assert!(!DhtNetworkManager::dial_plan_fully_failed_in_cache(
+            &cache, &addrs
+        ));
+
+        cache.record_failure(plan[0].0.dialable_socket_addr().unwrap());
+        assert!(
+            !DhtNetworkManager::dial_plan_fully_failed_in_cache(&cache, &addrs),
+            "one available planned address should keep the candidate queryable"
+        );
+
+        cache.record_failure(plan[1].0.dialable_socket_addr().unwrap());
+        assert!(
+            DhtNetworkManager::dial_plan_fully_failed_in_cache(&cache, &addrs),
+            "all planned dial addresses in the failure cache should suppress the candidate"
+        );
+    }
+
+    #[test]
+    fn dial_plan_fully_failed_in_cache_empty_plan_is_not_exhausted() {
+        let cache = DialFailureCache::new();
+
+        assert!(!DhtNetworkManager::dial_plan_fully_failed_in_cache(
+            &cache,
+            &[]
+        ));
     }
 
     fn sock(s: &str) -> SocketAddr {

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -22,11 +22,12 @@ use crate::{
     P2PError, PeerId, Result,
     adaptive::TrustEngine,
     adaptive::trust::DEFAULT_NEUTRAL_TRUST,
-    address::MultiAddr,
+    address::{MultiAddr, is_lan_ip},
     dht::core_engine::{AddressType, AtomicInstant, NodeInfo},
     dht::{AdmissionResult, DhtCoreEngine, DhtKey, Key, RoutingTableEvent},
     error::{DhtError, IdentityError, NetworkError},
     network::{NodeConfig, NodeMode},
+    security::canonicalize_ip,
     self_address::build_self_address_set,
 };
 use anyhow::Context as _;
@@ -188,11 +189,120 @@ const REBOOTSTRAP_COOLDOWN: Duration = Duration::from_secs(300); // 5 minutes
 /// Unverified/Direct entries published by NATed peers.
 const DIAL_FAILURE_CACHE_TTL: Duration = Duration::from_secs(30 * 60);
 
-/// Worst-case number of addresses [`DhtNetworkManager::select_dial_candidates`]
-/// returns for a single peer: one Relay plus at most one best non-Relay
-/// address per IP family (V4 and V6). Used to size the result vector so the
-/// hot path does not reallocate.
-const MAX_DIAL_PLAN_SIZE: usize = 3;
+/// Worst-case number of addresses
+/// [`DhtNetworkManager::select_dial_candidates_with_context`] returns for a
+/// single peer: one Relay plus at most one best WAN and one best LAN address
+/// per IP family (V4 and V6). Used to size the result vector so the hot path
+/// does not reallocate.
+const MAX_DIAL_PLAN_SIZE: usize = 5;
+
+#[derive(Debug, Default)]
+pub(crate) struct DialAddressContext {
+    local_wan_ips: HashSet<IpAddr>,
+    local_lan_ips: Vec<IpAddr>,
+    allow_loopback: bool,
+}
+
+impl DialAddressContext {
+    fn from_parts(
+        local_external_addresses: impl IntoIterator<Item = SocketAddr>,
+        local_listen_addresses: impl IntoIterator<Item = MultiAddr>,
+        allow_loopback: bool,
+    ) -> Self {
+        let mut local_wan_ips = HashSet::new();
+        let mut local_lan_ips = Vec::new();
+
+        for addr in local_external_addresses {
+            Self::record_local_ip(addr.ip(), &mut local_wan_ips, &mut local_lan_ips);
+        }
+        for addr in local_listen_addresses {
+            if let Some(ip) = addr.ip() {
+                Self::record_local_ip(ip, &mut local_wan_ips, &mut local_lan_ips);
+            }
+        }
+
+        Self {
+            local_wan_ips,
+            local_lan_ips,
+            allow_loopback,
+        }
+    }
+
+    fn record_local_ip(ip: IpAddr, wan_ips: &mut HashSet<IpAddr>, lan_ips: &mut Vec<IpAddr>) {
+        let ip = canonicalize_ip(ip);
+        if is_lan_ip(ip) {
+            if !lan_ips.contains(&ip) {
+                lan_ips.push(ip);
+            }
+        } else {
+            wan_ips.insert(ip);
+        }
+    }
+
+    fn peer_shares_wan(&self, typed: &[(MultiAddr, AddressType)]) -> bool {
+        !self.local_wan_ips.is_empty()
+            && typed.iter().any(|(addr, ty)| {
+                let ty = AddressType::for_advertised_address(addr, *ty);
+                !matches!(ty, AddressType::Relay | AddressType::Lan)
+                    && addr.ip().is_some_and(|ip| self.ip_shares_local_wan(ip))
+            })
+    }
+
+    fn address_shares_local_wan(&self, addr: &MultiAddr) -> bool {
+        addr.ip().is_some_and(|ip| self.ip_shares_local_wan(ip))
+    }
+
+    fn ip_shares_local_wan(&self, ip: IpAddr) -> bool {
+        let ip = canonicalize_ip(ip);
+        !is_lan_ip(ip) && self.local_wan_ips.contains(&ip)
+    }
+
+    fn lan_match_score(&self, ip: IpAddr) -> u8 {
+        let ip = canonicalize_ip(ip);
+        if !is_lan_ip(ip) {
+            return 4;
+        }
+        if ip.is_loopback() {
+            return if self.allow_loopback { 0 } else { 4 };
+        }
+        if self.local_lan_ips.contains(&ip) {
+            return 0;
+        }
+        if self
+            .local_lan_ips
+            .iter()
+            .any(|local| same_lan_prefix(*local, ip))
+        {
+            return 1;
+        }
+        3
+    }
+}
+
+fn same_lan_prefix(a: IpAddr, b: IpAddr) -> bool {
+    match (canonicalize_ip(a), canonicalize_ip(b)) {
+        (IpAddr::V4(a), IpAddr::V4(b)) => {
+            let a_octets = a.octets();
+            let b_octets = b.octets();
+            is_lan_ip(IpAddr::V4(a))
+                && is_lan_ip(IpAddr::V4(b))
+                && a_octets[0] == b_octets[0]
+                && a_octets[1] == b_octets[1]
+                && a_octets[2] == b_octets[2]
+        }
+        (IpAddr::V6(a), IpAddr::V6(b)) => {
+            let a_octets = a.octets();
+            let b_octets = b.octets();
+            is_lan_ip(IpAddr::V6(a))
+                && is_lan_ip(IpAddr::V6(b))
+                && a_octets[0..8]
+                    .iter()
+                    .zip(b_octets[0..8].iter())
+                    .all(|(a, b)| a == b)
+        }
+        _ => false,
+    }
+}
 
 /// Duration an identity-exchange *timeout* is remembered before the
 /// peer may be re-dialed. Used for the `IdentityFailed` outcome —
@@ -269,12 +379,12 @@ pub struct DHTNode {
 impl DHTNode {
     /// Pair each address with its type tag.
     ///
-    /// Untagged entries (legacy records that predate ADR-014, or any
-    /// position past the end of `address_types`) default to
-    /// [`AddressType::Unverified`] — the conservative assumption that
-    /// matches `address_type_at` on `NodeInfo`. A legacy publisher never
-    /// asserted reachability for these sockets, so we refuse to let them
-    /// stand in for a verified `Direct` tag.
+    /// Local-scope IP addresses are always returned as [`AddressType::Lan`],
+    /// even if the sender advertised a stronger tag. Other untagged entries
+    /// (legacy records that predate ADR-014, or any position past the end of
+    /// `address_types`) default to [`AddressType::Unverified`]. A legacy
+    /// publisher never asserted reachability for these sockets, so we refuse
+    /// to let them stand in for a verified `Direct` tag.
     ///
     /// The returned vec preserves the storage order from `addresses`;
     /// callers that need Relay-first ordering should pass the result to
@@ -285,18 +395,19 @@ impl DHTNode {
             .iter()
             .enumerate()
             .map(|(i, addr)| {
-                let ty = self
+                let advertised = self
                     .address_types
                     .get(i)
                     .copied()
                     .unwrap_or(AddressType::Unverified);
+                let ty = AddressType::for_advertised_address(addr, advertised);
                 (addr.clone(), ty)
             })
             .collect()
     }
 
     /// Addresses sorted by [`AddressType`] priority: Relay first, then
-    /// Direct, then NATted.  Within each tier the original insertion
+    /// Direct, Unverified, and Lan. Within each tier the original insertion
     /// order is preserved (stable sort).
     ///
     /// Use this instead of raw `addresses` whenever the caller needs to
@@ -331,6 +442,10 @@ impl DHTNode {
         // against legacy entries with trailing untagged addresses).
         while self.address_types.len() < self.addresses.len() {
             self.address_types.push(AddressType::Unverified);
+        }
+        for (i, addr) in self.addresses.iter().enumerate() {
+            self.address_types[i] =
+                AddressType::for_advertised_address(addr, self.address_types[i]);
         }
 
         for (addr, ty) in other.typed_addresses() {
@@ -2263,15 +2378,17 @@ impl DhtNetworkManager {
     ///
     /// The published address list uses the same shared self-address
     /// invariants as the reachability driver's `PublishAddressSet` fan-out:
-    /// relay first when present, then at most one best non-relay address per
-    /// IP family, each tagged as Direct only when the passive classifier has
-    /// proven that exact external socket. Wildcard and zero-port listen
-    /// addresses are dropped rather than published as undialable placeholders.
+    /// relay first when present, then at most one best WAN address per IP
+    /// family and one LAN address per IP family. WAN addresses are tagged as
+    /// Direct only when the passive classifier has proven that exact external
+    /// socket; local-scope addresses are tagged Lan. Wildcard and zero-port
+    /// listen addresses are dropped rather than published as undialable
+    /// placeholders.
     ///
     /// If neither source produces an address, the returned `DHTNode` has an
     /// empty `addresses` vec. That is intentional: it tells consumers "I
-    /// don't know how to be reached yet" rather than guessing a LAN or
-    /// bind-side wildcard address that internet peers cannot route to.
+    /// don't know how to be reached yet" rather than guessing a bind-side
+    /// wildcard address that peers cannot route to.
     async fn local_dht_node(&self) -> DHTNode {
         let observed = self.transport.non_relay_external_addresses();
         let listen = self.transport.listen_addrs().await;
@@ -2317,13 +2434,17 @@ impl DhtNetworkManager {
     /// closes the "NAT-through-NAT relay chain" failure mode where a
     /// node's observed-but-unverified ephemeral port would be treated as
     /// a dialable Direct candidate.
-    pub(crate) fn first_direct_dialable(node: &DHTNode) -> Option<MultiAddr> {
+    fn first_direct_dialable_with_filter(
+        node: &DHTNode,
+        accept: impl Fn(&MultiAddr) -> bool,
+    ) -> Option<MultiAddr> {
         for (i, addr) in node.addresses.iter().enumerate() {
-            let addr_type = node
+            let advertised = node
                 .address_types
                 .get(i)
                 .copied()
                 .unwrap_or(AddressType::Unverified);
+            let addr_type = AddressType::for_advertised_address(addr, advertised);
             if addr_type != AddressType::Direct {
                 continue;
             }
@@ -2333,9 +2454,35 @@ impl DhtNetworkManager {
             if sa.ip().is_unspecified() {
                 continue;
             }
+            if !accept(addr) {
+                continue;
+            }
             return Some(addr.clone());
         }
         None
+    }
+
+    pub(crate) fn first_direct_dialable(node: &DHTNode) -> Option<MultiAddr> {
+        Self::first_direct_dialable_with_filter(node, |_| true)
+    }
+
+    /// Return the first `Direct` relay-candidate address that is not on this
+    /// node's own WAN.
+    ///
+    /// Same-WAN and same-machine peers must not be selected as relayers: they
+    /// do not provide a distinct public route. Local-scope addresses are
+    /// already canonicalized to [`AddressType::Lan`] by
+    /// [`Self::first_direct_dialable_with_filter`].
+    pub(crate) fn first_direct_dialable_for_relay(
+        node: &DHTNode,
+        context: &DialAddressContext,
+    ) -> Option<MultiAddr> {
+        if context.local_wan_ips.is_empty() {
+            return Self::first_direct_dialable(node);
+        }
+        Self::first_direct_dialable_with_filter(node, |addr| {
+            !context.address_shares_local_wan(addr)
+        })
     }
 
     /// Predicate: is this address dialable (QUIC, non-unspecified)?
@@ -2376,7 +2523,7 @@ impl DhtNetworkManager {
     /// consume one of the plan slots — a fully cached plan therefore
     /// returns `None` without trying anything further down the priority
     /// list. This stops a peer that republishes the same broken Direct /
-    /// Unverified pair on every DHT query from causing a dial retry
+    /// Unverified / Lan set on every DHT query from causing a dial retry
     /// every time we encounter them.
     ///
     /// Bails out early when the peer is already connected — the caller
@@ -2394,7 +2541,7 @@ impl DhtNetworkManager {
             );
             return None;
         }
-        let plan = Self::select_dial_candidates(typed_addresses);
+        let plan = self.contextual_dial_plan(typed_addresses).await;
         if plan.is_empty() {
             debug!(
                 "dial_addresses: no dialable addresses for {}",
@@ -2447,13 +2594,14 @@ impl DhtNetworkManager {
     /// open channel without dialing.
     async fn lookup_candidate_dial_plan_is_exhausted(&self, node: &DHTNode) -> bool {
         let typed = node.typed_addresses();
-        if !Self::dial_plan_fully_failed_in_cache(self.dial_failure_cache.as_ref(), &typed) {
+        if !self.dial_plan_fully_failed_in_cache_for_local(&typed).await {
             return false;
         }
 
         !self.transport.is_peer_connected(&node.peer_id).await
     }
 
+    #[cfg(test)]
     fn dial_plan_fully_failed_in_cache(
         cache: &DialFailureCache,
         typed_addresses: &[(MultiAddr, AddressType)],
@@ -2463,6 +2611,32 @@ impl DhtNetworkManager {
             && plan.iter().all(|(addr, _)| {
                 addr.dialable_socket_addr()
                     .is_some_and(|socket_addr| cache.is_failed(&socket_addr))
+            })
+    }
+
+    pub(crate) async fn local_dial_address_context(&self) -> DialAddressContext {
+        let external = self.transport.non_relay_external_addresses();
+        let listen = self.transport.listen_addrs().await;
+        DialAddressContext::from_parts(external, listen, self.config.node_config.allow_loopback)
+    }
+
+    async fn contextual_dial_plan(
+        &self,
+        typed_addresses: &[(MultiAddr, AddressType)],
+    ) -> Vec<(MultiAddr, AddressType)> {
+        let context = self.local_dial_address_context().await;
+        Self::select_dial_candidates_with_context(typed_addresses, &context)
+    }
+
+    async fn dial_plan_fully_failed_in_cache_for_local(
+        &self,
+        typed_addresses: &[(MultiAddr, AddressType)],
+    ) -> bool {
+        let plan = self.contextual_dial_plan(typed_addresses).await;
+        !plan.is_empty()
+            && plan.iter().all(|(addr, _)| {
+                addr.dialable_socket_addr()
+                    .is_some_and(|socket_addr| self.dial_failure_cache.is_failed(&socket_addr))
             })
     }
 
@@ -3010,8 +3184,9 @@ impl DhtNetworkManager {
     /// dialable addresses.
     ///
     /// Result is sorted by [`AddressType`] priority — Relay first
-    /// (known-good relay endpoint), then Direct, Unverified, and NATted
-    /// — so the dialer tries the fastest path first.
+    /// (known-good relay endpoint), then Direct, Unverified, and Lan. The
+    /// final dial plan may override this order for same-WAN peers so LAN
+    /// routes are tried first only when they are plausible.
     pub(crate) async fn peer_addresses_for_dial_typed(
         &self,
         peer_id: &PeerId,
@@ -3029,19 +3204,25 @@ impl DhtNetworkManager {
         }
 
         // 2. Transport layer — for connected peers not yet in the
-        //    routing table. No type info available, so each address is
-        //    tagged `Unverified`: a transport-level handshake does not
-        //    prove the address is cold-dialable from arbitrary peers.
-        //    `Unverified` is still dialable (sorted after Relay/Direct,
-        //    before NATted) so these peers remain reachable for regular
-        //    DHT ops, but relay-candidate selection (which requires
-        //    `Direct`) correctly skips them.
+        //    routing table. Local-scope addresses are tagged `Lan`; all
+        //    other addresses are `Unverified` because a transport-level
+        //    handshake does not prove the address is cold-dialable from
+        //    arbitrary peers. `Unverified` remains dialable for regular DHT
+        //    ops, but relay-candidate selection (which requires `Direct`)
+        //    correctly skips it.
         if let Some(info) = self.transport.peer_info(peer_id).await {
             return info
                 .addresses
                 .into_iter()
                 .filter(Self::is_dialable)
-                .map(|a| (a, AddressType::Unverified))
+                .map(|a| {
+                    let ty = if a.ip().is_some_and(is_lan_ip) {
+                        AddressType::Lan
+                    } else {
+                        AddressType::Unverified
+                    };
+                    (a, ty)
+                })
                 .collect();
         }
 
@@ -3050,7 +3231,7 @@ impl DhtNetworkManager {
 
     /// Filter and sort typed addresses by [`AddressType::priority`].
     ///
-    /// Relay first, Direct second, Unverified third, NATted last. Stable
+    /// Relay first, Direct second, Unverified third, Lan last. Stable
     /// sort within each tier preserves the input order, so callers that
     /// hand in addresses in a meaningful sub-order (e.g., IPv6 before
     /// IPv4) keep that order within the type tier.
@@ -3060,7 +3241,10 @@ impl DhtNetworkManager {
         let mut candidates: Vec<(MultiAddr, AddressType)> = typed
             .iter()
             .filter(|pair| Self::is_dialable(&pair.0))
-            .cloned()
+            .map(|(addr, ty)| {
+                let ty = AddressType::for_advertised_address(addr, *ty);
+                (addr.clone(), ty)
+            })
             .collect();
 
         candidates.sort_by_key(|pair| pair.1.priority());
@@ -3071,28 +3255,38 @@ impl DhtNetworkManager {
     /// Pick a bounded per-family address plan for a single peer, applying
     /// the cold-start policy documented on [`Self::dial_addresses`].
     ///
-    /// Rules:
-    /// - If a Relay is published, dial the Relay first.
-    /// - Then dial at most one best non-Relay address per IP family. Direct
-    ///   wins over Unverified, which wins over NATted.
-    /// - If there is no Relay, dial the same per-family non-Relay plan.
+    /// Context-free rules:
+    /// - Relay is preferred first unless the relay endpoint is on our own
+    ///   WAN IP.
+    /// - Then dial at most one best WAN address per IP family. Direct wins
+    ///   over Unverified.
+    /// - LAN addresses are used only when there is no WAN/relay alternative.
     ///
-    /// Peers can publish a relay plus one V4 and one V6 non-Relay address.
-    /// Preserving both families avoids making the caller's first-contact
-    /// path depend on whichever family happened to appear first, while still
-    /// capping the worst case at three attempts.
+    /// The live dial path calls [`Self::select_dial_candidates_with_context`]
+    /// instead so same-WAN peers can use LAN routes before relay/direct.
+    #[cfg(test)]
     fn select_dial_candidates(typed: &[(MultiAddr, AddressType)]) -> Vec<(MultiAddr, AddressType)> {
+        Self::select_dial_candidates_with_context(typed, &DialAddressContext::default())
+    }
+
+    fn select_dial_candidates_with_context(
+        typed: &[(MultiAddr, AddressType)],
+        context: &DialAddressContext,
+    ) -> Vec<(MultiAddr, AddressType)> {
         let mut relay: Option<(MultiAddr, AddressType)> = None;
-        let mut non_relay_v4: Option<(usize, MultiAddr, AddressType)> = None;
-        let mut non_relay_v6: Option<(usize, MultiAddr, AddressType)> = None;
+        let mut wan_v4: Option<(usize, MultiAddr, AddressType)> = None;
+        let mut wan_v6: Option<(usize, MultiAddr, AddressType)> = None;
+        let mut lan_v4: Option<(usize, u8, MultiAddr, AddressType)> = None;
+        let mut lan_v6: Option<(usize, u8, MultiAddr, AddressType)> = None;
 
         for (index, (addr, ty)) in typed.iter().enumerate() {
             if !Self::is_dialable(addr) {
                 continue;
             }
-            if *ty == AddressType::Relay {
-                if relay.is_none() {
-                    relay = Some((addr.clone(), *ty));
+            let ty = AddressType::for_advertised_address(addr, *ty);
+            if ty == AddressType::Relay {
+                if relay.is_none() && !context.address_shares_local_wan(addr) {
+                    relay = Some((addr.clone(), ty));
                 }
                 continue;
             }
@@ -3101,28 +3295,60 @@ impl DhtNetworkManager {
                 continue;
             };
             let normalized = saorsa_transport::shared::normalize_socket_addr(socket_addr);
+            if ty == AddressType::Lan {
+                let score = context.lan_match_score(normalized.ip());
+                let slot = if normalized.ip().is_ipv4() {
+                    &mut lan_v4
+                } else {
+                    &mut lan_v6
+                };
+                let should_replace = slot
+                    .as_ref()
+                    .map(|(existing_index, existing_score, _, _)| {
+                        score < *existing_score
+                            || (score == *existing_score && index < *existing_index)
+                    })
+                    .unwrap_or(true);
+                if should_replace {
+                    *slot = Some((index, score, addr.clone(), ty));
+                }
+                continue;
+            }
+
             let slot = if normalized.ip().is_ipv4() {
-                &mut non_relay_v4
+                &mut wan_v4
             } else {
-                &mut non_relay_v6
+                &mut wan_v6
             };
             let should_replace = slot
                 .as_ref()
                 .map(|(_, _, existing_ty)| ty.priority() < existing_ty.priority())
                 .unwrap_or(true);
             if should_replace {
-                *slot = Some((index, addr.clone(), *ty));
+                *slot = Some((index, addr.clone(), ty));
             }
         }
 
         let mut out = Vec::with_capacity(MAX_DIAL_PLAN_SIZE);
+        let mut lan: Vec<_> = [lan_v4, lan_v6].into_iter().flatten().collect();
+        lan.sort_by_key(|(index, score, _, _)| (*score, *index));
+        let mut wan: Vec<_> = [wan_v4, wan_v6].into_iter().flatten().collect();
+        wan.sort_by_key(|(index, _, _)| *index);
+
+        let has_wan_or_relay = relay.is_some() || !wan.is_empty();
+        let lan_is_reachable = lan.iter().any(|(_, score, _, _)| *score <= 1);
+        let prefer_lan = !lan.is_empty() && (lan_is_reachable || context.peer_shares_wan(typed));
+
+        if prefer_lan {
+            out.extend(lan.iter().map(|(_, _, addr, ty)| (addr.clone(), *ty)));
+        }
         if let Some(relay) = relay {
             out.push(relay);
         }
-
-        let mut non_relay: Vec<_> = [non_relay_v4, non_relay_v6].into_iter().flatten().collect();
-        non_relay.sort_by_key(|(index, _, _)| *index);
-        out.extend(non_relay.into_iter().map(|(_, addr, ty)| (addr, ty)));
+        out.extend(wan.into_iter().map(|(_, addr, ty)| (addr, ty)));
+        if !prefer_lan && !has_wan_or_relay {
+            out.extend(lan.into_iter().map(|(_, _, addr, ty)| (addr, ty)));
+        }
         out
     }
 
@@ -3561,13 +3787,21 @@ impl DhtNetworkManager {
                 app_peer_id_hex, user_agent
             );
         } else {
-            // Transport-observed addresses are `Unverified` by default: a
-            // successful handshake with us doesn't prove the peer is
-            // cold-dialable by arbitrary third parties. The peer's own
-            // `PublishAddressSet` (driven by the reachability classifier)
-            // upgrades to `Direct` or `Relay` when authoritative info
-            // arrives.
-            let address_types = vec![crate::dht::AddressType::Unverified; addresses.len()];
+            // Transport-observed local-scope addresses are `Lan`; other
+            // observed addresses are `Unverified` because a successful
+            // handshake with us doesn't prove public cold-dialability. The
+            // peer's own `PublishAddressSet` upgrades to `Direct` or `Relay`
+            // when authoritative info arrives.
+            let address_types = addresses
+                .iter()
+                .map(|addr| {
+                    if addr.ip().is_some_and(is_lan_ip) {
+                        crate::dht::AddressType::Lan
+                    } else {
+                        crate::dht::AddressType::Unverified
+                    }
+                })
+                .collect();
             let node_info = NodeInfo {
                 id: node_id,
                 addresses,
@@ -4056,14 +4290,24 @@ impl DhtNetworkManager {
     /// Get current statistics
     /// Update a node's address in the DHT routing table.
     ///
-    /// The address is classified [`crate::dht::AddressType::Unverified`]:
+    /// Local-scope addresses are classified [`crate::dht::AddressType::Lan`].
+    /// Other addresses are classified [`crate::dht::AddressType::Unverified`]:
     /// transport-layer observations prove only reachability from us, not
     /// public dialability. Callers with authoritative type information (e.g.,
-    /// a relay allocation or a peer-advertised `PublishAddressSet`) must use
+    /// `AddressType::Relay` for relay addresses) must use
     /// [`Self::touch_node_typed`].
     pub async fn touch_node(&self, peer_id: &PeerId, address: Option<&MultiAddr>) -> bool {
         let dht = self.dht.read().await;
-        dht.touch_node(peer_id, address).await
+        let addr_type = if address.and_then(MultiAddr::ip).is_some_and(is_lan_ip) {
+            crate::dht::AddressType::Lan
+        } else {
+            crate::dht::AddressType::Unverified
+        };
+        if addr_type == crate::dht::AddressType::Unverified {
+            dht.touch_node(peer_id, address).await
+        } else {
+            dht.touch_node_typed(peer_id, address, addr_type).await
+        }
     }
 
     /// Update a node's address with an explicit type tag.
@@ -4523,6 +4767,18 @@ mod tests {
     }
 
     #[test]
+    fn dht_node_typed_addresses_canonicalize_local_scope_direct_to_lan() {
+        let node = dht_node(
+            1,
+            vec![("/ip4/192.168.1.10/udp/10003/quic", AddressType::Direct)],
+        );
+
+        let typed = node.typed_addresses();
+        assert_eq!(typed.len(), 1);
+        assert_eq!(typed[0].1, AddressType::Lan);
+    }
+
+    #[test]
     fn merge_from_adds_relay_entry_to_existing_unverified() {
         let mut existing = dht_node(
             1,
@@ -4911,11 +5167,11 @@ mod tests {
     }
 
     #[test]
-    fn first_direct_dialable_skips_natted() {
+    fn first_direct_dialable_skips_lan() {
         let node = dht_node(
             1,
             vec![
-                ("/ip4/10.0.0.1/udp/9000/quic", AddressType::NATted),
+                ("/ip4/10.0.0.1/udp/9000/quic", AddressType::Lan),
                 ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
             ],
         );
@@ -4923,6 +5179,58 @@ mod tests {
         assert_eq!(
             picked,
             "/ip4/203.0.113.7/udp/9001/quic"
+                .parse::<MultiAddr>()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn first_direct_dialable_canonicalizes_local_scope_direct_to_lan() {
+        let node = dht_node(
+            1,
+            vec![("/ip4/192.168.1.10/udp/9000/quic", AddressType::Direct)],
+        );
+
+        assert_eq!(DhtNetworkManager::first_direct_dialable(&node), None);
+    }
+
+    #[test]
+    fn first_direct_dialable_for_relay_skips_same_wan_candidate() {
+        let node = dht_node(
+            1,
+            vec![("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct)],
+        );
+        let context = DialAddressContext::from_parts(
+            ["203.0.113.7:12000".parse().unwrap()],
+            Vec::<MultiAddr>::new(),
+            false,
+        );
+
+        assert_eq!(
+            DhtNetworkManager::first_direct_dialable_for_relay(&node, &context),
+            None
+        );
+    }
+
+    #[test]
+    fn first_direct_dialable_for_relay_uses_non_same_wan_fallback() {
+        let node = dht_node(
+            1,
+            vec![
+                ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
+                ("/ip6/2001:db8::7/udp/9002/quic", AddressType::Direct),
+            ],
+        );
+        let context = DialAddressContext::from_parts(
+            ["203.0.113.7:12000".parse().unwrap()],
+            Vec::<MultiAddr>::new(),
+            false,
+        );
+
+        let picked = DhtNetworkManager::first_direct_dialable_for_relay(&node, &context).unwrap();
+        assert_eq!(
+            picked,
+            "/ip6/2001:db8::7/udp/9002/quic"
                 .parse::<MultiAddr>()
                 .unwrap()
         );
@@ -4996,7 +5304,7 @@ mod tests {
             ("/ip4/198.51.100.1/udp/9000/quic", AddressType::Relay),
             ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
             ("/ip4/192.0.2.9/udp/9002/quic", AddressType::Unverified),
-            ("/ip4/192.0.2.10/udp/9003/quic", AddressType::NATted),
+            ("/ip4/192.168.1.10/udp/9003/quic", AddressType::Lan),
         ]);
         let picks = DhtNetworkManager::select_dial_candidates(&addrs);
         assert_eq!(picks.len(), 2);
@@ -5023,12 +5331,61 @@ mod tests {
         let addrs = typed(vec![
             ("/ip4/198.51.100.1/udp/9000/quic", AddressType::Relay),
             ("/ip4/192.0.2.9/udp/9002/quic", AddressType::Unverified),
-            ("/ip4/192.0.2.10/udp/9003/quic", AddressType::NATted),
+            ("/ip4/192.168.1.10/udp/9003/quic", AddressType::Lan),
         ]);
         let picks = DhtNetworkManager::select_dial_candidates(&addrs);
         assert_eq!(picks.len(), 2);
         assert_eq!(picks[0].1, AddressType::Relay);
         assert_eq!(picks[1].1, AddressType::Unverified);
+    }
+
+    #[test]
+    fn select_dial_candidates_skips_same_wan_relay_for_direct_fallback() {
+        let addrs = typed(vec![
+            ("/ip4/203.0.113.7/udp/9000/quic", AddressType::Relay),
+            ("/ip4/198.51.100.9/udp/9001/quic", AddressType::Direct),
+        ]);
+        let context = DialAddressContext::from_parts(
+            ["203.0.113.7:12000".parse().unwrap()],
+            Vec::<MultiAddr>::new(),
+            false,
+        );
+
+        let picks = DhtNetworkManager::select_dial_candidates_with_context(&addrs, &context);
+        assert_eq!(picks.len(), 1);
+        assert_eq!(picks[0].1, AddressType::Direct);
+        assert_eq!(picks[0].0, addrs[1].0);
+    }
+
+    #[test]
+    fn select_dial_candidates_skips_same_wan_relay_for_unverified_fallback() {
+        let addrs = typed(vec![
+            ("/ip4/203.0.113.7/udp/9000/quic", AddressType::Relay),
+            ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Unverified),
+        ]);
+        let context = DialAddressContext::from_parts(
+            ["203.0.113.7:12000".parse().unwrap()],
+            Vec::<MultiAddr>::new(),
+            false,
+        );
+
+        let picks = DhtNetworkManager::select_dial_candidates_with_context(&addrs, &context);
+        assert_eq!(picks.len(), 1);
+        assert_eq!(picks[0].1, AddressType::Unverified);
+        assert_eq!(picks[0].0, addrs[1].0);
+    }
+
+    #[test]
+    fn select_dial_candidates_same_wan_relay_without_fallback_is_empty() {
+        let addrs = typed(vec![("/ip4/203.0.113.7/udp/9000/quic", AddressType::Relay)]);
+        let context = DialAddressContext::from_parts(
+            ["203.0.113.7:12000".parse().unwrap()],
+            Vec::<MultiAddr>::new(),
+            false,
+        );
+
+        let picks = DhtNetworkManager::select_dial_candidates_with_context(&addrs, &context);
+        assert!(picks.is_empty());
     }
 
     #[test]
@@ -5047,7 +5404,7 @@ mod tests {
         let addrs = typed(vec![
             ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
             ("/ip6/2001:db8::9/udp/9002/quic", AddressType::Unverified),
-            ("/ip6/2001:db8::10/udp/9003/quic", AddressType::NATted),
+            ("/ip6/fd00::10/udp/9003/quic", AddressType::Lan),
         ]);
         let picks = DhtNetworkManager::select_dial_candidates(&addrs);
         assert_eq!(picks.len(), 2);
@@ -5082,7 +5439,7 @@ mod tests {
         let addrs = typed(vec![
             ("/ip4/192.0.2.9/udp/9002/quic", AddressType::Unverified),
             ("/ip4/192.0.2.11/udp/9004/quic", AddressType::Unverified),
-            ("/ip4/192.0.2.10/udp/9003/quic", AddressType::NATted),
+            ("/ip4/192.168.1.10/udp/9003/quic", AddressType::Lan),
         ]);
         let picks = DhtNetworkManager::select_dial_candidates(&addrs);
         assert_eq!(picks.len(), 1);
@@ -5102,11 +5459,31 @@ mod tests {
     }
 
     #[test]
-    fn select_dial_candidates_only_natted_is_one() {
-        let addrs = typed(vec![("/ip4/192.0.2.10/udp/9003/quic", AddressType::NATted)]);
+    fn select_dial_candidates_only_lan_is_one() {
+        let addrs = typed(vec![("/ip4/192.168.1.10/udp/9003/quic", AddressType::Lan)]);
         let picks = DhtNetworkManager::select_dial_candidates(&addrs);
         assert_eq!(picks.len(), 1);
-        assert_eq!(picks[0].1, AddressType::NATted);
+        assert_eq!(picks[0].1, AddressType::Lan);
+    }
+
+    #[test]
+    fn select_dial_candidates_canonicalizes_local_scope_direct_to_lan() {
+        let addrs = typed(vec![
+            ("/ip4/198.51.100.1/udp/9000/quic", AddressType::Relay),
+            ("/ip4/192.168.1.10/udp/9003/quic", AddressType::Direct),
+        ]);
+
+        let picks = DhtNetworkManager::select_dial_candidates(&addrs);
+        assert_eq!(picks.len(), 1);
+        assert_eq!(picks[0].1, AddressType::Relay);
+
+        let local_only = typed(vec![(
+            "/ip4/192.168.1.10/udp/9003/quic",
+            AddressType::Unverified,
+        )]);
+        let picks = DhtNetworkManager::select_dial_candidates(&local_only);
+        assert_eq!(picks.len(), 1);
+        assert_eq!(picks[0].1, AddressType::Lan);
     }
 
     #[test]
@@ -5131,18 +5508,73 @@ mod tests {
     }
 
     #[test]
-    fn select_dial_candidates_prefers_unverified_over_natted() {
-        // When the "other" slot is contested, Unverified wins because it
-        // has a lower AddressType priority index than NATted.
+    fn select_dial_candidates_prefers_unverified_over_lan_without_local_context() {
+        // Without a same-WAN/local-LAN signal, LAN addresses are not tried
+        // while a WAN Unverified candidate exists.
         let addrs = typed(vec![
             ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
-            ("/ip6/2001:db8::10/udp/9003/quic", AddressType::NATted),
+            ("/ip6/fd00::10/udp/9003/quic", AddressType::Lan),
             ("/ip6/2001:db8::9/udp/9002/quic", AddressType::Unverified),
         ]);
         let picks = DhtNetworkManager::select_dial_candidates(&addrs);
         assert_eq!(picks.len(), 2);
         assert_eq!(picks[0].1, AddressType::Direct);
         assert_eq!(picks[1].1, AddressType::Unverified);
+    }
+
+    #[test]
+    fn select_dial_candidates_prefers_lan_for_same_wan_peer() {
+        let addrs = typed(vec![
+            ("/ip4/198.51.100.1/udp/9000/quic", AddressType::Relay),
+            ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Unverified),
+            ("/ip4/192.168.1.30/udp/9001/quic", AddressType::Lan),
+        ]);
+        let context = DialAddressContext::from_parts(
+            ["203.0.113.7:12000".parse().unwrap()],
+            ["/ip4/10.0.0.2/udp/9000/quic".parse().unwrap()],
+            false,
+        );
+
+        let picks = DhtNetworkManager::select_dial_candidates_with_context(&addrs, &context);
+        assert_eq!(picks.len(), 3);
+        assert_eq!(picks[0].1, AddressType::Lan);
+        assert_eq!(picks[1].1, AddressType::Relay);
+        assert_eq!(picks[2].1, AddressType::Unverified);
+    }
+
+    #[test]
+    fn select_dial_candidates_prefers_lan_for_same_lan_prefix() {
+        let addrs = typed(vec![
+            ("/ip4/198.51.100.1/udp/9000/quic", AddressType::Relay),
+            ("/ip4/192.168.1.30/udp/9001/quic", AddressType::Lan),
+        ]);
+        let context = DialAddressContext::from_parts(
+            Vec::<SocketAddr>::new(),
+            ["/ip4/192.168.1.20/udp/9000/quic".parse().unwrap()],
+            false,
+        );
+
+        let picks = DhtNetworkManager::select_dial_candidates_with_context(&addrs, &context);
+        assert_eq!(picks.len(), 2);
+        assert_eq!(picks[0].1, AddressType::Lan);
+        assert_eq!(picks[1].1, AddressType::Relay);
+    }
+
+    #[test]
+    fn select_dial_candidates_skips_lan_when_peer_is_external() {
+        let addrs = typed(vec![
+            ("/ip4/198.51.100.1/udp/9000/quic", AddressType::Relay),
+            ("/ip4/192.168.50.30/udp/9001/quic", AddressType::Lan),
+        ]);
+        let context = DialAddressContext::from_parts(
+            ["203.0.113.9:12000".parse().unwrap()],
+            ["/ip4/10.0.0.2/udp/9000/quic".parse().unwrap()],
+            false,
+        );
+
+        let picks = DhtNetworkManager::select_dial_candidates_with_context(&addrs, &context);
+        assert_eq!(picks.len(), 1);
+        assert_eq!(picks[0].1, AddressType::Relay);
     }
 
     #[test]

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -2174,7 +2174,13 @@ impl DhtNetworkManager {
         loop {
             match rx.recv().await {
                 Ok(failed_peer) if failed_peer == peer_id => return,
-                Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Ok(_) => continue,
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    // The skipped window may have contained this peer. Treat
+                    // lag as a conservative failure signal so lookup storms do
+                    // not leave waiters spending their full request timeout.
+                    return;
+                }
                 Err(broadcast::error::RecvError::Closed) => std::future::pending::<()>().await,
             }
         }
@@ -4453,6 +4459,25 @@ mod tests {
         )
         .await
         .expect("matching peer failure should wake the waiter");
+    }
+
+    #[tokio::test]
+    async fn lookup_failure_signal_aborts_when_receiver_lagged() {
+        let coordinator = LookupFailureCoordinator::new();
+        let target = pid(12);
+        let other = pid(13);
+        let rx = coordinator.subscribe();
+
+        for _ in 0..=LOOKUP_FAILURE_BROADCAST_CAPACITY {
+            coordinator.notify_failed(other);
+        }
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            DhtNetworkManager::wait_for_lookup_failure_signal(target, rx),
+        )
+        .await
+        .expect("lagged receiver should conservatively wake the waiter");
     }
 
     #[test]

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -3172,7 +3172,7 @@ impl DhtNetworkManager {
     /// Peers whose user agent is not yet known (e.g. identity announce still
     /// in flight) are skipped — they will be handled by the normal
     /// `PeerConnected` event path once authentication completes.
-    async fn reconcile_connected_peers(&self) {
+    async fn reconcile_connected_peers(self: &Arc<Self>) {
         let connected = self.transport.connected_peers().await;
         if connected.is_empty() {
             return;
@@ -3207,7 +3207,7 @@ impl DhtNetworkManager {
     /// The `node_id` is the authenticated app-level [`PeerId`] — no
     /// `canonical_app_peer_id()` lookup is needed because `PeerConnected`
     /// only fires after identity verification.
-    async fn handle_peer_connected(&self, node_id: PeerId, user_agent: &str) {
+    async fn handle_peer_connected(self: &Arc<Self>, node_id: PeerId, user_agent: &str) {
         let app_peer_id_hex = node_id.to_hex();
 
         info!(
@@ -3285,30 +3285,13 @@ impl DhtNetworkManager {
                         app_peer_id_hex,
                         stale_peers.len()
                     );
-                    match self
-                        .revalidate_and_retry_admission(
-                            candidate,
-                            candidate_ips,
-                            candidate_bucket_idx,
-                            stale_peers,
-                            &trust_fn,
-                        )
-                        .await
-                    {
-                        Ok(rt_events) => {
-                            info!(
-                                "Added peer {} to DHT routing table after stale revalidation",
-                                app_peer_id_hex
-                            );
-                            self.broadcast_routing_events(&rt_events);
-                        }
-                        Err(e) => {
-                            warn!(
-                                "Stale revalidation for peer {} failed: {}",
-                                app_peer_id_hex, e
-                            );
-                        }
-                    }
+                    self.spawn_revalidate_and_retry_admission(
+                        candidate,
+                        candidate_ips,
+                        candidate_bucket_idx,
+                        stale_peers,
+                        app_peer_id_hex.clone(),
+                    );
                 }
                 Err(e) => {
                     debug!(
@@ -3325,6 +3308,68 @@ impl DhtNetworkManager {
                 dht_key,
             });
         }
+    }
+
+    /// Spawn stale-peer revalidation and retry routing-table admission.
+    ///
+    /// This path can spend seconds pinging stale peers, so it must not run
+    /// inline on the transport event processor.
+    fn spawn_revalidate_and_retry_admission(
+        self: &Arc<Self>,
+        candidate: NodeInfo,
+        candidate_ips: Vec<IpAddr>,
+        candidate_bucket_idx: usize,
+        stale_peers: Vec<(PeerId, usize)>,
+        app_peer_id_hex: String,
+    ) {
+        let this = Arc::clone(self);
+        let trust_engine = self.trust_engine.clone();
+        let shutdown = self.shutdown.clone();
+
+        tokio::spawn(async move {
+            let result = tokio::select! {
+                () = shutdown.cancelled() => {
+                    debug!(
+                        "Cancelled stale revalidation for peer {} during shutdown",
+                        app_peer_id_hex
+                    );
+                    return;
+                }
+                result = async {
+                    let trust_fn = |peer_id: &PeerId| -> f64 {
+                        trust_engine
+                            .as_ref()
+                            .map(|engine| engine.score(peer_id))
+                            .unwrap_or(DEFAULT_NEUTRAL_TRUST)
+                    };
+
+                    this.revalidate_and_retry_admission(
+                        candidate,
+                        candidate_ips,
+                        candidate_bucket_idx,
+                        stale_peers,
+                        &trust_fn,
+                    )
+                    .await
+                } => result,
+            };
+
+            match result {
+                Ok(rt_events) => {
+                    info!(
+                        "Added peer {} to DHT routing table after stale revalidation",
+                        app_peer_id_hex
+                    );
+                    this.broadcast_routing_events(&rt_events);
+                }
+                Err(e) => {
+                    warn!(
+                        "Stale revalidation for peer {} failed: {}",
+                        app_peer_id_hex, e
+                    );
+                }
+            }
+        });
     }
 
     /// Start network event handler

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -136,6 +136,13 @@ const STALE_REVALIDATION_BUDGET: Duration =
 /// lagging.
 const PENDING_DIAL_BROADCAST_CAPACITY: usize = 16;
 
+/// Broadcast buffer for active FIND_NODE peer-failure signals.
+///
+/// Only active lookup probes subscribe, and each message is a single
+/// [`PeerId`]. A larger buffer than the dial coordinator keeps a short burst
+/// of failing peers from lagging sibling lookups during upload/download storms.
+const LOOKUP_FAILURE_BROADCAST_CAPACITY: usize = 1024;
+
 /// Maximum concurrent stale revalidation passes across all buckets.
 const MAX_CONCURRENT_REVALIDATIONS: usize = 8;
 
@@ -532,6 +539,10 @@ pub struct DhtNetworkManager {
     /// handshake runs once — not once per caller racing through the
     /// window where `peer_to_channel` has not yet been populated.
     pending_peer_dials: Arc<DashMap<PeerId, broadcast::Sender<PendingDialOutcome>>>,
+    /// Active FIND_NODE failure broadcaster. When one lookup observes that a
+    /// peer failed while it was being queried, every other active lookup that
+    /// is waiting on the same peer can stop spending an alpha slot on it.
+    lookup_failures: Arc<LookupFailureCoordinator>,
 }
 
 /// Outcome of a shared dial+identity-exchange attempt, broadcast to
@@ -877,6 +888,73 @@ const QUORUM_THRESHOLD: usize = 2;
 /// arrive and feeds [`compute_winner`].
 type SubjectReports = HashMap<PeerId, DHTNode>;
 
+#[derive(Debug)]
+struct LookupFailureCoordinator {
+    tx: broadcast::Sender<PeerId>,
+}
+
+impl LookupFailureCoordinator {
+    fn new() -> Self {
+        let (tx, _) = broadcast::channel(LOOKUP_FAILURE_BROADCAST_CAPACITY);
+        Self { tx }
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<PeerId> {
+        self.tx.subscribe()
+    }
+
+    fn notify_failed(&self, peer_id: PeerId) {
+        // No active subscribers is the common case. `send` only fails when
+        // receiver_count == 0, so ignore the returned peer id.
+        let _ = self.tx.send(peer_id);
+    }
+}
+
+/// Per-lookup state for peers in an iterative FIND_NODE query.
+///
+/// Mirrors rust-libp2p's closest-peer iterator model: peers move from
+/// "not contacted" (absence from the map) to `Waiting`, then to a final
+/// outcome. Final states are not selected again by the same lookup, so a
+/// failed or abandoned alpha probe cannot be reintroduced by later gossip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LookupPeerState {
+    Waiting,
+    Succeeded,
+    Failed,
+    Unresponsive,
+}
+
+#[derive(Debug, Default)]
+struct LookupPeerStates {
+    states: HashMap<PeerId, LookupPeerState>,
+}
+
+impl LookupPeerStates {
+    fn mark_waiting(&mut self, peer_id: PeerId) {
+        self.states.insert(peer_id, LookupPeerState::Waiting);
+    }
+
+    fn mark_succeeded(&mut self, peer_id: PeerId) {
+        self.states.insert(peer_id, LookupPeerState::Succeeded);
+    }
+
+    fn mark_failed(&mut self, peer_id: PeerId) {
+        self.states.insert(peer_id, LookupPeerState::Failed);
+    }
+
+    fn mark_unresponsive(&mut self, peer_id: PeerId) {
+        self.states.insert(peer_id, LookupPeerState::Unresponsive);
+    }
+
+    fn is_contactable(&self, peer_id: &PeerId) -> bool {
+        !self.states.contains_key(peer_id)
+    }
+
+    fn state(&self, peer_id: &PeerId) -> Option<LookupPeerState> {
+        self.states.get(peer_id).copied()
+    }
+}
+
 /// Best (lowest-numeric) [`AddressType::priority`] across a node's
 /// address tags. `u8::MAX` when the address list is empty.
 ///
@@ -1027,6 +1105,7 @@ impl DhtNetworkManager {
             dial_failure_cache: Arc::new(DialFailureCache::new()),
             identity_failure_cache: Arc::new(IdentityFailureCache::new()),
             pending_peer_dials: Arc::new(DashMap::new()),
+            lookup_failures: Arc::new(LookupFailureCoordinator::new()),
         })
     }
 
@@ -1627,7 +1706,7 @@ impl DhtNetworkManager {
         );
 
         let target_key = DhtKey::from_bytes(*key);
-        let mut queried_nodes: HashSet<PeerId> = HashSet::new();
+        let mut peer_states = LookupPeerStates::default();
         let mut best_nodes: Vec<DHTNode> = Vec::new();
 
         // Kademlia correctness: the local node must compete on distance in the
@@ -1635,7 +1714,7 @@ impl DhtNetworkManager {
         // Seed best_nodes with self and mark self as "queried" so the iterative
         // loop never tries to contact us.
         best_nodes.push(self.local_dht_node().await);
-        self.mark_self_queried(&mut queried_nodes);
+        self.mark_self_queried(&mut peer_states);
 
         // Candidates sorted by XOR distance to target (closest first).
         // Composite key (distance, peer_id) ensures uniqueness when two peers
@@ -1651,7 +1730,7 @@ impl DhtNetworkManager {
         // Start with local knowledge
         let initial = self.find_closest_nodes_local(key, count).await;
         for node in initial {
-            if !queried_nodes.contains(&node.peer_id) {
+            if peer_states.is_contactable(&node.peer_id) {
                 let dist = node.peer_id.distance(&target_key);
                 candidates.entry((dist, node.peer_id)).or_insert(node);
             }
@@ -1680,9 +1759,10 @@ impl DhtNetworkManager {
                     break;
                 };
                 let node = entry.remove();
-                if queried_nodes.contains(&node.peer_id) {
+                if !peer_states.is_contactable(&node.peer_id) {
                     continue;
                 }
+                peer_states.mark_waiting(node.peer_id);
                 batch.push(node);
             }
 
@@ -1720,41 +1800,34 @@ impl DhtNetworkManager {
                 .map(|node| {
                     let peer_id = node.peer_id;
                     let typed = node.typed_addresses();
-                    let op = DhtNetworkOperation::FindNode { key: *key };
+                    let lookup_key = *key;
+                    let failure_rx = self.lookup_failures.subscribe();
                     async move {
-                        // Pass the same typed candidate list to both
-                        // ensure_peer_channel and send_dht_request so
-                        // the request path doesn't pay a redundant
-                        // routing-table read. Trying every dialable
-                        // address — instead of stopping at the first
-                        // — protects against stale NAT bindings,
-                        // single-IP-family failures, and
-                        // recently-relayed peers whose direct address
-                        // is no longer reachable.
-                        //
-                        // Going through ensure_peer_channel (instead
-                        // of dial_addresses directly) registers the
-                        // in-flight dial in the peer-dial coordinator,
-                        // so a concurrent iterative lookup from a
-                        // different top-level operation that happens
-                        // to batch the same peer joins this dial
-                        // rather than racing it.
-                        let _ = self.ensure_peer_channel(&peer_id, &typed).await;
-                        (
-                            peer_id,
-                            self.send_dht_request(&peer_id, op, Some(&typed)).await,
-                        )
+                        self.send_find_node_lookup_request(peer_id, typed, lookup_key, failure_rx)
+                            .await
                     }
                 })
                 .collect();
 
             let results = Self::collect_iteration_results(query_stream).await;
+            let responded: HashSet<PeerId> = results.iter().map(|(peer_id, _)| *peer_id).collect();
+
+            // Queries still pending after the grace window are dropped. Treat
+            // them like libp2p's `Unresponsive`: they free alpha capacity and
+            // are skipped for the rest of this lookup, preventing later gossip
+            // from reintroducing the same abandoned probe.
+            for node in &batch {
+                if !responded.contains(&node.peer_id)
+                    && peer_states.state(&node.peer_id) == Some(LookupPeerState::Waiting)
+                {
+                    peer_states.mark_unresponsive(node.peer_id);
+                }
+            }
 
             for (peer_id, result) in results {
-                queried_nodes.insert(peer_id);
-
                 match result {
                     Ok(DhtNetworkResult::NodesFound { mut nodes, .. }) => {
+                        peer_states.mark_succeeded(peer_id);
                         // Add successful node to best_nodes
                         if let Some(queried_node) = batch.iter().find(|n| n.peer_id == peer_id) {
                             best_nodes.push(queried_node.clone());
@@ -1766,7 +1839,7 @@ impl DhtNetworkManager {
                         nodes.sort_by(|a, b| Self::compare_node_distance(a, b, key));
                         nodes.truncate(self.k_value());
                         for node in nodes {
-                            if queried_nodes.contains(&node.peer_id)
+                            if !peer_states.is_contactable(&node.peer_id)
                                 || self.is_local_peer_id(&node.peer_id)
                             {
                                 continue;
@@ -1832,6 +1905,7 @@ impl DhtNetworkManager {
                         }
                     }
                     Ok(DhtNetworkResult::PeerRejected) => {
+                        peer_states.mark_failed(peer_id);
                         // Remote peer rejected us (e.g. older node with blocking) —
                         // remove them from our routing table (no point retrying) but
                         // do NOT penalise their trust score; the rejection is an
@@ -1847,12 +1921,14 @@ impl DhtNetworkManager {
                         let _ = self.transport.disconnect_peer(&peer_id).await;
                     }
                     Ok(_) => {
+                        peer_states.mark_succeeded(peer_id);
                         // Add successful node to best_nodes
                         if let Some(queried_node) = batch.iter().find(|n| n.peer_id == peer_id) {
                             best_nodes.push(queried_node.clone());
                         }
                     }
                     Err(e) => {
+                        peer_states.mark_failed(peer_id);
                         trace!("[NETWORK] Query to {} failed: {}", peer_id.to_hex(), e);
                         // Trust failure is recorded inside send_dht_request —
                         // no additional recording needed here.
@@ -1913,6 +1989,85 @@ impl DhtNetworkManager {
         );
 
         Ok(best_nodes)
+    }
+
+    /// Send one iterative FIND_NODE probe, aborting early if another active
+    /// lookup reports the same peer as failed.
+    ///
+    /// This is the closest analogue to libp2p feeding a dial/connection
+    /// failure into every active query that is waiting on that peer. The
+    /// actual request owns the failure notification: externally-cancelled
+    /// probes return an error but do not rebroadcast, avoiding feedback loops.
+    async fn send_find_node_lookup_request(
+        &self,
+        peer_id: PeerId,
+        typed: Vec<(MultiAddr, AddressType)>,
+        key: Key,
+        failure_rx: broadcast::Receiver<PeerId>,
+    ) -> (PeerId, Result<DhtNetworkResult>) {
+        let request = async {
+            // Pass the same typed candidate list to both ensure_peer_channel
+            // and send_dht_request so the request path doesn't pay a redundant
+            // routing-table read. Trying every dialable address protects
+            // against stale NAT bindings, single-IP-family failures, and
+            // recently-relayed peers whose direct address is no longer reachable.
+            //
+            // Going through ensure_peer_channel registers the in-flight dial in
+            // the peer-dial coordinator, so concurrent iterative lookups that
+            // happen to batch the same peer join this dial rather than racing it.
+            self.ensure_peer_channel(&peer_id, &typed).await?;
+            self.send_dht_request(
+                &peer_id,
+                DhtNetworkOperation::FindNode { key },
+                Some(&typed),
+            )
+            .await
+        };
+        tokio::pin!(request);
+
+        let external_failure = Self::wait_for_lookup_failure_signal(peer_id, failure_rx);
+        tokio::pin!(external_failure);
+
+        let result = tokio::select! {
+            biased;
+
+            result = &mut request => {
+                if result.is_err() {
+                    self.notify_lookup_peer_failed(peer_id);
+                }
+                result
+            }
+            () = &mut external_failure => {
+                Err(Self::active_lookup_peer_failed_error(&peer_id))
+            }
+        };
+
+        (peer_id, result)
+    }
+
+    /// Wait until the active-lookup failure bus reports `peer_id`.
+    async fn wait_for_lookup_failure_signal(peer_id: PeerId, mut rx: broadcast::Receiver<PeerId>) {
+        loop {
+            match rx.recv().await {
+                Ok(failed_peer) if failed_peer == peer_id => return,
+                Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => std::future::pending::<()>().await,
+            }
+        }
+    }
+
+    fn notify_lookup_peer_failed(&self, peer_id: PeerId) {
+        self.lookup_failures.notify_failed(peer_id);
+    }
+
+    fn active_lookup_peer_failed_error(peer_id: &PeerId) -> P2PError {
+        P2PError::Network(NetworkError::PeerNotFound(
+            format!(
+                "peer {} failed in another active FIND_NODE lookup",
+                peer_id.to_hex()
+            )
+            .into(),
+        ))
     }
 
     /// Compare two nodes by their XOR distance to a target key.
@@ -2005,10 +2160,10 @@ impl DhtNetworkManager {
         }
     }
 
-    /// Add the local app-level peer ID to `queried` so that iterative lookups
-    /// never send RPCs to the local node.
-    fn mark_self_queried(&self, queried: &mut HashSet<PeerId>) {
-        queried.insert(self.config.peer_id);
+    /// Add the local app-level peer ID to the per-lookup state map so that
+    /// iterative lookups never send RPCs to the local node.
+    fn mark_self_queried(&self, peer_states: &mut LookupPeerStates) {
+        peer_states.mark_succeeded(self.config.peer_id);
     }
 
     /// Return the first dialable `Direct`-tagged address from a [`DHTNode`].
@@ -3401,6 +3556,7 @@ impl DhtNetworkManager {
                                         "DHT peer fully disconnected: app_id={}",
                                         peer_id.to_hex()
                                     );
+                                    self_arc.notify_lookup_peer_failed(peer_id);
 
                                     if self_arc.event_tx.receiver_count() > 0
                                         && let Err(e) = self_arc
@@ -4038,6 +4194,78 @@ mod tests {
             STALE_REVALIDATION_BUDGET,
             IDENTITY_EXCHANGE_TIMEOUT + STALE_REVALIDATION_PING_RTT,
         );
+    }
+
+    #[test]
+    fn lookup_peer_states_only_absent_peers_are_contactable() {
+        let mut states = LookupPeerStates::default();
+        let waiting = pid(1);
+        let succeeded = pid(2);
+        let failed = pid(3);
+        let unresponsive = pid(4);
+        let fresh = pid(5);
+
+        states.mark_waiting(waiting);
+        states.mark_succeeded(succeeded);
+        states.mark_failed(failed);
+        states.mark_unresponsive(unresponsive);
+
+        assert!(!states.is_contactable(&waiting));
+        assert!(!states.is_contactable(&succeeded));
+        assert!(!states.is_contactable(&failed));
+        assert!(!states.is_contactable(&unresponsive));
+        assert!(states.is_contactable(&fresh));
+    }
+
+    #[test]
+    fn lookup_peer_states_failure_and_unresponsive_are_final_for_lookup() {
+        let mut states = LookupPeerStates::default();
+        let failed = pid(7);
+        let unresponsive = pid(8);
+
+        states.mark_waiting(failed);
+        states.mark_failed(failed);
+        states.mark_waiting(unresponsive);
+        states.mark_unresponsive(unresponsive);
+
+        assert_eq!(states.state(&failed), Some(LookupPeerState::Failed));
+        assert_eq!(
+            states.state(&unresponsive),
+            Some(LookupPeerState::Unresponsive)
+        );
+        assert!(!states.is_contactable(&failed));
+        assert!(!states.is_contactable(&unresponsive));
+    }
+
+    #[tokio::test]
+    async fn lookup_failure_coordinator_broadcasts_to_all_subscribers() {
+        let coordinator = LookupFailureCoordinator::new();
+        let peer = pid(9);
+        let mut first = coordinator.subscribe();
+        let mut second = coordinator.subscribe();
+
+        coordinator.notify_failed(peer);
+
+        assert_eq!(first.recv().await.unwrap(), peer);
+        assert_eq!(second.recv().await.unwrap(), peer);
+    }
+
+    #[tokio::test]
+    async fn lookup_failure_signal_waits_for_matching_peer() {
+        let coordinator = LookupFailureCoordinator::new();
+        let target = pid(10);
+        let other = pid(11);
+        let rx = coordinator.subscribe();
+
+        coordinator.notify_failed(other);
+        coordinator.notify_failed(target);
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            DhtNetworkManager::wait_for_lookup_failure_signal(target, rx),
+        )
+        .await
+        .expect("matching peer failure should wake the waiter");
     }
 
     #[test]

--- a/src/network.rs
+++ b/src/network.rs
@@ -1505,31 +1505,6 @@ impl P2PNode {
         data: Vec<u8>,
         addrs: &[MultiAddr],
     ) -> Result<()> {
-        self.send_message_inner(peer_id, protocol, data, addrs, false)
-            .await
-    }
-
-    /// Send a message to an authenticated peer and wait until QUIC confirms
-    /// the remote endpoint received the full stream before returning.
-    pub async fn send_message_with_delivery_ack(
-        &self,
-        peer_id: &PeerId,
-        protocol: &str,
-        data: Vec<u8>,
-        addrs: &[MultiAddr],
-    ) -> Result<()> {
-        self.send_message_inner(peer_id, protocol, data, addrs, true)
-            .await
-    }
-
-    async fn send_message_inner(
-        &self,
-        peer_id: &PeerId,
-        protocol: &str,
-        data: Vec<u8>,
-        addrs: &[MultiAddr],
-        wait_for_delivery_ack: bool,
-    ) -> Result<()> {
         // Snapshot channel IDs before the send attempt — transport.send_message
         // prunes dead channels from bookkeeping but does NOT close the
         // underlying QUIC connection.  We need the original IDs for
@@ -1544,21 +1519,11 @@ impl P2PNode {
 
             // Another sender may have connected while we waited for the lock.
             if self.transport.is_peer_connected(peer_id).await {
-                return self
-                    .transport_send_message(peer_id, protocol, data, wait_for_delivery_ack)
-                    .await;
+                return self.transport.send_message(peer_id, protocol, data).await;
             }
 
             return self
-                .reconnect_and_send(
-                    peer_id,
-                    protocol,
-                    data,
-                    addrs,
-                    &[],
-                    &[],
-                    wait_for_delivery_ack,
-                )
+                .reconnect_and_send(peer_id, protocol, data, addrs, &[], &[])
                 .await;
         }
 
@@ -1576,9 +1541,7 @@ impl P2PNode {
         let retry_data = data.clone();
 
         // Fast path: try existing connection.
-        let send_result = self
-            .transport_send_message(peer_id, protocol, data, wait_for_delivery_ack)
-            .await;
+        let send_result = self.transport.send_message(peer_id, protocol, data).await;
         match send_result {
             Ok(()) => return Ok(()),
             Err(e) => {
@@ -1613,7 +1576,8 @@ impl P2PNode {
                 self.transport.disconnect_channel(channel_id).await;
             }
             return self
-                .transport_send_message(peer_id, protocol, retry_data, wait_for_delivery_ack)
+                .transport
+                .send_message(peer_id, protocol, retry_data)
                 .await;
         }
 
@@ -1624,7 +1588,6 @@ impl P2PNode {
             addrs,
             &saved_addrs,
             &existing_channels,
-            wait_for_delivery_ack,
         )
         .await
     }
@@ -1638,7 +1601,6 @@ impl P2PNode {
         addrs: &[MultiAddr],
         saved_addrs: &[MultiAddr],
         stale_channels: &[String],
-        wait_for_delivery_ack: bool,
     ) -> Result<()> {
         // Resolve a dial address: caller-provided > saved > DHT.
         let (address, kind) = self
@@ -1685,24 +1647,7 @@ impl P2PNode {
         }
 
         // Send on the fresh connection.
-        self.transport_send_message(peer_id, protocol, data, wait_for_delivery_ack)
-            .await
-    }
-
-    async fn transport_send_message(
-        &self,
-        peer_id: &PeerId,
-        protocol: &str,
-        data: Vec<u8>,
-        wait_for_delivery_ack: bool,
-    ) -> Result<()> {
-        if wait_for_delivery_ack {
-            self.transport
-                .send_message_with_delivery_ack(peer_id, protocol, data)
-                .await
-        } else {
-            self.transport.send_message(peer_id, protocol, data).await
-        }
+        self.transport.send_message(peer_id, protocol, data).await
     }
 
     /// Resolve a dial address for `peer_id`, preferring caller-provided

--- a/src/network.rs
+++ b/src/network.rs
@@ -705,6 +705,10 @@ pub enum P2PEvent {
         /// For signed messages this is the authenticated app-level [`PeerId`];
         /// `None` for unsigned messages.
         source: Option<PeerId>,
+        /// IP transport address that delivered this message, when known.
+        ///
+        /// This is provenance metadata, not an identity signal.
+        transport_source: Option<MultiAddr>,
         /// Raw message data payload
         data: Vec<u8>,
     },
@@ -1768,6 +1772,7 @@ pub(crate) struct ParsedMessage {
 
 pub(crate) fn parse_protocol_message(bytes: &[u8], source: &str) -> Option<ParsedMessage> {
     let message: WireMessage = postcard::from_bytes(bytes).ok()?;
+    let transport_source = source.parse::<SocketAddr>().ok().map(MultiAddr::quic);
 
     // Validate timestamp to prevent replay attacks
     let now = std::time::SystemTime::now()
@@ -1832,6 +1837,7 @@ pub(crate) fn parse_protocol_message(bytes: &[u8], source: &str) -> Option<Parse
         event: P2PEvent::Message {
             topic: message.protocol,
             source: authenticated_node_id,
+            transport_source,
             data: message.data,
         },
         authenticated_node_id,
@@ -3327,9 +3333,14 @@ mod tests {
             P2PEvent::Message {
                 topic,
                 source,
+                transport_source,
                 data,
             } => {
                 assert!(source.is_none(), "unsigned message source must be None");
+                assert!(
+                    transport_source.is_none(),
+                    "non-socket transport source should not produce an IP transport address"
+                );
                 assert_eq!(topic, "test/v1");
                 assert_eq!(data, vec![1u8, 2, 3]);
             }
@@ -3360,6 +3371,26 @@ mod tests {
 
         match parsed.event {
             P2PEvent::Message { data, .. } => assert!(data.is_empty()),
+            other => panic!("expected P2PEvent::Message, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_protocol_message_records_ip_transport_source() {
+        let bytes = make_wire_bytes("ping", vec![1], "sender", current_timestamp());
+
+        let parsed =
+            parse_protocol_message(&bytes, "192.168.1.2:4567").expect("valid message should parse");
+
+        match parsed.event {
+            P2PEvent::Message {
+                transport_source, ..
+            } => {
+                assert_eq!(
+                    transport_source,
+                    Some(MultiAddr::quic("192.168.1.2:4567".parse().unwrap()))
+                );
+            }
             other => panic!("expected P2PEvent::Message, got {:?}", other),
         }
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -1304,12 +1304,15 @@ impl P2PNode {
                                     "Updating DHT: peer {} relay address {} (connection was {})",
                                     peer_id, advertised_addr, peer_addr
                                 );
-                                dht.touch_node_typed(
-                                    &peer_id,
-                                    Some(&multi_addr),
-                                    AddressType::Relay,
-                                )
-                                .await;
+                                if !dht
+                                    .touch_legacy_relay_hint_if_unsequenced(&peer_id, &multi_addr)
+                                    .await
+                                {
+                                    debug!(
+                                        "DHT_BRIDGE: ignored legacy relay hint for sequenced peer {} addr {}",
+                                        peer_id, advertised_addr
+                                    );
+                                }
                             }
                         }
                     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -1505,6 +1505,31 @@ impl P2PNode {
         data: Vec<u8>,
         addrs: &[MultiAddr],
     ) -> Result<()> {
+        self.send_message_inner(peer_id, protocol, data, addrs, false)
+            .await
+    }
+
+    /// Send a message to an authenticated peer and wait until QUIC confirms
+    /// the remote endpoint received the full stream before returning.
+    pub async fn send_message_with_delivery_ack(
+        &self,
+        peer_id: &PeerId,
+        protocol: &str,
+        data: Vec<u8>,
+        addrs: &[MultiAddr],
+    ) -> Result<()> {
+        self.send_message_inner(peer_id, protocol, data, addrs, true)
+            .await
+    }
+
+    async fn send_message_inner(
+        &self,
+        peer_id: &PeerId,
+        protocol: &str,
+        data: Vec<u8>,
+        addrs: &[MultiAddr],
+        wait_for_delivery_ack: bool,
+    ) -> Result<()> {
         // Snapshot channel IDs before the send attempt — transport.send_message
         // prunes dead channels from bookkeeping but does NOT close the
         // underlying QUIC connection.  We need the original IDs for
@@ -1519,11 +1544,21 @@ impl P2PNode {
 
             // Another sender may have connected while we waited for the lock.
             if self.transport.is_peer_connected(peer_id).await {
-                return self.transport.send_message(peer_id, protocol, data).await;
+                return self
+                    .transport_send_message(peer_id, protocol, data, wait_for_delivery_ack)
+                    .await;
             }
 
             return self
-                .reconnect_and_send(peer_id, protocol, data, addrs, &[], &[])
+                .reconnect_and_send(
+                    peer_id,
+                    protocol,
+                    data,
+                    addrs,
+                    &[],
+                    &[],
+                    wait_for_delivery_ack,
+                )
                 .await;
         }
 
@@ -1541,7 +1576,10 @@ impl P2PNode {
         let retry_data = data.clone();
 
         // Fast path: try existing connection.
-        match self.transport.send_message(peer_id, protocol, data).await {
+        let send_result = self
+            .transport_send_message(peer_id, protocol, data, wait_for_delivery_ack)
+            .await;
+        match send_result {
             Ok(()) => return Ok(()),
             Err(e) => {
                 if !e.is_stale_channel_send_failure() {
@@ -1575,8 +1613,7 @@ impl P2PNode {
                 self.transport.disconnect_channel(channel_id).await;
             }
             return self
-                .transport
-                .send_message(peer_id, protocol, retry_data)
+                .transport_send_message(peer_id, protocol, retry_data, wait_for_delivery_ack)
                 .await;
         }
 
@@ -1587,6 +1624,7 @@ impl P2PNode {
             addrs,
             &saved_addrs,
             &existing_channels,
+            wait_for_delivery_ack,
         )
         .await
     }
@@ -1600,6 +1638,7 @@ impl P2PNode {
         addrs: &[MultiAddr],
         saved_addrs: &[MultiAddr],
         stale_channels: &[String],
+        wait_for_delivery_ack: bool,
     ) -> Result<()> {
         // Resolve a dial address: caller-provided > saved > DHT.
         let (address, kind) = self
@@ -1646,7 +1685,24 @@ impl P2PNode {
         }
 
         // Send on the fresh connection.
-        self.transport.send_message(peer_id, protocol, data).await
+        self.transport_send_message(peer_id, protocol, data, wait_for_delivery_ack)
+            .await
+    }
+
+    async fn transport_send_message(
+        &self,
+        peer_id: &PeerId,
+        protocol: &str,
+        data: Vec<u8>,
+        wait_for_delivery_ack: bool,
+    ) -> Result<()> {
+        if wait_for_delivery_ack {
+            self.transport
+                .send_message_with_delivery_ack(peer_id, protocol, data)
+                .await
+        } else {
+            self.transport.send_message(peer_id, protocol, data).await
+        }
     }
 
     /// Resolve a dial address for `peer_id`, preferring caller-provided

--- a/src/network.rs
+++ b/src/network.rs
@@ -1452,7 +1452,7 @@ impl P2PNode {
     /// Same as [`Self::connect_peer`] but threads the [`AddressType`]
     /// through to the transport-level dial log so an operator can tell,
     /// after the fact, whether a failed dial was against a `Direct`,
-    /// `Relay`, `Unverified`, or `NATted` address.
+    /// `Relay`, `Unverified`, or `Lan` address.
     pub async fn connect_peer_typed(
         &self,
         address: &MultiAddr,

--- a/src/reachability/acquisition.rs
+++ b/src/reachability/acquisition.rs
@@ -22,9 +22,10 @@
 //!
 //! 1. The caller supplies a pre-filtered list of [`RelayCandidate`]s sorted
 //!    by XOR distance (closest first). Filtering — selecting peers whose
-//!    own DHT record contains at least one `Direct` address — is the
-//!    caller's responsibility, not the coordinator's. See
-//!    [`DhtNetworkManager::first_direct_dialable`](crate::dht_network_manager::DhtNetworkManager::first_direct_dialable)
+//!    own DHT record contains at least one `Direct` address that is not on
+//!    the local node's WAN IP — is the caller's responsibility, not the
+//!    coordinator's. See
+//!    [`DhtNetworkManager::first_direct_dialable_for_relay`](crate::dht_network_manager::DhtNetworkManager::first_direct_dialable_for_relay)
 //!    for the canonical filter.
 //! 2. [`RelayAcquisition::acquire`] tries each candidate in order. On
 //!    `AtCapacity` or `Unreachable` it walks to the next candidate. On the

--- a/src/reachability/driver.rs
+++ b/src/reachability/driver.rs
@@ -64,7 +64,7 @@ use tracing::{debug, info, trace, warn};
 use crate::dht::AddressType;
 use crate::dht_network_manager::{DhtNetworkEvent, DhtNetworkManager};
 use crate::reachability::session::{RelayAcquisitionOutcome, run_relay_acquisition};
-use crate::self_address::build_typed_self_address_set;
+use crate::self_address::build_self_address_set;
 use crate::transport_handle::TransportHandle;
 use crate::{MultiAddr, PeerId};
 
@@ -229,14 +229,16 @@ impl AcquisitionDriver {
             "driver: preparing typed self address set"
         );
 
-        let typed = build_typed_self_address_set(observed, listen, relay, |sa| {
+        let self_addresses = build_self_address_set(observed, listen, relay, |sa| {
             self.transport.is_external_proven(sa)
         });
 
-        if typed.is_empty() {
+        if self_addresses.is_empty() {
             debug!("driver: publish skipped, no dialable self addresses");
             return;
         }
+
+        let typed = self_addresses.into_typed_vec();
 
         let own_key = *self.dht.peer_id().to_bytes();
         let all_peers = self

--- a/src/reachability/session.rs
+++ b/src/reachability/session.rs
@@ -14,11 +14,13 @@
 //! Unconditional MASQUE relay acquisition.
 //!
 //! Every non-client node tries to acquire a MASQUE relay from an XOR-closest
-//! peer after bootstrap. There is no dial-back probe and no public/private
-//! classification: the "is this candidate public?" question is answered
-//! ambiently by the dial attempt itself. A candidate whose Direct address is
-//! unreachable will simply fail to accept the CONNECT-UDP request, and the
-//! walker moves to the next-closest peer.
+//! peer after bootstrap. Candidates on the same WAN as this node are filtered
+//! out because they do not provide a distinct public route. There is no
+//! dial-back probe and no broader public/private classification: the "is this
+//! candidate public?" question is answered ambiently by the dial attempt
+//! itself. A candidate whose Direct address is unreachable will simply fail to
+//! accept the CONNECT-UDP request, and the walker moves to the next-closest
+//! peer.
 //!
 //! The acquisition walk is a thin wrapper around the reusable
 //! [`RelayAcquisition`] coordinator: build a filtered candidate list from
@@ -71,10 +73,10 @@ pub(crate) enum RelayAcquisitionOutcome {
 
 /// Run a single unconditional relay-acquisition attempt.
 ///
-/// Walks the XOR-closest peers in the local routing table, filters to
-/// those advertising at least one `Direct` address, and tries each in
-/// order via the [`RelayAcquisition`] coordinator until one accepts a
-/// MASQUE CONNECT-UDP reservation.
+/// Walks the XOR-closest peers in the local routing table, filters to those
+/// advertising at least one `Direct` address that is not on this node's own
+/// WAN IP, and tries each in order via the [`RelayAcquisition`] coordinator
+/// until one accepts a MASQUE CONNECT-UDP reservation.
 ///
 /// The "is this candidate public?" check is implicit: a private candidate's
 /// Direct address is unreachable from outside its NAT, so the QUIC dial
@@ -94,6 +96,7 @@ pub(crate) async fn run_relay_acquisition(
 
     let own_key = *dht.peer_id().to_bytes();
     let closest = dht.find_closest_nodes_local(&own_key, dht.k_value()).await;
+    let local_address_context = dht.local_dial_address_context().await;
 
     debug!(
         closest_count = closest.len(),
@@ -103,7 +106,8 @@ pub(crate) async fn run_relay_acquisition(
     let mut candidates: Vec<RelayCandidate> = Vec::new();
     for node in &closest {
         let typed = node.typed_addresses();
-        let direct = DhtNetworkManager::first_direct_dialable(node);
+        let direct =
+            DhtNetworkManager::first_direct_dialable_for_relay(node, &local_address_context);
         debug!(
             peer = %node.peer_id.to_hex(),
             typed_addresses = ?typed,

--- a/src/self_address.rs
+++ b/src/self_address.rs
@@ -36,7 +36,6 @@
 //! same-family non-relay candidates only makes receivers discard or ignore
 //! them, so this helper selects the address set receivers can actually use.
 
-use std::collections::HashSet;
 use std::net::SocketAddr;
 
 use tracing::{debug, trace};
@@ -44,20 +43,17 @@ use tracing::{debug, trace};
 use crate::MultiAddr;
 use crate::dht::AddressType;
 
-pub(crate) fn build_typed_self_address_set<F>(
+pub(crate) fn build_self_address_set<F>(
     observed: impl IntoIterator<Item = SocketAddr>,
     listen: impl IntoIterator<Item = MultiAddr>,
     relay: Option<SocketAddr>,
     mut is_external_proven: F,
-) -> Vec<(MultiAddr, AddressType)>
+) -> SelfAddressSet
 where
     F: FnMut(SocketAddr) -> bool,
 {
-    let mut typed: Vec<(MultiAddr, AddressType)> = Vec::new();
-    let mut non_relay: Vec<FamilyAddressChoice> = Vec::new();
-    // Normalize addresses before dedup so IPv4-mapped IPv6
-    // (::ffff:a.b.c.d) and plain IPv4 (a.b.c.d) are treated as equal.
-    let mut seen: HashSet<SocketAddr> = HashSet::new();
+    let mut set = SelfAddressSet::default();
+    let mut candidate_index = 0;
 
     if let Some(relay_addr) = relay {
         let normalized = saorsa_transport::shared::normalize_socket_addr(relay_addr);
@@ -65,8 +61,7 @@ where
             address = %normalized,
             "self-address: adding relay address to publish set"
         );
-        typed.push((MultiAddr::quic(normalized), AddressType::Relay));
-        seen.insert(normalized);
+        set.relay = Some(normalized);
     }
 
     // Prefer observed (post-NAT) addresses when the reachability tier is the
@@ -77,8 +72,8 @@ where
         record_non_relay_self_address(
             sa,
             AddressSource::Observed,
-            &mut seen,
-            &mut non_relay,
+            &mut set,
+            &mut candidate_index,
             &mut is_external_proven,
         );
     }
@@ -93,17 +88,120 @@ where
         record_non_relay_self_address(
             sa,
             AddressSource::Listen,
-            &mut seen,
-            &mut non_relay,
+            &mut set,
+            &mut candidate_index,
             &mut is_external_proven,
         );
     }
 
-    for choice in non_relay {
-        typed.push((choice.address, choice.tag));
+    set
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct SelfAddressSet {
+    relay: Option<SocketAddr>,
+    v4: Option<FamilyAddressChoice>,
+    v6: Option<FamilyAddressChoice>,
+}
+
+impl SelfAddressSet {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.relay.is_none() && self.v4.is_none() && self.v6.is_none()
     }
 
-    typed
+    pub(crate) fn into_typed_vec(self) -> Vec<(MultiAddr, AddressType)> {
+        let mut typed = Vec::with_capacity(self.len());
+        if let Some(relay) = self.relay {
+            typed.push((MultiAddr::quic(relay), AddressType::Relay));
+        }
+        self.for_each_non_relay(|choice| {
+            typed.push((MultiAddr::quic(choice.socket_addr), choice.tag));
+        });
+        typed
+    }
+
+    pub(crate) fn into_parallel_vecs(self) -> (Vec<MultiAddr>, Vec<AddressType>) {
+        let mut addresses = Vec::with_capacity(self.len());
+        let mut address_types = Vec::with_capacity(self.len());
+        if let Some(relay) = self.relay {
+            addresses.push(MultiAddr::quic(relay));
+            address_types.push(AddressType::Relay);
+        }
+        self.for_each_non_relay(|choice| {
+            addresses.push(MultiAddr::quic(choice.socket_addr));
+            address_types.push(choice.tag);
+        });
+        (addresses, address_types)
+    }
+
+    fn len(&self) -> usize {
+        usize::from(self.relay.is_some())
+            + usize::from(self.v4.is_some())
+            + usize::from(self.v6.is_some())
+    }
+
+    fn contains_selected(&self, socket_addr: SocketAddr) -> bool {
+        self.relay == Some(socket_addr)
+            || self
+                .v4
+                .map(|choice| choice.socket_addr == socket_addr)
+                .unwrap_or(false)
+            || self
+                .v6
+                .map(|choice| choice.socket_addr == socket_addr)
+                .unwrap_or(false)
+    }
+
+    fn record_non_relay_choice(
+        &mut self,
+        socket_addr: SocketAddr,
+        tag: AddressType,
+        replace_same_tier: bool,
+        candidate_index: usize,
+    ) {
+        let slot = if socket_addr.ip().is_ipv4() {
+            &mut self.v4
+        } else {
+            &mut self.v6
+        };
+
+        let Some(existing) = slot else {
+            *slot = Some(FamilyAddressChoice {
+                first_seen_index: candidate_index,
+                socket_addr,
+                tag,
+            });
+            return;
+        };
+
+        if tag.priority() < existing.tag.priority()
+            || (replace_same_tier && tag.priority() == existing.tag.priority())
+        {
+            trace!(
+                old_tag = ?existing.tag,
+                new_tag = ?tag,
+                "self-address: replacing candidate for IP family"
+            );
+            existing.socket_addr = socket_addr;
+            existing.tag = tag;
+        }
+    }
+
+    fn for_each_non_relay(self, mut visit: impl FnMut(FamilyAddressChoice)) {
+        match (self.v4, self.v6) {
+            (Some(v4), Some(v6)) if v4.first_seen_index <= v6.first_seen_index => {
+                visit(v4);
+                visit(v6);
+            }
+            (Some(v4), Some(v6)) => {
+                visit(v6);
+                visit(v4);
+            }
+            (Some(v4), None) => visit(v4),
+            (None, Some(v6)) => visit(v6),
+            (None, None) => {}
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -132,8 +230,8 @@ impl AddressSource {
 fn record_non_relay_self_address<F>(
     socket_addr: SocketAddr,
     source: AddressSource,
-    seen: &mut HashSet<SocketAddr>,
-    non_relay: &mut Vec<FamilyAddressChoice>,
+    set: &mut SelfAddressSet,
+    candidate_index: &mut usize,
     is_external_proven: &mut F,
 ) where
     F: FnMut(SocketAddr) -> bool,
@@ -147,78 +245,43 @@ fn record_non_relay_self_address<F>(
         return;
     }
     let normalized = saorsa_transport::shared::normalize_socket_addr(socket_addr);
+    // Only emitted addresses need deduping. Same-family candidates that lose
+    // selection cannot win later with the same proof state, so tracking every
+    // seen candidate would add work without changing the publish set.
+    if set.contains_selected(normalized) {
+        trace!(
+            address = %normalized,
+            source = source.label(),
+            "self-address: deduped self address"
+        );
+        return;
+    }
+
     let tag = if is_external_proven(normalized) {
         AddressType::Direct
     } else {
         AddressType::Unverified
     };
-    if seen.insert(normalized) {
-        debug!(
-            address = %normalized,
-            tag = ?tag,
-            source = source.label(),
-            "self-address: adding address to candidate publish set"
-        );
-        record_non_relay_choice(non_relay, normalized, tag, source.replace_same_tier());
-    } else {
-        trace!(
-            address = %normalized,
-            tag = ?tag,
-            source = source.label(),
-            "self-address: deduped self address"
-        );
-    }
+    debug!(
+        address = %normalized,
+        tag = ?tag,
+        source = source.label(),
+        "self-address: adding address to candidate publish set"
+    );
+    set.record_non_relay_choice(
+        normalized,
+        tag,
+        source.replace_same_tier(),
+        *candidate_index,
+    );
+    *candidate_index = (*candidate_index).saturating_add(1);
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum IpFamily {
-    V4,
-    V6,
-}
-
-#[derive(Clone, Debug)]
 struct FamilyAddressChoice {
-    family: IpFamily,
-    address: MultiAddr,
-    tag: AddressType,
-}
-
-fn record_non_relay_choice(
-    choices: &mut Vec<FamilyAddressChoice>,
+    first_seen_index: usize,
     socket_addr: SocketAddr,
     tag: AddressType,
-    replace_same_tier: bool,
-) {
-    // Callers normalize before reaching this helper, so IPv4-mapped IPv6 is
-    // already represented as plain IPv4 and cannot be mis-bucketed as V6.
-    let family = if socket_addr.ip().is_ipv4() {
-        IpFamily::V4
-    } else {
-        IpFamily::V6
-    };
-
-    let address = MultiAddr::quic(socket_addr);
-    let Some(existing) = choices.iter_mut().find(|choice| choice.family == family) else {
-        choices.push(FamilyAddressChoice {
-            family,
-            address,
-            tag,
-        });
-        return;
-    };
-
-    if tag.priority() < existing.tag.priority()
-        || (replace_same_tier && tag.priority() == existing.tag.priority())
-    {
-        trace!(
-            family = ?family,
-            old_tag = ?existing.tag,
-            new_tag = ?tag,
-            "self-address: replacing candidate for IP family"
-        );
-        existing.address = address;
-        existing.tag = tag;
-    }
 }
 
 #[cfg(test)]
@@ -233,9 +296,38 @@ mod tests {
         s.parse().unwrap()
     }
 
+    fn typed_self_address_set<F>(
+        observed: impl IntoIterator<Item = SocketAddr>,
+        listen: impl IntoIterator<Item = MultiAddr>,
+        relay: Option<SocketAddr>,
+        is_external_proven: F,
+    ) -> Vec<(MultiAddr, AddressType)>
+    where
+        F: FnMut(SocketAddr) -> bool,
+    {
+        build_self_address_set(observed, listen, relay, is_external_proven).into_typed_vec()
+    }
+
+    #[test]
+    fn parallel_materialization_matches_typed_order() {
+        let proven_v4 = sock("203.0.113.10:10004");
+        let set = build_self_address_set(
+            [proven_v4, sock("[2001:db8::10]:10004")],
+            Vec::<MultiAddr>::new(),
+            Some(sock("198.51.100.1:45000")),
+            |sa| sa == proven_v4,
+        );
+
+        let typed = set.into_typed_vec();
+        let (addresses, address_types) = set.into_parallel_vecs();
+        let parallel_as_typed: Vec<_> = addresses.into_iter().zip(address_types).collect();
+
+        assert_eq!(parallel_as_typed, typed);
+    }
+
     #[test]
     fn publish_set_keeps_relay_primary_and_unverified_fallback() {
-        let typed = build_typed_self_address_set(
+        let typed = typed_self_address_set(
             [sock("203.0.113.10:10004")],
             Vec::<MultiAddr>::new(),
             Some(sock("198.51.100.1:45000")),
@@ -257,7 +349,7 @@ mod tests {
     #[test]
     fn publish_set_keeps_relay_primary_and_direct_fallback() {
         let proven = sock("203.0.113.10:10004");
-        let typed = build_typed_self_address_set(
+        let typed = typed_self_address_set(
             [proven],
             Vec::<MultiAddr>::new(),
             Some(sock("198.51.100.1:45000")),
@@ -278,7 +370,7 @@ mod tests {
 
     #[test]
     fn publish_set_keeps_relay_when_no_non_relay_address_exists() {
-        let typed = build_typed_self_address_set(
+        let typed = typed_self_address_set(
             Vec::<SocketAddr>::new(),
             Vec::<MultiAddr>::new(),
             Some(sock("198.51.100.1:45000")),
@@ -294,7 +386,7 @@ mod tests {
     #[test]
     fn publish_set_without_relay_prefers_direct_over_unverified() {
         let proven = sock("203.0.113.10:10004");
-        let typed = build_typed_self_address_set(
+        let typed = typed_self_address_set(
             [proven, sock("203.0.113.11:10004")],
             Vec::<MultiAddr>::new(),
             None,
@@ -314,7 +406,7 @@ mod tests {
     fn publish_set_keeps_unverified_for_family_without_direct() {
         let proven_v4 = sock("203.0.113.10:10004");
         let unverified_v6 = sock("[2001:db8::10]:10004");
-        let typed = build_typed_self_address_set(
+        let typed = typed_self_address_set(
             [proven_v4, unverified_v6],
             Vec::<MultiAddr>::new(),
             Some(sock("198.51.100.1:45000")),
@@ -341,12 +433,10 @@ mod tests {
     fn publish_set_keeps_one_best_non_relay_per_family() {
         let older_v4 = sock("203.0.113.10:10004");
         let newer_v4 = sock("203.0.113.11:10004");
-        let typed = build_typed_self_address_set(
-            [older_v4, newer_v4],
-            Vec::<MultiAddr>::new(),
-            None,
-            |sa| sa == older_v4 || sa == newer_v4,
-        );
+        let typed =
+            typed_self_address_set([older_v4, newer_v4], Vec::<MultiAddr>::new(), None, |sa| {
+                sa == older_v4 || sa == newer_v4
+            });
 
         assert_eq!(
             typed,
@@ -359,7 +449,7 @@ mod tests {
 
     #[test]
     fn publish_set_without_relay_publishes_unverified_when_no_direct() {
-        let typed = build_typed_self_address_set(
+        let typed = typed_self_address_set(
             [sock("203.0.113.11:10004")],
             Vec::<MultiAddr>::new(),
             None,
@@ -377,7 +467,7 @@ mod tests {
 
     #[test]
     fn publish_set_dedupes_listen_address_after_observed_address() {
-        let typed = build_typed_self_address_set(
+        let typed = typed_self_address_set(
             [sock("203.0.113.10:10004")],
             [addr("/ip4/203.0.113.10/udp/10004/quic")],
             None,
@@ -395,7 +485,7 @@ mod tests {
 
     #[test]
     fn publish_set_drops_wildcard_and_zero_port_addresses() {
-        let typed = build_typed_self_address_set(
+        let typed = typed_self_address_set(
             [sock("0.0.0.0:10004"), sock("203.0.113.10:0")],
             [
                 addr("/ip4/0.0.0.0/udp/10005/quic"),

--- a/src/self_address.rs
+++ b/src/self_address.rs
@@ -23,13 +23,17 @@
 //!
 //! 1. If a relay address exists, publish it first and tag it
 //!    [`AddressType::Relay`].
-//! 2. Publish at most one best non-relay address per IP family. A proven
-//!    externally reachable address is tagged [`AddressType::Direct`]; an
-//!    observed-but-unproven address is tagged [`AddressType::Unverified`].
-//!    Direct wins over Unverified within the same family.
-//! 3. If there is no relay, publish the same best non-relay set: Direct when
-//!    present, otherwise Unverified.
-//! 4. Drop non-dialable wildcard or zero-port addresses rather than
+//! 2. Publish at most one best WAN address per IP family. A proven externally
+//!    reachable address is tagged [`AddressType::Direct`]; an
+//!    observed-but-unproven WAN address is tagged
+//!    [`AddressType::Unverified`]. Direct wins over Unverified within the
+//!    same family.
+//! 3. Publish at most one LAN address per IP family, tagged
+//!    [`AddressType::Lan`]. LAN addresses are kept separate from WAN
+//!    Direct/Unverified addresses so same-WAN peers can prefer the local path
+//!    without advertising it as generally reachable.
+//! 4. If there is no relay, publish the same best WAN/LAN set.
+//! 5. Drop non-dialable wildcard or zero-port addresses rather than
 //!    advertising placeholders peers cannot connect to.
 //!
 //! The per-family cap mirrors the peer storage/dial policy. Publishing more
@@ -41,6 +45,7 @@ use std::net::SocketAddr;
 use tracing::{debug, trace};
 
 use crate::MultiAddr;
+use crate::address::is_lan_ip;
 use crate::dht::AddressType;
 
 pub(crate) fn build_self_address_set<F>(
@@ -66,8 +71,8 @@ where
 
     // Prefer observed (post-NAT) addresses when the reachability tier is the
     // same, since those are what peers actually see from the outside. Listen
-    // addresses still participate in tier selection, so a proven Direct
-    // listen socket can beat an Unverified observed socket in the same family.
+    // addresses still participate in tier selection, so a proven WAN listen
+    // socket can beat an Unverified observed socket in the same family.
     for sa in observed {
         record_non_relay_self_address(
             sa,
@@ -100,13 +105,19 @@ where
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(crate) struct SelfAddressSet {
     relay: Option<SocketAddr>,
-    v4: Option<FamilyAddressChoice>,
-    v6: Option<FamilyAddressChoice>,
+    wan_v4: Option<FamilyAddressChoice>,
+    wan_v6: Option<FamilyAddressChoice>,
+    lan_v4: Option<FamilyAddressChoice>,
+    lan_v6: Option<FamilyAddressChoice>,
 }
 
 impl SelfAddressSet {
     pub(crate) fn is_empty(&self) -> bool {
-        self.relay.is_none() && self.v4.is_none() && self.v6.is_none()
+        self.relay.is_none()
+            && self.wan_v4.is_none()
+            && self.wan_v6.is_none()
+            && self.lan_v4.is_none()
+            && self.lan_v6.is_none()
     }
 
     pub(crate) fn into_typed_vec(self) -> Vec<(MultiAddr, AddressType)> {
@@ -136,18 +147,28 @@ impl SelfAddressSet {
 
     fn len(&self) -> usize {
         usize::from(self.relay.is_some())
-            + usize::from(self.v4.is_some())
-            + usize::from(self.v6.is_some())
+            + usize::from(self.wan_v4.is_some())
+            + usize::from(self.wan_v6.is_some())
+            + usize::from(self.lan_v4.is_some())
+            + usize::from(self.lan_v6.is_some())
     }
 
     fn contains_selected(&self, socket_addr: SocketAddr) -> bool {
         self.relay == Some(socket_addr)
             || self
-                .v4
+                .wan_v4
                 .map(|choice| choice.socket_addr == socket_addr)
                 .unwrap_or(false)
             || self
-                .v6
+                .wan_v6
+                .map(|choice| choice.socket_addr == socket_addr)
+                .unwrap_or(false)
+            || self
+                .lan_v4
+                .map(|choice| choice.socket_addr == socket_addr)
+                .unwrap_or(false)
+            || self
+                .lan_v6
                 .map(|choice| choice.socket_addr == socket_addr)
                 .unwrap_or(false)
     }
@@ -159,10 +180,11 @@ impl SelfAddressSet {
         replace_same_tier: bool,
         candidate_index: usize,
     ) {
-        let slot = if socket_addr.ip().is_ipv4() {
-            &mut self.v4
-        } else {
-            &mut self.v6
+        let slot = match (tag, socket_addr.ip().is_ipv4()) {
+            (AddressType::Lan, true) => &mut self.lan_v4,
+            (AddressType::Lan, false) => &mut self.lan_v6,
+            (_, true) => &mut self.wan_v4,
+            (_, false) => &mut self.wan_v6,
         };
 
         let Some(existing) = slot else {
@@ -188,18 +210,14 @@ impl SelfAddressSet {
     }
 
     fn for_each_non_relay(self, mut visit: impl FnMut(FamilyAddressChoice)) {
-        match (self.v4, self.v6) {
-            (Some(v4), Some(v6)) if v4.first_seen_index <= v6.first_seen_index => {
-                visit(v4);
-                visit(v6);
-            }
-            (Some(v4), Some(v6)) => {
-                visit(v6);
-                visit(v4);
-            }
-            (Some(v4), None) => visit(v4),
-            (None, Some(v6)) => visit(v6),
-            (None, None) => {}
+        let mut choices: Vec<FamilyAddressChoice> =
+            [self.wan_v4, self.wan_v6, self.lan_v4, self.lan_v6]
+                .into_iter()
+                .flatten()
+                .collect();
+        choices.sort_by_key(|choice| (choice.tag.priority(), choice.first_seen_index));
+        for choice in choices {
+            visit(choice);
         }
     }
 }
@@ -257,7 +275,9 @@ fn record_non_relay_self_address<F>(
         return;
     }
 
-    let tag = if is_external_proven(normalized) {
+    let tag = if is_lan_ip(normalized.ip()) {
+        AddressType::Lan
+    } else if is_external_proven(normalized) {
         AddressType::Direct
     } else {
         AddressType::Unverified
@@ -462,6 +482,44 @@ mod tests {
                 addr("/ip4/203.0.113.11/udp/10004/quic"),
                 AddressType::Unverified,
             )]
+        );
+    }
+
+    #[test]
+    fn publish_set_tags_private_address_as_lan() {
+        let typed = typed_self_address_set(
+            [sock("192.168.1.10:10004")],
+            Vec::<MultiAddr>::new(),
+            None,
+            |_| true,
+        );
+
+        assert_eq!(
+            typed,
+            vec![(addr("/ip4/192.168.1.10/udp/10004/quic"), AddressType::Lan,)]
+        );
+    }
+
+    #[test]
+    fn publish_set_keeps_lan_alongside_same_family_direct() {
+        let proven = sock("203.0.113.10:10004");
+        let typed = typed_self_address_set(
+            [proven],
+            [addr("/ip4/192.168.1.10/udp/10004/quic")],
+            Some(sock("198.51.100.1:45000")),
+            |sa| sa == proven,
+        );
+
+        assert_eq!(
+            typed,
+            vec![
+                (addr("/ip4/198.51.100.1/udp/45000/quic"), AddressType::Relay),
+                (
+                    addr("/ip4/203.0.113.10/udp/10004/quic"),
+                    AddressType::Direct,
+                ),
+                (addr("/ip4/192.168.1.10/udp/10004/quic"), AddressType::Lan,),
+            ]
         );
     }
 

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -597,6 +597,30 @@ impl P2PNetworkNode<P2pLinkTransport> {
             .with_context(|| format!("QUIC send to {} ({} bytes) failed", addr, data.len()))
     }
 
+    /// Send data to a peer and wait for QUIC to acknowledge peer receipt of the full stream.
+    pub async fn send_to_peer_optimized_with_delivery_ack(
+        &self,
+        addr: &SocketAddr,
+        data: &[u8],
+    ) -> Result<()> {
+        trace!(
+            "[QUIC SEND] endpoint().send_with_delivery_ack() to {} ({} bytes)",
+            addr,
+            data.len()
+        );
+        self.transport
+            .endpoint()
+            .send_with_delivery_ack(addr, data)
+            .await
+            .with_context(|| {
+                format!(
+                    "QUIC delivery-ack send to {} ({} bytes) failed",
+                    addr,
+                    data.len()
+                )
+            })
+    }
+
     /// Disconnect a specific peer, closing the underlying QUIC connection.
     ///
     /// Calls `P2pEndpoint::disconnect()` to tear down the QUIC connection
@@ -1907,6 +1931,43 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         // correctly-configured dual-stack node but guarded for safety.
         Err(anyhow::anyhow!(
             "send_to_peer_optimized to {}: no compatible stack bound (v4={}, v6={})",
+            addr,
+            self.v4.is_some(),
+            self.v6.is_some()
+        ))
+    }
+
+    /// Send to peer using P2pEndpoint's optimized send method, waiting until
+    /// QUIC confirms the peer received the full stream.
+    pub async fn send_to_peer_optimized_with_delivery_ack(
+        &self,
+        addr: &SocketAddr,
+        data: &[u8],
+    ) -> Result<()> {
+        if addr.is_ipv4()
+            && let Some(v4) = &self.v4
+        {
+            return v4
+                .send_to_peer_optimized_with_delivery_ack(addr, data)
+                .await
+                .map_err(|e| e.context(format!("IPv4 delivery-ack send to {} failed", addr)));
+        }
+
+        if let Some(v6) = &self.v6 {
+            let wire_addr = self.to_mapped_if_needed(addr);
+            return v6
+                .send_to_peer_optimized_with_delivery_ack(&wire_addr, data)
+                .await
+                .map_err(|e| {
+                    e.context(format!(
+                        "IPv6 delivery-ack send to {} (wire {}) failed",
+                        addr, wire_addr
+                    ))
+                });
+        }
+
+        Err(anyhow::anyhow!(
+            "send_to_peer_optimized_with_delivery_ack to {}: no compatible stack bound (v4={}, v6={})",
             addr,
             self.v4.is_some(),
             self.v6.is_some()

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -578,8 +578,8 @@ impl P2PNetworkNode<P2pLinkTransport> {
     /// Send data to a peer using P2pEndpoint's send method
     ///
     /// This method is specialized for P2pLinkTransport and uses the underlying
-    /// P2pEndpoint's send() method which corresponds with recv() for proper
-    /// bidirectional communication.
+    /// P2pEndpoint's send() method, which waits for QUIC to confirm peer
+    /// receipt of the full stream.
     ///
     /// On failure the underlying transport error is preserved via
     /// `anyhow::Context` so callers can inspect the cause (e.g. QUIC
@@ -595,30 +595,6 @@ impl P2PNetworkNode<P2pLinkTransport> {
             .send(addr, data)
             .await
             .with_context(|| format!("QUIC send to {} ({} bytes) failed", addr, data.len()))
-    }
-
-    /// Send data to a peer and wait for QUIC to acknowledge peer receipt of the full stream.
-    pub async fn send_to_peer_optimized_with_delivery_ack(
-        &self,
-        addr: &SocketAddr,
-        data: &[u8],
-    ) -> Result<()> {
-        trace!(
-            "[QUIC SEND] endpoint().send_with_delivery_ack() to {} ({} bytes)",
-            addr,
-            data.len()
-        );
-        self.transport
-            .endpoint()
-            .send_with_delivery_ack(addr, data)
-            .await
-            .with_context(|| {
-                format!(
-                    "QUIC delivery-ack send to {} ({} bytes) failed",
-                    addr,
-                    data.len()
-                )
-            })
     }
 
     /// Disconnect a specific peer, closing the underlying QUIC connection.
@@ -1931,43 +1907,6 @@ impl DualStackNetworkNode<P2pLinkTransport> {
         // correctly-configured dual-stack node but guarded for safety.
         Err(anyhow::anyhow!(
             "send_to_peer_optimized to {}: no compatible stack bound (v4={}, v6={})",
-            addr,
-            self.v4.is_some(),
-            self.v6.is_some()
-        ))
-    }
-
-    /// Send to peer using P2pEndpoint's optimized send method, waiting until
-    /// QUIC confirms the peer received the full stream.
-    pub async fn send_to_peer_optimized_with_delivery_ack(
-        &self,
-        addr: &SocketAddr,
-        data: &[u8],
-    ) -> Result<()> {
-        if addr.is_ipv4()
-            && let Some(v4) = &self.v4
-        {
-            return v4
-                .send_to_peer_optimized_with_delivery_ack(addr, data)
-                .await
-                .map_err(|e| e.context(format!("IPv4 delivery-ack send to {} failed", addr)));
-        }
-
-        if let Some(v6) = &self.v6 {
-            let wire_addr = self.to_mapped_if_needed(addr);
-            return v6
-                .send_to_peer_optimized_with_delivery_ack(&wire_addr, data)
-                .await
-                .map_err(|e| {
-                    e.context(format!(
-                        "IPv6 delivery-ack send to {} (wire {}) failed",
-                        addr, wire_addr
-                    ))
-                });
-        }
-
-        Err(anyhow::anyhow!(
-            "send_to_peer_optimized_with_delivery_ack to {}: no compatible stack bound (v4={}, v6={})",
             addr,
             self.v4.is_some(),
             self.v6.is_some()

--- a/src/transport/saorsa_transport_adapter.rs
+++ b/src/transport/saorsa_transport_adapter.rs
@@ -157,8 +157,9 @@ const HAPPY_EYEBALLS_V4_STAGGER: Duration = Duration::from_millis(50);
 /// Per-attempt direct connect timeout used by the Happy Eyeballs race.
 ///
 /// Keep this short because DHT lookups expect to encounter unreachable
-/// candidates on live networks and should move on quickly.
-const DIRECT_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+/// candidates on live networks and should move on quickly, but leave enough
+/// room for one QUIC initial-flight retransmission on slower relay paths.
+const DIRECT_CONNECT_TIMEOUT: Duration = Duration::from_millis(1250);
 
 /// Per-attempt direct handshake timeout after connection progress is observed.
 const DIRECT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(4);

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -145,6 +145,8 @@ fn classify_transport_send_stage(stage: saorsa_transport::SendFailureStage) -> S
         }
         saorsa_transport::SendFailureStage::Write => SendFailureKind::StreamWrite,
         saorsa_transport::SendFailureStage::Finish => SendFailureKind::StreamFinish,
+        saorsa_transport::SendFailureStage::DeliveryAck
+        | saorsa_transport::SendFailureStage::DeliveryAckTimeout => SendFailureKind::StreamFinish,
     }
 }
 
@@ -1502,6 +1504,28 @@ impl TransportHandle {
         protocol: &str,
         data: Vec<u8>,
     ) -> Result<()> {
+        self.send_message_inner(peer_id, protocol, data, false)
+            .await
+    }
+
+    /// Send a message to an authenticated peer, waiting until QUIC confirms
+    /// the remote endpoint received the full stream before returning.
+    pub async fn send_message_with_delivery_ack(
+        &self,
+        peer_id: &PeerId,
+        protocol: &str,
+        data: Vec<u8>,
+    ) -> Result<()> {
+        self.send_message_inner(peer_id, protocol, data, true).await
+    }
+
+    async fn send_message_inner(
+        &self,
+        peer_id: &PeerId,
+        protocol: &str,
+        data: Vec<u8>,
+        wait_for_delivery_ack: bool,
+    ) -> Result<()> {
         let peer_hex = peer_id.to_hex();
         let channels: Vec<String> = self
             .peer_to_channel
@@ -1518,7 +1542,7 @@ impl TransportHandle {
         let mut last_err = None;
         for channel_id in &channels {
             match self
-                .send_on_channel(channel_id, protocol, data.clone())
+                .send_on_channel_inner(channel_id, protocol, data.clone(), wait_for_delivery_ack)
                 .await
             {
                 Ok(()) => return Ok(()),
@@ -1562,6 +1586,17 @@ impl TransportHandle {
         channel_id: &str,
         protocol: &str,
         data: Vec<u8>,
+    ) -> Result<()> {
+        self.send_on_channel_inner(channel_id, protocol, data, false)
+            .await
+    }
+
+    async fn send_on_channel_inner(
+        &self,
+        channel_id: &str,
+        protocol: &str,
+        data: Vec<u8>,
+        wait_for_delivery_ack: bool,
     ) -> Result<()> {
         debug!(
             "Sending message to channel {} on protocol {}",
@@ -1616,11 +1651,12 @@ impl TransportHandle {
         let raw_data_len = data.len();
         let message_data = self.create_protocol_message(protocol, data)?;
         debug!(
-            "Sending {} bytes to channel {} on protocol {} (raw data: {} bytes)",
+            "Sending {} bytes to channel {} on protocol {} (raw data: {} bytes, wait_for_delivery_ack={})",
             message_data.len(),
             channel_id,
             protocol,
-            raw_data_len
+            raw_data_len,
+            wait_for_delivery_ack
         );
 
         let addr: SocketAddr = channel_id.parse().map_err(|e: std::net::AddrParseError| {
@@ -1628,17 +1664,22 @@ impl TransportHandle {
                 format!("Invalid channel ID address: {e}").into(),
             ))
         })?;
-        let result = self
-            .dual_node
-            .send_to_peer_optimized(&addr, &message_data)
-            .await
-            .map_err(|e| {
-                let kind = classify_send_error(&e);
-                P2PError::Transport(TransportError::SendFailed {
-                    kind,
-                    reason: e.to_string().into(),
-                })
-            });
+        let send_result = if wait_for_delivery_ack {
+            self.dual_node
+                .send_to_peer_optimized_with_delivery_ack(&addr, &message_data)
+                .await
+        } else {
+            self.dual_node
+                .send_to_peer_optimized(&addr, &message_data)
+                .await
+        };
+        let result = send_result.map_err(|e| {
+            let kind = classify_send_error(&e);
+            P2PError::Transport(TransportError::SendFailed {
+                kind,
+                reason: e.to_string().into(),
+            })
+        });
 
         if result.is_ok() {
             debug!(

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -145,8 +145,7 @@ fn classify_transport_send_stage(stage: saorsa_transport::SendFailureStage) -> S
         }
         saorsa_transport::SendFailureStage::Write => SendFailureKind::StreamWrite,
         saorsa_transport::SendFailureStage::Finish => SendFailureKind::StreamFinish,
-        saorsa_transport::SendFailureStage::DeliveryAck
-        | saorsa_transport::SendFailureStage::DeliveryAckTimeout => SendFailureKind::StreamFinish,
+        saorsa_transport::SendFailureStage::DeliveryAck => SendFailureKind::StreamFinish,
     }
 }
 
@@ -1504,28 +1503,6 @@ impl TransportHandle {
         protocol: &str,
         data: Vec<u8>,
     ) -> Result<()> {
-        self.send_message_inner(peer_id, protocol, data, false)
-            .await
-    }
-
-    /// Send a message to an authenticated peer, waiting until QUIC confirms
-    /// the remote endpoint received the full stream before returning.
-    pub async fn send_message_with_delivery_ack(
-        &self,
-        peer_id: &PeerId,
-        protocol: &str,
-        data: Vec<u8>,
-    ) -> Result<()> {
-        self.send_message_inner(peer_id, protocol, data, true).await
-    }
-
-    async fn send_message_inner(
-        &self,
-        peer_id: &PeerId,
-        protocol: &str,
-        data: Vec<u8>,
-        wait_for_delivery_ack: bool,
-    ) -> Result<()> {
         let peer_hex = peer_id.to_hex();
         let channels: Vec<String> = self
             .peer_to_channel
@@ -1542,7 +1519,7 @@ impl TransportHandle {
         let mut last_err = None;
         for channel_id in &channels {
             match self
-                .send_on_channel_inner(channel_id, protocol, data.clone(), wait_for_delivery_ack)
+                .send_on_channel(channel_id, protocol, data.clone())
                 .await
             {
                 Ok(()) => return Ok(()),
@@ -1586,17 +1563,6 @@ impl TransportHandle {
         channel_id: &str,
         protocol: &str,
         data: Vec<u8>,
-    ) -> Result<()> {
-        self.send_on_channel_inner(channel_id, protocol, data, false)
-            .await
-    }
-
-    async fn send_on_channel_inner(
-        &self,
-        channel_id: &str,
-        protocol: &str,
-        data: Vec<u8>,
-        wait_for_delivery_ack: bool,
     ) -> Result<()> {
         debug!(
             "Sending message to channel {} on protocol {}",
@@ -1651,12 +1617,11 @@ impl TransportHandle {
         let raw_data_len = data.len();
         let message_data = self.create_protocol_message(protocol, data)?;
         debug!(
-            "Sending {} bytes to channel {} on protocol {} (raw data: {} bytes, wait_for_delivery_ack={})",
+            "Sending {} bytes to channel {} on protocol {} (raw data: {} bytes)",
             message_data.len(),
             channel_id,
             protocol,
-            raw_data_len,
-            wait_for_delivery_ack
+            raw_data_len
         );
 
         let addr: SocketAddr = channel_id.parse().map_err(|e: std::net::AddrParseError| {
@@ -1664,15 +1629,10 @@ impl TransportHandle {
                 format!("Invalid channel ID address: {e}").into(),
             ))
         })?;
-        let send_result = if wait_for_delivery_ack {
-            self.dual_node
-                .send_to_peer_optimized_with_delivery_ack(&addr, &message_data)
-                .await
-        } else {
-            self.dual_node
-                .send_to_peer_optimized(&addr, &message_data)
-                .await
-        };
+        let send_result = self
+            .dual_node
+            .send_to_peer_optimized(&addr, &message_data)
+            .await;
         let result = send_result.map_err(|e| {
             let kind = classify_send_error(&e);
             P2PError::Transport(TransportError::SendFailed {

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -2041,6 +2041,7 @@ impl TransportHandle {
         self.send_event(P2PEvent::Message {
             topic: topic.to_string(),
             source: Some(*self.node_identity.peer_id()),
+            transport_source: None,
             data: data.to_vec(),
         });
 

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -113,7 +113,7 @@ fn address_kind_label(kind: Option<AddressType>) -> &'static str {
         Some(AddressType::Relay) => "Relay",
         Some(AddressType::Direct) => "Direct",
         Some(AddressType::Unverified) => "Unverified",
-        Some(AddressType::NATted) => "NATted",
+        Some(AddressType::Lan) => "Lan",
         None => "unknown",
     }
 }
@@ -1194,7 +1194,7 @@ impl TransportHandle {
     /// return [`NetworkError::InvalidAddress`].
     ///
     /// Callers that already know how the address was classified (Direct,
-    /// Relay, Unverified, NATted) should prefer
+    /// Relay, Unverified, Lan) should prefer
     /// [`Self::connect_peer_typed`] so the success/failure logs include
     /// the address kind. This entry point is preserved for callers
     /// (tests, public API consumers) that don't have type metadata.
@@ -1207,7 +1207,7 @@ impl TransportHandle {
     /// Same as [`Self::connect_peer`] but additionally records the
     /// [`AddressType`] tag in the success/failure logs so an operator
     /// can tell, after the fact, whether a failed dial was against a
-    /// `Direct`, `Relay`, `Unverified`, or `NATted` address.
+    /// `Direct`, `Relay`, `Unverified`, or `Lan` address.
     pub async fn connect_peer_typed(
         &self,
         address: &MultiAddr,

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -1160,6 +1160,93 @@ impl TransportHandle {
             }
         }
     }
+
+    fn upsert_connected_channel_static(
+        active_connections: &DashSet<String>,
+        peers: &DashMap<String, PeerInfo>,
+        channel_id: &str,
+        remote_address: SocketAddr,
+        source: &'static str,
+        refresh_connected_at: bool,
+    ) {
+        let normalized_addr = saorsa_transport::shared::normalize_socket_addr(remote_address);
+        let address = MultiAddr::quic(normalized_addr);
+        let now = Instant::now();
+
+        active_connections.insert(channel_id.to_string());
+
+        match peers.entry(channel_id.to_string()) {
+            DashEntry::Occupied(mut entry) => {
+                let peer_info = entry.get_mut();
+                peer_info.status = ConnectionStatus::Connected;
+                if refresh_connected_at {
+                    peer_info.connected_at = now;
+                }
+                if !peer_info.addresses.contains(&address) {
+                    peer_info.addresses.push(address);
+                }
+            }
+            DashEntry::Vacant(entry) => {
+                debug!("{source}: registering connected channel {channel_id}");
+                entry.insert(PeerInfo {
+                    channel_id: channel_id.to_string(),
+                    addresses: vec![address],
+                    status: ConnectionStatus::Connected,
+                    last_seen: now,
+                    connected_at: now,
+                    protocols: Vec::new(),
+                    heartbeat_count: 0,
+                });
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_authenticated_peer_channel_static(
+        active_connections: &DashSet<String>,
+        peers: &DashMap<String, PeerInfo>,
+        peer_to_channel: &DashMap<PeerId, HashSet<String>>,
+        channel_to_peers: &DashMap<String, HashSet<PeerId>>,
+        peer_user_agents: &DashMap<PeerId, String>,
+        event_tx: &broadcast::Sender<P2PEvent>,
+        channel_id: &str,
+        remote_address: SocketAddr,
+        app_id: PeerId,
+        peer_user_agent: &str,
+    ) {
+        Self::upsert_connected_channel_static(
+            active_connections,
+            peers,
+            channel_id,
+            remote_address,
+            "authenticated peer registration",
+            false,
+        );
+
+        let mut is_new_peer = false;
+        let inserted = match peer_to_channel.entry(app_id) {
+            DashEntry::Occupied(mut entry) => entry.get_mut().insert(channel_id.to_string()),
+            DashEntry::Vacant(entry) => {
+                is_new_peer = true;
+                let mut set = HashSet::new();
+                set.insert(channel_id.to_string());
+                entry.insert(set);
+                true
+            }
+        };
+        if inserted {
+            channel_to_peers
+                .entry(channel_id.to_string())
+                .or_default()
+                .insert(app_id);
+        }
+
+        if is_new_peer {
+            let peer_user_agent = peer_user_agent.to_string();
+            peer_user_agents.insert(app_id, peer_user_agent.clone());
+            broadcast_event(event_tx, P2PEvent::PeerConnected(app_id, peer_user_agent));
+        }
+    }
 }
 
 // ============================================================================
@@ -2179,6 +2266,8 @@ impl TransportHandle {
 
             let event_tx = self.event_tx.clone();
             let active_requests = Arc::clone(&self.active_requests);
+            let active_connections = Arc::clone(&self.active_connections);
+            let peers = Arc::clone(&self.peers);
             let peer_to_channel = Arc::clone(&self.peer_to_channel);
             let channel_to_peers = Arc::clone(&self.channel_to_peers);
             let peer_user_agents = Arc::clone(&self.peer_user_agents);
@@ -2191,6 +2280,8 @@ impl TransportHandle {
                     shard_rx,
                     event_tx,
                     active_requests,
+                    active_connections,
+                    peers,
                     peer_to_channel,
                     channel_to_peers,
                     peer_user_agents,
@@ -2275,6 +2366,8 @@ impl TransportHandle {
         mut shard_rx: tokio::sync::mpsc::Receiver<(SocketAddr, Vec<u8>)>,
         event_tx: broadcast::Sender<P2PEvent>,
         active_requests: Arc<DashMap<String, PendingRequest>>,
+        active_connections: Arc<DashSet<String>>,
+        peers: Arc<DashMap<String, PeerInfo>>,
         peer_to_channel: Arc<DashMap<PeerId, HashSet<String>>>,
         channel_to_peers: Arc<DashMap<String, HashSet<PeerId>>>,
         peer_user_agents: Arc<DashMap<PeerId, String>>,
@@ -2323,39 +2416,21 @@ impl TransportHandle {
                                 .await;
                         }
 
-                        // Atomically determine whether this is the peer's
-                        // first channel. Using `entry` per-shard avoids the
-                        // contains_key/insert TOCTOU that could otherwise
-                        // double-fire `PeerConnected` when two channels for
-                        // the same peer arrive concurrently on different
-                        // dispatch shards.
-                        let mut is_new_peer = false;
-                        let inserted = match peer_to_channel.entry(*app_id) {
-                            DashEntry::Occupied(mut entry) => {
-                                entry.get_mut().insert(channel_id.clone())
-                            }
-                            DashEntry::Vacant(entry) => {
-                                is_new_peer = true;
-                                let mut set = HashSet::new();
-                                set.insert(channel_id.clone());
-                                entry.insert(set);
-                                true
-                            }
-                        };
-                        if inserted {
-                            channel_to_peers
-                                .entry(channel_id.clone())
-                                .or_default()
-                                .insert(*app_id);
-                        }
-
-                        if is_new_peer {
-                            peer_user_agents.insert(*app_id, peer_user_agent.clone());
-                            broadcast_event(
-                                &event_tx,
-                                P2PEvent::PeerConnected(*app_id, peer_user_agent.clone()),
-                            );
-                        }
+                        // This helper owns the app-level PeerConnected invariant:
+                        // `peer_info(app_id)` must be queryable before the event
+                        // is broadcast to DHT or other subscribers.
+                        Self::register_authenticated_peer_channel_static(
+                            &active_connections,
+                            &peers,
+                            &peer_to_channel,
+                            &channel_to_peers,
+                            &peer_user_agents,
+                            &event_tx,
+                            &channel_id,
+                            from_addr,
+                            *app_id,
+                            &peer_user_agent,
+                        );
                     }
 
                     // Identity announces are internal plumbing — don't
@@ -2572,26 +2647,14 @@ impl TransportHandle {
                                     channel_id, remote_address
                                 );
 
-                                active_connections.insert(channel_id.clone());
-
-                                peers
-                                    .entry(channel_id.clone())
-                                    .and_modify(|peer_info| {
-                                        peer_info.status = ConnectionStatus::Connected;
-                                        peer_info.connected_at = Instant::now();
-                                    })
-                                    .or_insert_with(|| {
-                                        debug!("Registering new incoming channel: {}", channel_id);
-                                        PeerInfo {
-                                            channel_id: channel_id.clone(),
-                                            addresses: vec![MultiAddr::quic(remote_address)],
-                                            status: ConnectionStatus::Connected,
-                                            last_seen: Instant::now(),
-                                            connected_at: Instant::now(),
-                                            protocols: Vec::new(),
-                                            heartbeat_count: 0,
-                                        }
-                                    });
+                                Self::upsert_connected_channel_static(
+                                    &active_connections,
+                                    &peers,
+                                    &channel_id,
+                                    remote_address,
+                                    "connection lifecycle",
+                                    true,
+                                );
 
                                 // Send identity announce so the remote peer can authenticate us.
                                 //
@@ -2774,6 +2837,61 @@ mod address_event_observer_tests {
             Some(second)
         );
         assert_eq!(TransportHandle::drain_latest_socket_event(&rx), None);
+    }
+}
+
+#[cfg(test)]
+mod authenticated_peer_registration_tests {
+    use super::*;
+
+    #[test]
+    fn authenticated_registration_makes_peer_info_queryable_before_event_consumers_run() {
+        let active_connections = DashSet::new();
+        let peers = DashMap::new();
+        let peer_to_channel = DashMap::new();
+        let channel_to_peers = DashMap::new();
+        let peer_user_agents = DashMap::new();
+        let (event_tx, mut event_rx) = broadcast::channel(4);
+
+        let app_id = PeerId::from_bytes([0x31; 32]);
+        let remote_addr: SocketAddr = "64.227.163.41:43782".parse().expect("test addr");
+        let channel_id = canonical_channel_id(remote_addr);
+
+        TransportHandle::register_authenticated_peer_channel_static(
+            &active_connections,
+            &peers,
+            &peer_to_channel,
+            &channel_to_peers,
+            &peer_user_agents,
+            &event_tx,
+            &channel_id,
+            remote_addr,
+            app_id,
+            "node/test",
+        );
+
+        assert!(active_connections.contains(&channel_id));
+
+        let mapped_channel = peer_to_channel
+            .get(&app_id)
+            .and_then(|channels| channels.value().iter().next().cloned())
+            .expect("app peer should be mapped to a channel");
+        let peer_info = peers
+            .get(&mapped_channel)
+            .map(|entry| entry.value().clone())
+            .expect("mapped channel should have peer info before event consumers run");
+
+        assert_eq!(peer_info.channel_id, channel_id);
+        assert_eq!(peer_info.status, ConnectionStatus::Connected);
+        assert_eq!(peer_info.addresses, vec![MultiAddr::quic(remote_addr)]);
+
+        match event_rx.try_recv().expect("peer connected event") {
+            P2PEvent::PeerConnected(peer_id, user_agent) => {
+                assert_eq!(peer_id, app_id);
+                assert_eq!(user_agent, "node/test");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
     }
 }
 

--- a/tests/masque_relay_e2e.rs
+++ b/tests/masque_relay_e2e.rs
@@ -246,6 +246,7 @@ async fn private_node_receives_messages_through_masque_relay() {
                     topic,
                     source,
                     data,
+                    ..
                 }) if topic == "test/relay-msg" => {
                     return (source, data);
                 }
@@ -293,6 +294,7 @@ async fn private_node_receives_messages_through_masque_relay() {
                     topic,
                     source,
                     data,
+                    ..
                 }) if topic == "test/relay-sustained" => {
                     return (source, data);
                 }


### PR DESCRIPTION
## Summary
- Hardens DHT lookup correctness by rejecting stale relay winners, propagating failed lookup peers, skipping peers with exhausted dial plans, handling lagged lookup-failure receivers, and avoiding liveness refresh from address gossip alone.
- Stabilizes self-address and transport behavior with structured relay/IPv4/IPv6 candidate selection, the current saorsa-transport stability branch, updated Cargo.lock pins, and adjusted QUIC direct-connect/send semantics.
- Enforces non-zero DHT address publish/replace sequence numbers so zero stays reserved as the no-sequence sentinel.
- Classifies LAN-scoped addresses separately from Direct, Unverified, and Relay addresses, replacing AddressType::NATted with AddressType::Lan while still accepting the legacy NATted wire name as Lan.
- Tightens LAN-first dialing by canonicalizing IPv4-mapped LAN addresses and requiring same-WAN compatibility before preferring private/link-local/loopback paths; otherwise peers fall back to WAN or relay candidates.

## Recent additions
- feat(network)!: classify LAN addresses separately
- fix(network): canonicalize mapped IPv4 LAN addresses
- fix(network): require same WAN for LAN-first dialing

## Testing
- Not run in this session (PR description only).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens DHT lookup correctness and self-address stability across several independent concerns: stale relay records are no longer treated as authoritative results during iterative FIND_NODE lookups, peer failures observed by one active lookup are propagated to sibling lookups via a broadcast coordinator, and admission revalidation is moved off the transport event loop onto its own spawned task. A new `SelfAddressSet` struct replaces the earlier `Vec`+`HashSet` approach with structured relay/IPv4/IPv6 slots that produce a stable, deduplicated address set every time.

- `AddressReplaceMode` in `core_engine.rs` prevents third-party gossip from refreshing `last_seen` or bucket MRU order; `touch_legacy_relay_hint_if_unsequenced` blocks stale relay hints from overwriting a peer that has already published a sequenced address record.
- `compute_winner` gains a \"newest publish-sequence wins\" rule (before quorum and XOR-distance fallback), and `apply_lookup_report_winners` replaces stale candidate copies with the per-subject winner before returning results to callers.
- `saorsa-transport` is switched from the crates.io registry to a git branch for upstream stability fixes; `DeliveryAck` is mapped to `StreamFinish` (not `StaleChannel`) to avoid reconnect-triggered duplicate sends.

<h3>Confidence Score: 4/5</h3>

The core logic changes are sound and backed by a solid suite of new unit tests; the main open question is stabilising the upstream transport dependency before merging to a release branch.

All production code correctly avoids panics and the DHT correctness improvements are well-reasoned and tested. The broadcast-lag case in wait_for_lookup_failure_signal silently drops the early-abort signal, a minor performance concern rather than a correctness one. The saorsa-transport git branch reference is the more pressing concern: a force-push or deletion breaks any workflow that regenerates Cargo.lock.

Cargo.toml and Cargo.lock warrant a second look before landing on a release branch; src/dht_network_manager.rs is the largest change and benefits from end-to-end integration testing since the lookup failure propagation path has not been exercised in this session.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | saorsa-transport switched from pinned registry version (0.34.1) to a mutable git branch. Cargo.lock pins a specific commit today, but the branch reference is unstable and could cause build failures if force-pushed or deleted. |
| src/dht/core_engine.rs | Adds AddressReplaceMode enum to gate liveness refreshes, touch_legacy_relay_hint_if_unsequenced guard, replace_node_addresses_from_gossip gossip path, and find_/all_nodes_with_publish_seq query helpers. Logic is consistent and well-tested. |
| src/dht_network_manager.rs | Major rework: LookupPeerStates replaces HashSet, LookupFailureCoordinator broadcasts peer failures across concurrent lookups, compute_winner gains a publish-seq freshness rule, apply_lookup_report_winners refreshes stale candidate copies. Minor: Lagged broadcast receiver can silently miss the target failure signal, losing the early-abort optimisation without any indication. |
| src/network.rs | Relay hint path switched to touch_legacy_relay_hint_if_unsequenced, preventing stale relay hints from overwriting a sequenced publish record. Cosmetic variable rename for send_result. |
| src/reachability/driver.rs | Trivial call-site update: build_typed_self_address_set renamed to build_self_address_set returning SelfAddressSet; into_typed_vec() materialises the vec for the publish fan-out. No logic changes. |
| src/self_address.rs | SelfAddressSet replaces Vec+HashSet tracking with structured relay/v4/v6 slots that emit addresses in stable first-seen order. Dedup scope narrowed from all-seen to selected-only, which is correct because unselected same-family losers cannot displace the winner later. Well-tested. |
| src/transport/saorsa_transport_adapter.rs | DIRECT_CONNECT_TIMEOUT bumped from 1000ms to 1250ms to accommodate one QUIC initial-flight retransmission. Comment clarified for send() delivery semantics. Both changes are non-breaking. |
| src/transport_handle.rs | New DeliveryAck SendFailureStage variant mapped to StreamFinish (not StaleChannel), so delivery-ack failures do not trigger reconnect+retry — correct for QUIC semantics where the data may already have been received. Cosmetic variable rename only. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant DhtNetworkManager
    participant LookupPeerStates
    participant LookupFailureCoordinator
    participant RemotePeer

    Caller->>DhtNetworkManager: iterative_find_nodes(key)
    DhtNetworkManager->>LookupPeerStates: mark_self_queried (Succeeded)
    DhtNetworkManager->>LookupPeerStates: mark_failed (exhausted dial plans)
    loop Alpha batch
        DhtNetworkManager->>LookupPeerStates: mark_waiting(peer)
        DhtNetworkManager->>LookupFailureCoordinator: "subscribe() -> failure_rx"
        DhtNetworkManager->>RemotePeer: send_find_node_lookup_request
        alt Request completes with error
            RemotePeer-->>DhtNetworkManager: Err
            DhtNetworkManager->>LookupFailureCoordinator: notify_failed(peer)
            DhtNetworkManager->>LookupPeerStates: mark_failed(peer)
        else External failure signal arrives first
            LookupFailureCoordinator-->>DhtNetworkManager: peer failed (from sibling lookup)
            DhtNetworkManager->>LookupPeerStates: mark_unresponsive(peer)
        else Success
            RemotePeer-->>DhtNetworkManager: NodesFound(nodes, seq)
            DhtNetworkManager->>LookupPeerStates: mark_succeeded(peer)
            DhtNetworkManager->>DhtNetworkManager: merge_gossiped_typed_addresses (seq-aware)
        end
    end
    DhtNetworkManager->>DhtNetworkManager: apply_lookup_report_winners(best_nodes, subject_reports)
    DhtNetworkManager-->>Caller: "Vec<DHTNode> (refreshed)"
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/dht_network_manager.rs`, line 996-1005 ([link](https://github.com/saorsa-labs/saorsa-core/blob/a7380fea86e964adf039f7a1c2b4529c4da656ac/src/dht_network_manager.rs#L996-L1005)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Lagged broadcast receiver silently loses the failure signal**

   When the broadcast ring buffer overflows a `Lagged` error is returned and the receiver position is bumped forward, dropping the skipped messages. If the specific `peer_id` this waiter is watching was among the dropped notifications, the loop will keep calling `recv().await` for new messages that never carry that peer, so the `external_failure` branch of the `select!` never fires. The early-abort optimisation is silently lost for that probe for the rest of its lifetime. The `request` branch still resolves the outer future, so there is no deadlock — only a missed short-circuit. Given the 1024-entry buffer this is unlikely in practice, but under a lookup storm where many probes fail in rapid succession the lag window can be wide enough to drop the target.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/dht_network_manager.rs
   Line: 996-1005

   Comment:
   **Lagged broadcast receiver silently loses the failure signal**

   When the broadcast ring buffer overflows a `Lagged` error is returned and the receiver position is bumped forward, dropping the skipped messages. If the specific `peer_id` this waiter is watching was among the dropped notifications, the loop will keep calling `recv().await` for new messages that never carry that peer, so the `external_failure` branch of the `select!` never fires. The early-abort optimisation is silently lost for that probe for the rest of its lifetime. The `request` branch still resolves the outer future, so there is no deadlock — only a missed short-circuit. Given the 1024-entry buffer this is unlikely in practice, but under a lookup storm where many probes fail in rapid succession the lag window can be wide enough to drop the target.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Cargo.toml:67
**Mutable git branch as a production dependency**

`saorsa-transport` now resolves from a live branch (`fix/stability-improvements`) rather than a published registry version or a pinned tag. The Cargo.lock records a specific commit hash, so builds are reproducible today, but the branch can be force-pushed or deleted at any time — any workflow that drops the lock file (e.g., a `cargo update`, a fresh worktree, or a CI job that regenerates the lock) will silently pull whatever HEAD the branch points to at that moment, or fail entirely if the branch no longer exists. Prefer a git tag or a published crate version once the upstream fixes land.

### Issue 2 of 2
src/dht_network_manager.rs:996-1005
**Lagged broadcast receiver silently loses the failure signal**

When the broadcast ring buffer overflows a `Lagged` error is returned and the receiver position is bumped forward, dropping the skipped messages. If the specific `peer_id` this waiter is watching was among the dropped notifications, the loop will keep calling `recv().await` for new messages that never carry that peer, so the `external_failure` branch of the `select!` never fires. The early-abort optimisation is silently lost for that probe for the rest of its lifetime. The `request` branch still resolves the outer future, so there is no deadlock — only a missed short-circuit. Given the 1024-entry buffer this is unlikely in practice, but under a lookup storm where many probes fail in rapid succession the lag window can be wide enough to drop the target.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): switch \`saorsa-transport\` t..."](https://github.com/saorsa-labs/saorsa-core/commit/a7380fea86e964adf039f7a1c2b4529c4da656ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31460677)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
