### PR TITLE
chore(release): promote rc-2026.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.24.3-rc.1"
+version = "0.24.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2636,8 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.34.2-rc.1"
-source = "git+https://github.com/saorsa-labs/saorsa-transport?branch=rc-2026.5.2#0e0de4d8992b06ef2c93701024ce509527db05e0"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852400712537856ab6fec5293be4290daf0130df0dbcb249a6e8280f9257665f"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
  "ring",
@@ -2513,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.24.2"
+version = "0.24.3-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2627,8 +2636,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.34.1"
-source = "git+https://github.com/saorsa-labs/saorsa-transport?branch=fix%2Fstability-improvements#55f423ca5e3312e31ba22475b68a76f4ffd50285"
+version = "0.34.2-rc.1"
+source = "git+https://github.com/saorsa-labs/saorsa-transport?branch=rc-2026.5.2#0e0de4d8992b06ef2c93701024ce509527db05e0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4135,10 +4144,11 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec",
  "time",
 ]
 
@@ -4187,9 +4197,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "saorsa-core"
 # 0.22.0: MASQUE relay data plane, upgrade saorsa-transport to 0.31.0
 # 0.24.0: upgrade saorsa-transport to 0.33.0
 # 0.24.1: release candidate fixes
-version = "0.24.3-rc.1"
+version = "0.24.3"
 edition = "2024"
 authors = ["Saorsa Labs Limited <david@saorsalabs.com>"]
 license = "AGPL-3.0"
@@ -64,7 +64,7 @@ once_cell = "1.21"
 dashmap = "6"
 
 # Networking
-saorsa-transport = { git = "https://github.com/saorsa-labs/saorsa-transport", branch = "rc-2026.5.2" }
+saorsa-transport = "0.34.2"
 
 # Core-specific dependencies
 dirs = "6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "saorsa-core"
 # 0.22.0: MASQUE relay data plane, upgrade saorsa-transport to 0.31.0
 # 0.24.0: upgrade saorsa-transport to 0.33.0
 # 0.24.1: release candidate fixes
-version = "0.24.2"
+version = "0.24.3-rc.1"
 edition = "2024"
 authors = ["Saorsa Labs Limited <david@saorsalabs.com>"]
 license = "AGPL-3.0"
@@ -64,7 +64,7 @@ once_cell = "1.21"
 dashmap = "6"
 
 # Networking
-saorsa-transport = { git = "https://github.com/saorsa-labs/saorsa-transport", branch = "fix/stability-improvements" }
+saorsa-transport = { git = "https://github.com/saorsa-labs/saorsa-transport", branch = "rc-2026.5.2" }
 
 # Core-specific dependencies
 dirs = "6.0"


### PR DESCRIPTION
Promotes `rc-2026.5.2` to release version(s): 0.24.3.

- strips `-rc.*` from `[package].version`
- rewrites internal git+branch deps to crates.io version pins
- regenerates `Cargo.lock`

Once merged, the release tag will be pushed to fire the publish workflow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a release-promotion PR that advances `saorsa-core` from `0.24.3-rc.*` to `0.24.3`, converting the internal git+branch `saorsa-transport` dependency to the published crates.io pin `0.34.2` and regenerating the lock file.

- **`Cargo.toml`**: version bumped to `0.24.3`; `saorsa-transport` moved from `git+branch fix/stability-improvements` to `"0.34.2"`.
- **`Cargo.lock`**: lock file regenerated — `saorsa-transport` now resolves from the registry; transitive bumps include `aws-lc-rs` (1.17.0), `aws-lc-sys` (0.41.0), `rcgen` (0.14.8), `yasna` (0.6.0, which gains a new `bit-vec` transitive dep), and `zerofrom` (0.1.8).

<h3>Confidence Score: 5/5</h3>

Straightforward release-promotion: version suffix stripped, git dependency replaced with the matching published crate, lock file regenerated with checksums intact.

Both files change exactly what the PR description promises — the version is bumped, the git+branch dep is replaced by a registry pin, and all lock-file checksums are present. The only gap is the missing version-history comments in Cargo.toml.

No files require special attention; the only note is the inline changelog comments in Cargo.toml missing entries for 0.24.2 and 0.24.3.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Version bumped 0.24.2→0.24.3; `saorsa-transport` git+branch dep replaced with crates.io pin `0.34.2`. Version history comments are missing entries for 0.24.2 and 0.24.3. |
| Cargo.lock | Lock file regenerated: `saorsa-core` bumped to 0.24.3, `saorsa-transport` moved from git to registry 0.34.2, plus minor bumps to `aws-lc-rs`, `aws-lc-sys`, `rcgen`, `yasna` (now requires new `bit-vec 0.9.1`), and `zerofrom`. All checksums are present and consistent. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["rc-2026.5.2 branch\nsaorsa-core 0.24.3-rc.*\nsaorsa-transport git+branch"] -->|"Strip -rc.* suffix\nRewrite git dep → crates.io"| B["main branch\nsaorsa-core 0.24.3\nsaorsa-transport 0.34.2 (crates.io)"]
    B --> C["Merge → push release tag"]
    C --> D["Publish workflow fires\n→ crates.io publish"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Cargo.toml:23-25
The inline version-history comments jump from `0.24.1` directly to `0.24.3`, leaving both `0.24.2` and `0.24.3` undocumented. Every other version in this block has a one-line annotation; readers tracing the history later will hit a gap at these two releases.

```suggestion
# 0.24.0: upgrade saorsa-transport to 0.33.0
# 0.24.1: release candidate fixes
# 0.24.2: <previous release description>
# 0.24.3: promote rc-2026.5.2, pin saorsa-transport to 0.34.2
version = "0.24.3"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): promote rc-2026.5.2 to 0..."](https://github.com/saorsa-labs/saorsa-core/commit/15b3e8a5d7b041726c4f887dd7ca5f0838048055) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32020953)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->