### PR TITLE
fix(dht): drop wildcard / port-zero addresses at store side

### DIFF
--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -251,6 +251,33 @@ impl NodeInfo {
             .collect()
     }
 
+    /// Drop every non-storable address (wildcard `0.0.0.0` / `::`, port-zero)
+    /// in place, keeping `addresses` and `address_types` index-aligned.
+    ///
+    /// This is the record-level equivalent of the single-address filter in
+    /// [`Self::merge_typed_address`]. Admission paths that derive diversity
+    /// state from the raw address list (e.g. `DhtCoreEngine::add_node`
+    /// building `candidate_ips`) must call this first so a record carrying
+    /// both a wildcard and a routable address is admitted with only the
+    /// routable address, instead of being rejected wholesale by the
+    /// unspecified-IP guard before the bucket-side store filter can run.
+    pub fn retain_storable_addresses(&mut self) {
+        // Pad address_types so the index alignment holds before we filter
+        // (legacy records may carry fewer tags than addresses).
+        while self.address_types.len() < self.addresses.len() {
+            self.address_types.push(AddressType::Unverified);
+        }
+        // Rebuild both vectors in lockstep, keeping only storable addresses.
+        let addresses = std::mem::take(&mut self.addresses);
+        let address_types = std::mem::take(&mut self.address_types);
+        for (addr, addr_type) in addresses.into_iter().zip(address_types) {
+            if is_storable_address(&addr) {
+                self.addresses.push(addr);
+                self.address_types.push(addr_type);
+            }
+        }
+    }
+
     /// Merge a new address with default type `Direct`.
     /// Prefer `merge_typed_address` when the type is known.
     pub fn merge_address(&mut self, addr: MultiAddr) {
@@ -1736,18 +1763,30 @@ impl DhtCoreEngine {
     /// the same replacement through [`Self::replace_node_addresses_from_gossip`]
     /// without refreshing liveness.
     ///
-    /// - Loopback entries are filtered out unless [`Self::allow_loopback`]
-    ///   is set (devnets/tests), matching the loopback-injection guard in
-    ///   [`KBucket::touch_node_typed`].
-    /// - Empty input address lists are rejected. If filtering strips every
-    ///   supplied address, the empty set is still applied so stale addresses
-    ///   from an older publish cannot survive a newer full replacement.
+    /// - Empty input address lists are rejected outright (returns `false`).
+    /// - Filtering happens in two stages with **different empty-result
+    ///   semantics**, because they guard against different things:
+    ///   - *Loopback* (this method, via [`Self::filter_publish_address_set`],
+    ///     skipped when [`Self::allow_loopback`] is set for devnets/tests):
+    ///     if stripping loopback empties a non-empty input, the **empty set
+    ///     is still applied**. A publisher that legitimately drops to zero
+    ///     reachable addresses must not keep stale ones alive, and
+    ///     `last_publish_seqs` advances normally.
+    ///   - *Wildcard / port-zero* ([`KBucket::replace_node_addresses_with_mode`]
+    ///     via `is_storable_address`): if this empties a non-empty input the
+    ///     replace is **refused** — prior good addresses are preserved and
+    ///     `last_publish_seqs` is NOT advanced, so a corrected republish at
+    ///     the same `seq` can still land. Wildcard-only is treated as a
+    ///     malformed publish, not an intentional "I have no addresses", so
+    ///     callers and tests must not assume all filter-empty publishes
+    ///     share the same outcome.
     /// - `seq` must be non-zero and strictly exceed the last sequence
     ///   observed from `node_id`; zero, older, or duplicate sequences are
     ///   ignored.
     ///
     /// Returns `true` when the peer's addresses were replaced, `false`
-    /// otherwise (peer absent, stale sequence, or empty input list).
+    /// otherwise (peer absent, stale sequence, empty input list, or a
+    /// wildcard-only input whose prior addresses were preserved).
     pub async fn replace_node_addresses(
         &self,
         node_id: &PeerId,
@@ -1827,7 +1866,7 @@ impl DhtCoreEngine {
     /// (DhtNetworkManager) must handle the revalidation flow.
     pub async fn add_node(
         &mut self,
-        node: NodeInfo,
+        mut node: NodeInfo,
         trust_score: &impl Fn(&PeerId) -> f64,
     ) -> Result<AdmissionResult> {
         // Reject self-insertion — a node must never appear in its own routing table.
@@ -1836,6 +1875,24 @@ impl DhtCoreEngine {
         }
 
         let peer_id = node.id;
+
+        // Strip wildcard / port-zero addresses before any admission logic runs.
+        // Without this, a NodeInfo carrying both /ip4/0.0.0.0/... and a valid
+        // routable address would be rejected wholesale by the unspecified-IP
+        // check in `add_with_diversity` — the per-address store filter in
+        // `KBucket::add_node` never gets a chance to run. Sanitizing here lets
+        // mixed records through with only their routable addresses retained,
+        // matching the store-side filter applied at the bucket boundary.
+        node.retain_storable_addresses();
+
+        // A record left with no addresses after sanitization carried nothing
+        // but wildcard / port-zero entries. It is not a non-IP transport, so
+        // it must not fall through to the non-IP bypass below — reject it.
+        if node.addresses.is_empty() {
+            return Err(anyhow!(
+                "all addresses were wildcard / port-zero; nothing storable"
+            ));
+        }
 
         // Extract ALL IP addresses from the candidate for diversity checking.
         // If candidate has no IP-based addresses, it's a non-IP transport — bypass diversity.
@@ -5138,6 +5195,67 @@ mod tests {
         // After filtering, addresses is empty — add_node rejects the slot.
         let result = bucket.add_node(node);
         assert!(result.is_err());
+    }
+
+    /// Engine-level (P2): a mixed wildcard + routable record must be admitted
+    /// through the public `DhtCoreEngine::add_node` path with only the
+    /// routable address stored. Before the sanitize step, `candidate_ips`
+    /// was built from the raw address list and the unspecified-IP guard in
+    /// `add_with_diversity` rejected the whole record before the bucket-side
+    /// store filter could run.
+    #[tokio::test]
+    async fn engine_add_node_admits_mixed_wildcard_and_routable() {
+        let mut dht = DhtCoreEngine::new_for_tests(PeerId::from_bytes([0u8; 32])).unwrap();
+        let routable: MultiAddr = "/ip4/198.51.100.7/udp/10000/quic".parse().unwrap();
+        let wildcard: MultiAddr = "/ip6/::/udp/10000/quic".parse().unwrap();
+        let peer = PeerId::from_bytes([7u8; 32]);
+        let node = NodeInfo {
+            id: peer,
+            addresses: vec![wildcard, routable.clone()],
+            address_types: vec![AddressType::Direct, AddressType::Direct],
+            last_seen: AtomicInstant::now(),
+        };
+
+        let events = dht.add_node_no_trust(node).await.unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, RoutingTableEvent::PeerAdded(p) if *p == peer)),
+            "mixed record should be admitted, got events: {events:?}"
+        );
+
+        let stored = dht.get_node_addresses(&peer).await;
+        assert_eq!(
+            stored,
+            vec![routable],
+            "only the routable address should survive sanitization"
+        );
+    }
+
+    /// Engine-level: a record carrying *only* wildcard addresses has nothing
+    /// storable left after sanitization and must be rejected by the public
+    /// `add_node` path (the empty `candidate_ips` early-out / bucket filter).
+    #[tokio::test]
+    async fn engine_add_node_rejects_only_wildcard_record() {
+        let mut dht = DhtCoreEngine::new_for_tests(PeerId::from_bytes([0u8; 32])).unwrap();
+        let wildcard: MultiAddr = "/ip4/0.0.0.0/udp/10000/quic".parse().unwrap();
+        let peer = PeerId::from_bytes([9u8; 32]);
+        let node = NodeInfo {
+            id: peer,
+            addresses: vec![wildcard],
+            address_types: vec![AddressType::Direct],
+            last_seen: AtomicInstant::now(),
+        };
+
+        let result = dht.add_node_no_trust(node).await;
+        assert!(
+            result.is_err(),
+            "record with only wildcard addresses must not be admitted"
+        );
+        assert!(
+            dht.get_node_addresses(&peer).await.is_empty(),
+            "rejected peer must not appear in the routing table"
+        );
     }
 
     #[test]

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -163,6 +163,33 @@ impl AddressType {
     }
 }
 
+/// Whether `addr` is worth storing in a peer's address record.
+///
+/// Filters out wildcard binds (`0.0.0.0` / `::`) and port `0` for any
+/// IP-based transport (QUIC, TCP, UDP). Such addresses are never dialable:
+/// they identify a *bind* socket on the publisher's side, not a routable
+/// destination. Older saorsa-core builds (pre-self-address filter)
+/// sometimes published their bind addresses verbatim, so receivers kept
+/// warning on every dial attempt against the stored wildcard. Dropping
+/// them at the store boundary stops the noise without changing dial logic
+/// downstream — `is_dialable` (the consumer-side check at
+/// [`DhtNetworkManager::is_dialable`]) keeps its existing rejection so an
+/// untrusted address that slips through any future store path is still
+/// caught at dial time.
+///
+/// Non-IP transports return `true` (filter does not apply) — the address
+/// type itself encodes whatever reachability semantics are appropriate.
+///
+/// Loopback is intentionally NOT filtered here: local devnets legitimately
+/// store loopback addresses, and the per-node `allow_loopback` config lives
+/// at [`DhtCoreEngine::replace_node_addresses`].
+pub(crate) fn is_storable_address(addr: &MultiAddr) -> bool {
+    let Some(sa) = addr.socket_addr() else {
+        return true;
+    };
+    !sa.ip().is_unspecified() && sa.port() != 0
+}
+
 /// Convenience alias for the internal callers that predate the method form.
 const fn type_priority(t: AddressType) -> u8 {
     t.priority()
@@ -238,6 +265,9 @@ impl NodeInfo {
     /// the "at most 1 Relay + 1 WAN non-Relay + 1 LAN per IP family"
     /// invariant holds.
     pub fn merge_typed_address(&mut self, addr: MultiAddr, addr_type: AddressType) {
+        if !is_storable_address(&addr) {
+            return;
+        }
         let addr_type = AddressType::for_advertised_address(&addr, addr_type);
 
         // Ensure address_types is in sync with addresses (legacy compat).
@@ -430,6 +460,9 @@ impl NodeInfo {
         addr: MultiAddr,
         addr_type: AddressType,
     ) -> bool {
+        if !is_storable_address(&addr) {
+            return false;
+        }
         let addr_type = AddressType::for_advertised_address(&addr, addr_type);
         if let Some(pos) = self.addresses.iter().position(|a| a == &addr) {
             let existing = self.address_type_at(pos);
@@ -478,6 +511,37 @@ impl KBucket {
     }
 
     fn add_node(&mut self, mut node: NodeInfo) -> Result<()> {
+        // Drop wildcard / port-zero addresses up front — they are never
+        // dialable destinations (they identify a *bind* socket on the
+        // publisher's side) and storing them just produces dial-time noise
+        // every time the peer is selected as a candidate.
+        let pre_filter_len = node.addresses.len();
+        let mut kept_types = Vec::with_capacity(pre_filter_len);
+        let mut kept_addrs = Vec::with_capacity(pre_filter_len);
+        for (i, addr) in node.addresses.drain(..).enumerate() {
+            if is_storable_address(&addr) {
+                let ty = node
+                    .address_types
+                    .get(i)
+                    .copied()
+                    .unwrap_or(AddressType::Unverified);
+                kept_addrs.push(addr);
+                kept_types.push(ty);
+            }
+        }
+        let stripped = pre_filter_len - kept_addrs.len();
+        let kept_count = kept_addrs.len();
+        node.addresses = kept_addrs;
+        node.address_types = kept_types;
+        if stripped > 0 {
+            tracing::debug!(
+                node_id = %node.id.to_hex(),
+                stripped,
+                kept = kept_count,
+                "stripped non-dialable address(es) from incoming NodeInfo",
+            );
+        }
+
         // Reject nodes with no addresses — a node without reachable
         // addresses is useless in the routing table and would waste a slot.
         if node.addresses.is_empty() {
@@ -753,13 +817,27 @@ impl KBucket {
             return false;
         };
 
+        let input_was_non_empty = !typed_addresses.is_empty();
         let mut typed: Vec<(MultiAddr, AddressType)> = typed_addresses
             .into_iter()
+            .filter(|(addr, _)| is_storable_address(addr))
             .map(|(addr, ty)| {
                 let ty = AddressType::for_advertised_address(&addr, ty);
                 (addr, ty)
             })
             .collect();
+
+        // If filtering emptied a non-empty input (publisher sent only
+        // wildcards or other non-storable addresses), refuse the replace
+        // entirely. The caller (KademliaRoutingTable::replace_node_addresses_with_mode)
+        // gates `last_publish_seqs` on this return value, so refusing here
+        // preserves the peer's prior good addresses AND leaves the door
+        // open for a subsequent CORRECT publish at the same sequence number
+        // to land. Without this guard we would (a) wipe a working address
+        // list and (b) lock the peer out of future republishes ≤ this seq.
+        if typed.is_empty() && input_was_non_empty {
+            return false;
+        }
         typed.sort_by_key(|(_, t)| type_priority(*t));
         typed.truncate(MAX_ADDRESSES_PER_NODE);
 
@@ -4934,5 +5012,205 @@ mod tests {
         assert!(!changed);
         assert_eq!(node.addresses.len(), 1);
         assert_eq!(node.address_type_at(0), AddressType::Direct);
+    }
+
+    // -----------------------------------------------------------------------
+    // Wildcard-address store-side filter tests (silences ~66k WARN/3.7h
+    // observed on prod where peers running older saorsa-core publish their
+    // bind-side `0.0.0.0` / `::` addresses verbatim).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn is_storable_address_rejects_wildcard_v4() {
+        let addr: MultiAddr = "/ip4/0.0.0.0/udp/9000/quic".parse().unwrap();
+        assert!(!is_storable_address(&addr));
+    }
+
+    #[test]
+    fn is_storable_address_rejects_wildcard_v6() {
+        let addr: MultiAddr = "/ip6/::/udp/9000/quic".parse().unwrap();
+        assert!(!is_storable_address(&addr));
+    }
+
+    #[test]
+    fn is_storable_address_rejects_port_zero() {
+        let addr: MultiAddr = "/ip4/192.0.2.1/udp/0/quic".parse().unwrap();
+        assert!(!is_storable_address(&addr));
+    }
+
+    #[test]
+    fn is_storable_address_accepts_routable() {
+        let addr: MultiAddr = "/ip4/203.0.113.10/udp/9000/quic".parse().unwrap();
+        assert!(is_storable_address(&addr));
+    }
+
+    #[test]
+    fn is_storable_address_accepts_loopback_for_devnet() {
+        // Loopback is intentionally accepted — local devnets need it. The
+        // per-node `allow_loopback` config gates routing-table admission
+        // separately.
+        let v4: MultiAddr = "/ip4/127.0.0.1/udp/9000/quic".parse().unwrap();
+        let v6: MultiAddr = "/ip6/::1/udp/9000/quic".parse().unwrap();
+        assert!(is_storable_address(&v4));
+        assert!(is_storable_address(&v6));
+    }
+
+    #[test]
+    fn merge_typed_address_drops_wildcard_silently() {
+        let mut node = NodeInfo {
+            id: PeerId::from_bytes([1u8; 32]),
+            addresses: vec![],
+            address_types: vec![],
+            last_seen: AtomicInstant::now(),
+        };
+        let wildcard: MultiAddr = "/ip6/::/udp/55928/quic".parse().unwrap();
+        node.merge_typed_address(wildcard, AddressType::Direct);
+        assert!(node.addresses.is_empty());
+        assert!(node.address_types.is_empty());
+    }
+
+    #[test]
+    fn merge_typed_address_upgrade_only_returns_false_on_wildcard() {
+        let mut node = NodeInfo {
+            id: PeerId::from_bytes([1u8; 32]),
+            addresses: vec![],
+            address_types: vec![],
+            last_seen: AtomicInstant::now(),
+        };
+        let wildcard: MultiAddr = "/ip4/0.0.0.0/udp/10000/quic".parse().unwrap();
+        let changed = node.merge_typed_address_upgrade_only(wildcard, AddressType::Direct);
+        assert!(!changed);
+        assert!(node.addresses.is_empty());
+    }
+
+    #[test]
+    fn replace_node_addresses_strips_wildcards_keeps_routable() {
+        let k = 8;
+        let mut bucket = KBucket::new(k);
+        bucket
+            .add_node(make_node(1, "/ip4/203.0.113.1/udp/9000/quic"))
+            .unwrap();
+
+        // Publish a mixed set: one routable + one wildcard.
+        let routable: MultiAddr = "/ip4/198.51.100.5/udp/10000/quic".parse().unwrap();
+        let wildcard: MultiAddr = "/ip4/0.0.0.0/udp/10000/quic".parse().unwrap();
+        let typed = vec![
+            (routable.clone(), AddressType::Direct),
+            (wildcard, AddressType::Direct),
+        ];
+        let applied = bucket.replace_node_addresses(&PeerId::from_bytes([1u8; 32]), typed);
+        assert!(applied);
+
+        let node = bucket.get_nodes().last().unwrap();
+        assert_eq!(node.addresses, vec![routable]);
+        assert_eq!(node.address_types, vec![AddressType::Direct]);
+    }
+
+    #[test]
+    fn add_node_strips_wildcards_from_incoming_record() {
+        let k = 8;
+        let mut bucket = KBucket::new(k);
+        let routable: MultiAddr = "/ip4/198.51.100.5/udp/10000/quic".parse().unwrap();
+        let wildcard: MultiAddr = "/ip6/::/udp/10000/quic".parse().unwrap();
+        let node = NodeInfo {
+            id: PeerId::from_bytes([42u8; 32]),
+            addresses: vec![wildcard, routable.clone()],
+            address_types: vec![AddressType::Direct, AddressType::Direct],
+            last_seen: AtomicInstant::now(),
+        };
+        bucket.add_node(node).unwrap();
+        let stored = bucket.get_nodes().last().unwrap();
+        assert_eq!(stored.addresses, vec![routable]);
+        assert_eq!(stored.address_types, vec![AddressType::Direct]);
+    }
+
+    #[test]
+    fn add_node_rejects_record_with_only_wildcard_addresses() {
+        let k = 8;
+        let mut bucket = KBucket::new(k);
+        let wildcard: MultiAddr = "/ip4/0.0.0.0/udp/10000/quic".parse().unwrap();
+        let node = NodeInfo {
+            id: PeerId::from_bytes([42u8; 32]),
+            addresses: vec![wildcard],
+            address_types: vec![AddressType::Direct],
+            last_seen: AtomicInstant::now(),
+        };
+        // After filtering, addresses is empty — add_node rejects the slot.
+        let result = bucket.add_node(node);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn is_storable_address_rejects_tcp_wildcard() {
+        // The dialable_socket_addr() helper only matches QUIC; the filter
+        // must use socket_addr() to also catch TCP / raw UDP wildcards.
+        let tcp_wildcard: MultiAddr = "/ip4/0.0.0.0/tcp/9000".parse().unwrap();
+        assert!(!is_storable_address(&tcp_wildcard));
+    }
+
+    #[test]
+    fn is_storable_address_rejects_udp_wildcard_v6() {
+        let udp_wildcard: MultiAddr = "/ip6/::/udp/9000".parse().unwrap();
+        assert!(!is_storable_address(&udp_wildcard));
+    }
+
+    #[test]
+    fn replace_node_addresses_preserves_state_when_filter_empties_input() {
+        // If a publisher sends a non-empty set that gets entirely filtered
+        // out (e.g. only wildcards), the bucket must NOT wipe the peer's
+        // existing good addresses. The caller relies on `false` to skip
+        // advancing the per-peer publish sequence.
+        let k = 8;
+        let mut bucket = KBucket::new(k);
+        let original: MultiAddr = "/ip4/203.0.113.42/udp/9000/quic".parse().unwrap();
+        bucket
+            .add_node(NodeInfo {
+                id: PeerId::from_bytes([7u8; 32]),
+                addresses: vec![original.clone()],
+                address_types: vec![AddressType::Direct],
+                last_seen: AtomicInstant::now(),
+            })
+            .unwrap();
+
+        let wildcard: MultiAddr = "/ip6/::/udp/55928/quic".parse().unwrap();
+        let typed = vec![(wildcard, AddressType::Direct)];
+        let applied = bucket.replace_node_addresses(&PeerId::from_bytes([7u8; 32]), typed);
+
+        assert!(!applied, "filter-empty publish must not be applied");
+        let node = bucket.get_nodes().last().unwrap();
+        assert_eq!(
+            node.addresses,
+            vec![original],
+            "original addresses must be preserved"
+        );
+    }
+
+    #[test]
+    fn replace_node_addresses_strips_wildcards_with_relay_and_direct() {
+        // Mixed-tier publish: Relay + Direct + wildcard. Filter drops the
+        // wildcard, type-priority sort keeps Relay first, Direct second.
+        let k = 8;
+        let mut bucket = KBucket::new(k);
+        bucket
+            .add_node(make_node(1, "/ip4/203.0.113.1/udp/9000/quic"))
+            .unwrap();
+
+        let relay: MultiAddr = "/ip4/198.51.100.1/udp/8443/quic".parse().unwrap();
+        let direct: MultiAddr = "/ip4/198.51.100.5/udp/10000/quic".parse().unwrap();
+        let wildcard: MultiAddr = "/ip4/0.0.0.0/udp/10000/quic".parse().unwrap();
+        let typed = vec![
+            (direct.clone(), AddressType::Direct),
+            (wildcard, AddressType::Direct),
+            (relay.clone(), AddressType::Relay),
+        ];
+        let applied = bucket.replace_node_addresses(&PeerId::from_bytes([1u8; 32]), typed);
+        assert!(applied);
+
+        let node = bucket.get_nodes().last().unwrap();
+        assert_eq!(node.addresses, vec![relay, direct]);
+        assert_eq!(
+            node.address_types,
+            vec![AddressType::Relay, AddressType::Direct]
+        );
     }
 }


### PR DESCRIPTION
## Why

Prod fleet measurement (24 ant-node v0.11.3 hosts, 3h47m window, 2026-05-14 23:15 → 2026-05-15 03:02 UTC) shows **66,653** of these WARN lines:

```
WARN saorsa_core::dht_network_manager: Rejecting unspecified address: /ip6/::/udp/<port>/quic
```

That's the loudest WARN pattern in the entire log corpus and represents 58% of all WARNs across the fleet. Every prod node sees it.

### Root cause

Older saorsa-core builds (pre-self-address filter at `self_address.rs:257`) publish their bind-side wildcard addresses verbatim via `PUBLISH_ADDRESS_SET`, `OBSERVED_ADDRESS`, and `FIND_NODE` gossip. Receivers store them as if they were dialable, then **every** dial attempt against the peer reads the wildcard back out of the routing table and emits the WARN at `dht_network_manager.rs:2537`. Once a wildcard enters our routing table from a stale-version peer, it sticks — there's no expiry that drops "addresses that fail `is_dialable` permanently."

The current self-side publish filter (`self_address.rs:257`) blocks our own node from broadcasting wildcards, but does nothing for wildcards we receive from peers.

## What

Adds a centralised `is_storable_address(&MultiAddr) -> bool` helper that returns `false` for `0.0.0.0`, `::`, and port-zero on any IP-based transport (QUIC, TCP, UDP), and applies it at the four store entry points:

- **`NodeInfo::merge_typed_address`** — returns silently
- **`NodeInfo::merge_typed_address_upgrade_only`** — returns `false` (no change reported)
- **`KBucket::add_node`** — filters incoming `node.addresses`; rejects whole record if all addresses are stripped
- **`KBucket::replace_node_addresses_with_mode`** — filters input vec. **If filtering empties a non-empty input, returns `false`** so the caller (`KademliaRoutingTable::replace_node_addresses_with_mode`) does not advance `last_publish_seqs` and does not wipe the peer's prior good addresses. This preserves the peer's working state AND keeps the publish-sequence window open for a subsequent correct republish at the same seq.

The downstream `is_dialable` check in `DhtNetworkManager` keeps its existing rejection so any wildcard slipping past a future store path is still caught at dial time (defence in depth).

### What's intentionally NOT filtered

- **Loopback** (`127.0.0.1` / `::1`): local devnets legitimately store loopback addresses, and the per-node `allow_loopback` config gates routing-table admission separately.
- **Non-IP transports**: the address type itself encodes whatever reachability semantics are appropriate.

## Tests

13 new tests added covering:

- The helper (5 tests: wildcard v4/v6, port zero, routable accept, loopback accept)
- Both `NodeInfo` merge variants (2 tests)
- Both `KBucket` entry points (3 tests)
- TCP and UDP wildcards (not just QUIC) (2 tests)
- The preservation invariant: filter-empty publish must not wipe good state (1 test)
- Mixed Relay + Direct + wildcard publish (1 test)

All 475 lib tests pass. `cargo fmt --all -- --check` clean. `cargo clippy --lib --all-features -- -D warnings` clean.

## Adversarial review

Ran an adversarial review pass before push. Two issues found and fixed:

1. **TCP / raw-UDP wildcards bypassed the filter** — `dialable_socket_addr()` only matches QUIC. Switched to `socket_addr()` to catch all IP transports.
2. **Empty filtered publish would have wiped good state** — original draft would have applied an empty replace and advanced the publish sequence, locking out future correct republishes at the same seq. Now returns `false` early so the caller skips the seq advance.

## Impact

Expected: silences ~60k WARN/h across the fleet immediately on rollout, with no eviction or behaviour change. Routing table entries for misbehaving peers no longer accumulate dead wildcard addresses, so dial budgets aren't wasted on them. No change to dial logic, no change to admission, no change to any wire format.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `is_storable_address` guard that drops wildcard (`0.0.0.0` / `::`) and port-0 addresses at four routing-table store entry points, silencing the ~66k WARN/h seen on the prod fleet where older peers published their bind-side addresses verbatim. A preservation guard in `replace_node_addresses_with_mode` returns `false` (without advancing `last_publish_seqs`) when the entire input is filtered to empty, preventing good addresses from being wiped while keeping the sequence window open for a correct republish.

- `is_storable_address` uses `socket_addr()` (not `dialable_socket_addr()`) so TCP and bare-UDP wildcards are also caught, not just QUIC.
- The preservation invariant is well-tested (13 new tests), but the early-return path in `replace_node_addresses_with_mode` skips `last_seen.store_now()` for `AuthenticatedSelfPublish` mode, which is a subtle behaviour change from the stated \"no eviction\" goal for peers that publish exclusively wildcard addresses.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the primary goal of silencing the wildcard-address WARN flood; the two issues are minor doc staleness and an edge-case liveness side-effect.

The core logic is correct and well-tested across 13 scenarios including the critical preservation invariant. The liveness side-effect only matters for peers that exclusively publish wildcard addresses, which are effectively unreachable and can still refresh liveness via FIND_NODE responses.

src/dht/core_engine.rs — specifically the replace_node_addresses_with_mode early-return path and the stale doc comment.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/dht/core_engine.rs | Adds `is_storable_address` helper and applies it at four store entry points; includes a preservation guard that returns false without advancing last_publish_seqs when all addresses in a non-empty publish are filtered; 13 new unit tests cover the key paths. Minor: doc comment on replace_node_addresses not updated for the new false case, and the early return for all-wildcard AuthenticatedSelfPublish skips the last_seen refresh. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PublishAddressSet received"] --> B["filter_lan_addresses_for_store"]
    B --> C["DhtCoreEngine::replace_node_addresses"]
    C --> D{"typed_addresses empty?"}
    D -- "yes" --> E["return false"]
    D -- "no" --> F["filter_publish_address_set"]
    F --> G["KademliaRoutingTable::replace_node_addresses_with_mode"]
    G --> H{"seq invalid/stale?"}
    H -- "yes" --> I["return false"]
    H -- "no" --> J["KBucket::replace_node_addresses_with_mode"]
    J --> K["filter is_storable_address"]
    K --> L{"input non-empty, result empty?"}
    L -- "yes" --> M["return false: addresses preserved, seq not advanced, last_seen not refreshed"]
    L -- "no" --> N["sort + truncate + cap"]
    N --> O["write node.addresses"]
    O --> P{"AuthenticatedSelfPublish?"}
    P -- "yes" --> Q["last_seen.store_now, advance seq"]
    P -- "no" --> R["advance seq only"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/dht/core_engine.rs`, line 782-783 ([link](https://github.com/saorsa-labs/saorsa-core/blob/6ec50a0701dc04e8526136388d69b3f0393c335b/src/dht/core_engine.rs#L782-L783)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The doc comment for `replace_node_addresses` (and the private `replace_node_addresses_with_mode`) now has a stale return-value description. The comment says `false` means "peer is not in this bucket," but after this PR there is a second reason to return `false`: a non-empty input set that is entirely filtered to wildcards. A caller that checks the return value to infer bucket membership will draw the wrong conclusion in the new case.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/dht/core_engine.rs
   Line: 782-783

   Comment:
   The doc comment for `replace_node_addresses` (and the private `replace_node_addresses_with_mode`) now has a stale return-value description. The comment says `false` means "peer is not in this bucket," but after this PR there is a second reason to return `false`: a non-empty input set that is entirely filtered to wildcards. A caller that checks the return value to infer bucket membership will draw the wrong conclusion in the new case.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/dht/core_engine.rs:782-783
The doc comment for `replace_node_addresses` (and the private `replace_node_addresses_with_mode`) now has a stale return-value description. The comment says `false` means "peer is not in this bucket," but after this PR there is a second reason to return `false`: a non-empty input set that is entirely filtered to wildcards. A caller that checks the return value to infer bucket membership will draw the wrong conclusion in the new case.

```suggestion
    /// Returns `true` when the peer was found and its addresses replaced,
    /// `false` when the peer is not in this bucket or when every address in
    /// `typed_addresses` was filtered out as non-storable (e.g., all wildcards).
```

### Issue 2 of 2
src/dht/core_engine.rs:838-840
**Liveness not refreshed on all-wildcard authenticated self-publish**

The early `return false` here exits before the `if mode.refreshes_liveness()` block that calls `last_seen.store_now()` and moves the node to the tail (lines 858–863). For `AuthenticatedSelfPublish` mode, this means a peer that sends a `PublishAddressSet` containing only wildcards will not have its `last_seen` timestamp updated even though it demonstrably just communicated with us. The PR description says "no eviction or behaviour change," but this path silently stops refreshing liveness for that edge case. A minimal fix would be to separate the address-update return value from the liveness-update side effect, or to explicitly document that this is intentional.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dht): drop wildcard / port-zero addr..."](https://github.com/saorsa-labs/saorsa-core/commit/6ec50a0701dc04e8526136388d69b3f0393c335b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32274191)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->