### PR TITLE
fix(dht): throttle maintenance lookups

### DIFF
--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -452,7 +452,7 @@ struct KBucket {
     /// Monotonic timestamp of the last completed refresh probe for this
     /// bucket. This is deliberately separate from live-peer refresh so failed
     /// or empty probes can be deprioritised without masking stale buckets.
-    last_probe_finished: Instant,
+    last_probe_finished: AtomicInstant,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -487,7 +487,7 @@ impl KBucket {
             nodes: Vec::new(),
             max_size,
             last_refreshed_by_live_peer: now,
-            last_probe_finished: now,
+            last_probe_finished: AtomicInstant::from_instant(now),
         }
     }
 
@@ -1120,7 +1120,7 @@ impl KademliaRoutingTable {
             .map(|(index, bucket)| {
                 let live_peer_age =
                     now.saturating_duration_since(bucket.last_refreshed_by_live_peer);
-                let probe_age = now.saturating_duration_since(bucket.last_probe_finished);
+                let probe_age = now.saturating_duration_since(bucket.last_probe_finished.load());
                 let refresh_debt = live_peer_age.min(probe_age);
                 BucketRefreshCandidate {
                     index,
@@ -1132,11 +1132,11 @@ impl KademliaRoutingTable {
             .collect()
     }
 
-    fn mark_bucket_probe_finished(&mut self, bucket_idx: usize) -> bool {
-        let Some(bucket) = self.buckets.get_mut(bucket_idx) else {
+    fn mark_bucket_probe_finished(&self, bucket_idx: usize) -> bool {
+        let Some(bucket) = self.buckets.get(bucket_idx) else {
             return false;
         };
-        bucket.last_probe_finished = Instant::now();
+        bucket.last_probe_finished.store_now();
         true
     }
 }
@@ -1368,7 +1368,7 @@ impl DhtCoreEngine {
     /// freshness.
     pub(crate) async fn mark_bucket_probe_finished(&self, bucket_idx: usize) -> bool {
         self.routing_table
-            .write()
+            .read()
             .await
             .mark_bucket_probe_finished(bucket_idx)
     }
@@ -4066,7 +4066,7 @@ mod tests {
             let mut routing = dht.routing_table_for_test().write().await;
             let bucket = &mut routing.buckets[bucket_idx];
             bucket.last_refreshed_by_live_peer = instant_ago(live_age);
-            bucket.last_probe_finished = instant_ago(probe_age);
+            bucket.last_probe_finished.store(instant_ago(probe_age));
         }
 
         let candidates = dht.bucket_refresh_candidates().await;
@@ -4094,7 +4094,7 @@ mod tests {
             let mut routing = dht.routing_table_for_test().write().await;
             let bucket = &mut routing.buckets[bucket_idx];
             bucket.last_refreshed_by_live_peer = old_live;
-            bucket.last_probe_finished = old_probe;
+            bucket.last_probe_finished.store(old_probe);
         }
 
         assert!(dht.mark_bucket_probe_finished(bucket_idx).await);
@@ -4102,7 +4102,7 @@ mod tests {
         let routing = dht.routing_table_for_test().read().await;
         let bucket = &routing.buckets[bucket_idx];
         assert_eq!(bucket.last_refreshed_by_live_peer, old_live);
-        assert!(bucket.last_probe_finished > old_probe);
+        assert!(bucket.last_probe_finished.load() > old_probe);
     }
 
     #[tokio::test]

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -446,9 +446,21 @@ impl NodeInfo {
 struct KBucket {
     nodes: Vec<NodeInfo>,
     max_size: usize,
-    /// Monotonic timestamp of the last time this bucket was refreshed
-    /// (node added, updated, or touched).
-    last_refreshed: Instant,
+    /// Monotonic timestamp of the last time this bucket was refreshed by
+    /// live-peer evidence (node added, updated, or touched).
+    last_refreshed_by_live_peer: Instant,
+    /// Monotonic timestamp of the last completed refresh probe for this
+    /// bucket. This is deliberately separate from live-peer refresh so failed
+    /// or empty probes can be deprioritised without masking stale buckets.
+    last_probe_finished: Instant,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct BucketRefreshCandidate {
+    pub(crate) index: usize,
+    pub(crate) refresh_debt: Duration,
+    pub(crate) live_peer_age: Duration,
+    pub(crate) probe_age: Duration,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -470,10 +482,12 @@ impl AddressReplaceMode {
 
 impl KBucket {
     fn new(max_size: usize) -> Self {
+        let now = Instant::now();
         Self {
             nodes: Vec::new(),
             max_size,
-            last_refreshed: Instant::now(),
+            last_refreshed_by_live_peer: now,
+            last_probe_finished: now,
         }
     }
 
@@ -517,7 +531,7 @@ impl KBucket {
                 existing.merge_typed_address(addr, addr_type);
             }
             self.nodes.push(existing);
-            self.last_refreshed = Instant::now();
+            self.last_refreshed_by_live_peer = Instant::now();
             return Ok(());
         }
 
@@ -528,7 +542,7 @@ impl KBucket {
             // connection handler batching advertised addresses.
             node.enforce_per_ip_family_cap();
             self.nodes.push(node);
-            self.last_refreshed = Instant::now();
+            self.last_refreshed_by_live_peer = Instant::now();
             Ok(())
         } else {
             Err(anyhow!(
@@ -572,7 +586,7 @@ impl KBucket {
             }
             let node = self.nodes.remove(pos);
             self.nodes.push(node);
-            self.last_refreshed = Instant::now();
+            self.last_refreshed_by_live_peer = Instant::now();
             true
         } else {
             false
@@ -583,9 +597,9 @@ impl KBucket {
     /// upgrade-only semantics: never demote a higher-priority tag already
     /// on the same address.
     ///
-    /// **Pure address-set update.** Does NOT bump the peer's `last_seen`,
-    /// does NOT reorder the bucket (no MRU promotion), and does NOT bump
-    /// the bucket's `last_refreshed` timestamp. Intended for FIND_NODE
+    /// **Pure address-set update.** Does NOT bump the peer's `last_seen`, does
+    /// NOT reorder the bucket (no MRU promotion), and does NOT bump the
+    /// bucket's `last_refreshed_by_live_peer` timestamp. Intended for FIND_NODE
     /// gossip ingestion, where a responder's typed view of a *third*
     /// peer is trusted enough to widen our known address set or promote
     /// `Unverified` → `Direct`/`Relay`, but is **not** evidence of:
@@ -594,13 +608,14 @@ impl KBucket {
     ///   gossip would let peers we cannot authenticate with ourselves
     ///   stay perpetually "fresh", indefinitely deferring the
     ///   [`DhtCoreEngine::stale_k_closest`] eviction worker), or
-    /// * bucket-level discovery activity (covered by `last_refreshed` —
-    ///   the bucket-refresh task uses it to decide when to run a
+    /// * bucket-level discovery activity (covered by
+    ///   `last_refreshed_by_live_peer` — the bucket-refresh task uses it to
+    ///   decide when to run a
     ///   FIND_NODE for a random key in this bucket's range, which is how
     ///   we discover *new* peers. Gossip about peers we already know is
-    ///   not discovery; bumping `last_refreshed` from gossip would mask
-    ///   genuinely-stale buckets and silently suppress discovery as long
-    ///   as some neighbour kept gossiping about a peer in that range).
+    ///   not discovery; bumping `last_refreshed_by_live_peer` from gossip would
+    ///   mask genuinely-stale buckets and silently suppress discovery as long as
+    ///   some neighbour kept gossiping about a peer in that range).
     ///
     /// Returns `true` when the merge changed the peer's address record
     /// (a new address was appended, or an existing tag was promoted to a
@@ -782,7 +797,7 @@ impl KBucket {
             // Move to tail (most recently seen).
             let node = self.nodes.remove(pos);
             self.nodes.push(node);
-            self.last_refreshed = Instant::now();
+            self.last_refreshed_by_live_peer = Instant::now();
         }
 
         true
@@ -1092,14 +1107,38 @@ impl KademliaRoutingTable {
             .collect()
     }
 
-    /// Return indices of buckets whose `last_refreshed` exceeds `threshold`.
-    fn stale_bucket_indices(&self, threshold: Duration) -> Vec<usize> {
+    /// Return refresh candidates for buckets whose live-peer refresh exceeds
+    /// `threshold`.
+    fn stale_bucket_refresh_candidates(&self, threshold: Duration) -> Vec<BucketRefreshCandidate> {
+        let now = Instant::now();
         self.buckets
             .iter()
             .enumerate()
-            .filter(|(_, b)| b.last_refreshed.elapsed() > threshold)
-            .map(|(i, _)| i)
+            .filter_map(|(index, bucket)| {
+                let live_peer_age =
+                    now.saturating_duration_since(bucket.last_refreshed_by_live_peer);
+                if live_peer_age <= threshold {
+                    return None;
+                }
+                let probe_age = now.saturating_duration_since(bucket.last_probe_finished);
+                let overdue = live_peer_age.saturating_sub(threshold);
+                let refresh_debt = overdue.min(probe_age);
+                Some(BucketRefreshCandidate {
+                    index,
+                    refresh_debt,
+                    live_peer_age,
+                    probe_age,
+                })
+            })
             .collect()
+    }
+
+    fn mark_bucket_probe_finished(&mut self, bucket_idx: usize) -> bool {
+        let Some(bucket) = self.buckets.get_mut(bucket_idx) else {
+            return false;
+        };
+        bucket.last_probe_finished = Instant::now();
+        true
     }
 }
 
@@ -1321,12 +1360,25 @@ impl DhtCoreEngine {
             .collect()
     }
 
-    /// Return bucket indices that haven't been refreshed within the given threshold.
-    pub(crate) async fn stale_bucket_indices(&self, threshold: Duration) -> Vec<usize> {
+    /// Return bucket refresh candidates that have not seen live-peer refresh
+    /// within the given threshold.
+    pub(crate) async fn stale_bucket_refresh_candidates(
+        &self,
+        threshold: Duration,
+    ) -> Vec<BucketRefreshCandidate> {
         self.routing_table
             .read()
             .await
-            .stale_bucket_indices(threshold)
+            .stale_bucket_refresh_candidates(threshold)
+    }
+
+    /// Mark a bucket refresh probe as completed without changing live-peer
+    /// freshness.
+    pub(crate) async fn mark_bucket_probe_finished(&self, bucket_idx: usize) -> bool {
+        self.routing_table
+            .write()
+            .await
+            .mark_bucket_probe_finished(bucket_idx)
     }
 
     /// Generate a random key that would fall into the specified bucket index
@@ -2137,7 +2189,7 @@ impl DhtCoreEngine {
             // Move to tail (most recently seen)
             let updated = routing.buckets[bucket_idx].nodes.remove(pos);
             routing.buckets[bucket_idx].nodes.push(updated);
-            routing.buckets[bucket_idx].last_refreshed = Instant::now();
+            routing.buckets[bucket_idx].last_refreshed_by_live_peer = Instant::now();
             return Ok(AdmissionResult::Admitted(Vec::new()));
         }
 
@@ -2648,14 +2700,14 @@ mod tests {
     }
 
     #[test]
-    fn gossip_merge_does_not_bump_last_refreshed() {
+    fn gossip_merge_does_not_bump_live_peer_refresh() {
         let k = 8;
         let mut bucket = KBucket::new(k);
         bucket
             .add_node(make_node(1, "/ip4/1.1.1.1/udp/9000/quic"))
             .unwrap();
 
-        let before = bucket.last_refreshed;
+        let before = bucket.last_refreshed_by_live_peer;
 
         let gossiped: MultiAddr = "/ip4/8.8.8.8/udp/9000/quic".parse().unwrap();
         let changed = bucket.merge_typed_address_upgrade_only(
@@ -2665,8 +2717,8 @@ mod tests {
         );
         assert!(changed);
         assert_eq!(
-            bucket.last_refreshed, before,
-            "gossip ingestion is not bucket-level discovery — last_refreshed must not advance"
+            bucket.last_refreshed_by_live_peer, before,
+            "gossip ingestion is not bucket-level discovery — live-peer refresh must not advance"
         );
     }
 
@@ -2916,7 +2968,7 @@ mod tests {
             .unwrap()
             .last_seen
             .load();
-        let before_last_refreshed = table.buckets[bucket_index].last_refreshed;
+        let before_last_refreshed = table.buckets[bucket_index].last_refreshed_by_live_peer;
 
         let gossiped: Vec<(MultiAddr, AddressType)> = vec![(
             "/ip4/2.2.2.2/udp/9000/quic".parse().unwrap(),
@@ -2936,7 +2988,7 @@ mod tests {
             "third-party gossip must not prove subject-peer liveness"
         );
         assert_eq!(
-            table.buckets[bucket_index].last_refreshed, before_last_refreshed,
+            table.buckets[bucket_index].last_refreshed_by_live_peer, before_last_refreshed,
             "third-party gossip must not count as bucket discovery activity"
         );
         assert_eq!(table.publish_seq_for(&peer), 10);
@@ -4002,13 +4054,65 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_stale_bucket_indices_returns_empty_when_fresh() {
+    async fn test_stale_bucket_refresh_candidates_returns_empty_when_fresh() {
         let dht = DhtCoreEngine::new_for_tests(PeerId::random()).unwrap();
-        let stale = dht.stale_bucket_indices(Duration::from_secs(3600)).await;
+        let stale = dht
+            .stale_bucket_refresh_candidates(Duration::from_secs(3600))
+            .await;
         assert!(
             stale.is_empty(),
             "freshly created routing table should have no stale buckets"
         );
+    }
+
+    #[tokio::test]
+    async fn stale_bucket_refresh_candidates_use_probe_debt() {
+        let dht = DhtCoreEngine::new_for_tests(PeerId::random()).unwrap();
+        let bucket_idx = 7;
+        let now = Instant::now();
+        {
+            let mut routing = dht.routing_table_for_test().write().await;
+            let bucket = &mut routing.buckets[bucket_idx];
+            bucket.last_refreshed_by_live_peer = now - Duration::from_secs(2 * 3600);
+            bucket.last_probe_finished = now - Duration::from_secs(60);
+        }
+
+        let candidates = dht
+            .stale_bucket_refresh_candidates(Duration::from_secs(3600))
+            .await;
+        let candidate = candidates
+            .into_iter()
+            .find(|candidate| candidate.index == bucket_idx)
+            .expect("stale bucket should be returned");
+
+        assert!(candidate.live_peer_age >= Duration::from_secs(2 * 3600));
+        assert!(candidate.probe_age >= Duration::from_secs(60));
+        assert!(
+            candidate.refresh_debt <= Duration::from_secs(65),
+            "recent probe should limit refresh debt: {:?}",
+            candidate.refresh_debt
+        );
+    }
+
+    #[tokio::test]
+    async fn marking_bucket_probe_finished_does_not_refresh_live_peer_timestamp() {
+        let dht = DhtCoreEngine::new_for_tests(PeerId::random()).unwrap();
+        let bucket_idx = 11;
+        let old_live = Instant::now() - Duration::from_secs(2 * 3600);
+        let old_probe = Instant::now() - Duration::from_secs(3600);
+        {
+            let mut routing = dht.routing_table_for_test().write().await;
+            let bucket = &mut routing.buckets[bucket_idx];
+            bucket.last_refreshed_by_live_peer = old_live;
+            bucket.last_probe_finished = old_probe;
+        }
+
+        assert!(dht.mark_bucket_probe_finished(bucket_idx).await);
+
+        let routing = dht.routing_table_for_test().read().await;
+        let bucket = &routing.buckets[bucket_idx];
+        assert_eq!(bucket.last_refreshed_by_live_peer, old_live);
+        assert!(bucket.last_probe_finished > old_probe);
     }
 
     #[tokio::test]

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -1107,28 +1107,27 @@ impl KademliaRoutingTable {
             .collect()
     }
 
-    /// Return refresh candidates for buckets whose live-peer refresh exceeds
-    /// `threshold`.
-    fn stale_bucket_refresh_candidates(&self, threshold: Duration) -> Vec<BucketRefreshCandidate> {
+    /// Return refresh candidates for every bucket.
+    ///
+    /// Refresh debt is bounded by both clocks: recent live-peer evidence and a
+    /// recent refresh probe each make the bucket low priority. This keeps bucket
+    /// maintenance continuous without needing a separate stale-age threshold.
+    fn bucket_refresh_candidates(&self) -> Vec<BucketRefreshCandidate> {
         let now = Instant::now();
         self.buckets
             .iter()
             .enumerate()
-            .filter_map(|(index, bucket)| {
+            .map(|(index, bucket)| {
                 let live_peer_age =
                     now.saturating_duration_since(bucket.last_refreshed_by_live_peer);
-                if live_peer_age <= threshold {
-                    return None;
-                }
                 let probe_age = now.saturating_duration_since(bucket.last_probe_finished);
-                let overdue = live_peer_age.saturating_sub(threshold);
-                let refresh_debt = overdue.min(probe_age);
-                Some(BucketRefreshCandidate {
+                let refresh_debt = live_peer_age.min(probe_age);
+                BucketRefreshCandidate {
                     index,
                     refresh_debt,
                     live_peer_age,
                     probe_age,
-                })
+                }
             })
             .collect()
     }
@@ -1360,16 +1359,9 @@ impl DhtCoreEngine {
             .collect()
     }
 
-    /// Return bucket refresh candidates that have not seen live-peer refresh
-    /// within the given threshold.
-    pub(crate) async fn stale_bucket_refresh_candidates(
-        &self,
-        threshold: Duration,
-    ) -> Vec<BucketRefreshCandidate> {
-        self.routing_table
-            .read()
-            .await
-            .stale_bucket_refresh_candidates(threshold)
+    /// Return refresh candidates for every bucket.
+    pub(crate) async fn bucket_refresh_candidates(&self) -> Vec<BucketRefreshCandidate> {
+        self.routing_table.read().await.bucket_refresh_candidates()
     }
 
     /// Mark a bucket refresh probe as completed without changing live-peer
@@ -1384,8 +1376,8 @@ impl DhtCoreEngine {
     /// Generate a random key that would fall into the specified bucket index
     /// relative to this node's ID.
     ///
-    /// Used for bucket refresh: looking up a random key in a stale bucket's range
-    /// discovers new peers that populate that bucket.
+    /// Used for bucket refresh: looking up a random key in a selected bucket's
+    /// range discovers new peers that populate that bucket.
     ///
     /// Returns `None` if `bucket_idx` is out of range (>= 256).
     pub(crate) fn generate_random_key_for_bucket(&self, bucket_idx: usize) -> Option<DhtKey> {
@@ -4054,19 +4046,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_stale_bucket_refresh_candidates_returns_empty_when_fresh() {
+    async fn test_bucket_refresh_candidates_returns_all_buckets_when_fresh() {
         let dht = DhtCoreEngine::new_for_tests(PeerId::random()).unwrap();
-        let stale = dht
-            .stale_bucket_refresh_candidates(Duration::from_secs(3600))
-            .await;
-        assert!(
-            stale.is_empty(),
-            "freshly created routing table should have no stale buckets"
+        let candidates = dht.bucket_refresh_candidates().await;
+        assert_eq!(
+            candidates.len(),
+            KADEMLIA_BUCKET_COUNT,
+            "bucket refresh should continuously rank all buckets"
         );
     }
 
     #[tokio::test]
-    async fn stale_bucket_refresh_candidates_use_probe_debt() {
+    async fn bucket_refresh_candidates_use_probe_debt() {
         let dht = DhtCoreEngine::new_for_tests(PeerId::random()).unwrap();
         let bucket_idx = 7;
         let now = Instant::now();
@@ -4077,13 +4068,11 @@ mod tests {
             bucket.last_probe_finished = now - Duration::from_secs(60);
         }
 
-        let candidates = dht
-            .stale_bucket_refresh_candidates(Duration::from_secs(3600))
-            .await;
+        let candidates = dht.bucket_refresh_candidates().await;
         let candidate = candidates
             .into_iter()
             .find(|candidate| candidate.index == bucket_idx)
-            .expect("stale bucket should be returned");
+            .expect("bucket should be returned");
 
         assert!(candidate.live_peer_age >= Duration::from_secs(2 * 3600));
         assert!(candidate.probe_age >= Duration::from_secs(60));

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -4060,12 +4060,13 @@ mod tests {
     async fn bucket_refresh_candidates_use_probe_debt() {
         let dht = DhtCoreEngine::new_for_tests(PeerId::random()).unwrap();
         let bucket_idx = 7;
-        let now = Instant::now();
+        let live_age = Duration::from_secs(2);
+        let probe_age = Duration::from_millis(50);
         {
             let mut routing = dht.routing_table_for_test().write().await;
             let bucket = &mut routing.buckets[bucket_idx];
-            bucket.last_refreshed_by_live_peer = now - Duration::from_secs(2 * 3600);
-            bucket.last_probe_finished = now - Duration::from_secs(60);
+            bucket.last_refreshed_by_live_peer = instant_ago(live_age);
+            bucket.last_probe_finished = instant_ago(probe_age);
         }
 
         let candidates = dht.bucket_refresh_candidates().await;
@@ -4074,10 +4075,10 @@ mod tests {
             .find(|candidate| candidate.index == bucket_idx)
             .expect("bucket should be returned");
 
-        assert!(candidate.live_peer_age >= Duration::from_secs(2 * 3600));
-        assert!(candidate.probe_age >= Duration::from_secs(60));
+        assert!(candidate.live_peer_age >= live_age);
+        assert!(candidate.probe_age >= probe_age);
         assert!(
-            candidate.refresh_debt <= Duration::from_secs(65),
+            candidate.refresh_debt < live_age,
             "recent probe should limit refresh debt: {:?}",
             candidate.refresh_debt
         );
@@ -4087,8 +4088,8 @@ mod tests {
     async fn marking_bucket_probe_finished_does_not_refresh_live_peer_timestamp() {
         let dht = DhtCoreEngine::new_for_tests(PeerId::random()).unwrap();
         let bucket_idx = 11;
-        let old_live = Instant::now() - Duration::from_secs(2 * 3600);
-        let old_probe = Instant::now() - Duration::from_secs(3600);
+        let old_live = instant_ago(Duration::from_secs(2));
+        let old_probe = instant_ago(Duration::from_millis(50));
         {
             let mut routing = dht.routing_table_for_test().write().await;
             let bucket = &mut routing.buckets[bucket_idx];
@@ -4122,6 +4123,19 @@ mod tests {
             }
         }
         None
+    }
+
+    /// Return an `Instant` approximately `duration` in the past without
+    /// assuming the runner's monotonic clock has already existed that long.
+    fn instant_ago(duration: Duration) -> Instant {
+        if let Some(instant) = Instant::now().checked_sub(duration) {
+            return instant;
+        }
+
+        std::thread::sleep(duration.saturating_add(Duration::from_millis(1)));
+        Instant::now()
+            .checked_sub(duration)
+            .expect("runner Instant should be old enough after sleeping")
     }
 
     // =======================================================================

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -151,42 +151,41 @@ const MAX_CONCURRENT_REVALIDATIONS: usize = 8;
 /// Maximum concurrent pings within a single stale revalidation pass.
 const MAX_CONCURRENT_REVALIDATION_PINGS: usize = 4;
 
-/// Duration after which a bucket without activity is considered stale.
-const STALE_BUCKET_THRESHOLD: Duration = Duration::from_secs(3600); // 1 hour
-
 /// Minimum self-lookup interval (randomized between min and max).
 const SELF_LOOKUP_INTERVAL_MIN: Duration = Duration::from_secs(300); // 5 minutes
 
 /// Maximum self-lookup interval.
 const SELF_LOOKUP_INTERVAL_MAX: Duration = Duration::from_secs(600); // 10 minutes
 
-/// Minimum periodic refresh cadence for stale k-buckets (randomized between
-/// min and max). Jittering this interval prevents 1000s of nodes that started
-/// in lockstep from all firing their bucket-refresh FIND_NODEs in the same
-/// second once their distant buckets cross [`STALE_BUCKET_THRESHOLD`].
+/// Minimum periodic refresh cadence for k-buckets (randomized between min and
+/// max). Jittering this interval prevents 1000s of nodes that started in
+/// lockstep from all firing their bucket-refresh FIND_NODEs in the same second.
 const BUCKET_REFRESH_INTERVAL_MIN: Duration = Duration::from_secs(450); // 7.5 minutes
 
-/// Maximum periodic refresh cadence for stale k-buckets.
+/// Maximum periodic refresh cadence for k-buckets.
 const BUCKET_REFRESH_INTERVAL_MAX: Duration = Duration::from_secs(750); // 12.5 minutes
 
-/// Maximum stale k-buckets refreshed during a single bucket-refresh pass.
+/// Maximum k-buckets refreshed during a single bucket-refresh pass.
 ///
-/// A large production routing table can have many stale buckets at once. Without
-/// a per-pass budget, the refresh task can spend the whole interval running
-/// iterative network lookups back-to-back.
-const MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS: usize = 4;
+/// A large production routing table has 256 buckets to maintain. Without a
+/// per-pass budget, the refresh task can spend the whole interval running
+/// iterative network lookups back-to-back. With the current 7.5-12.5 minute
+/// interval, refreshing two buckets per pass gives an approximate once-per-day
+/// full-table maintenance cadence while keeping background lookup pressure low.
+const MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS: usize = 2;
 
 /// Maximum concurrent maintenance lookups.
 ///
 /// This is intentionally scoped to background maintenance so foreground/user
-/// lookup behaviour remains unchanged.
+/// lookup behaviour remains unchanged. Automatic re-bootstrap is intentionally
+/// exempt: it is gated separately by [`REBOOTSTRAP_COOLDOWN`] and only runs
+/// when the routing table has fallen below [`AUTO_REBOOTSTRAP_THRESHOLD`].
 const MAX_CONCURRENT_MAINTENANCE_LOOKUPS: usize = 1;
 
 /// Random jitter applied to bucket-refresh debt ordering.
 ///
-/// Kept small relative to the one-hour stale threshold so the oldest/debtiest
-/// buckets still dominate, while same-age buckets do not refresh in lockstep
-/// across nodes.
+/// Kept small so the oldest/debtiest buckets still dominate, while same-age
+/// buckets do not refresh in lockstep across nodes.
 const BUCKET_REFRESH_SELECTION_JITTER: Duration = Duration::from_secs(60);
 
 /// Routing table size below which automatic re-bootstrap is triggered.
@@ -1503,10 +1502,10 @@ impl DhtNetworkManager {
     /// Spawn the periodic bucket refresh background task.
     ///
     /// At a randomised interval between [`BUCKET_REFRESH_INTERVAL_MIN`] and
-    /// [`BUCKET_REFRESH_INTERVAL_MAX`], finds stale buckets (not refreshed
-    /// within [`STALE_BUCKET_THRESHOLD`]) and performs a FIND_NODE lookup for
-    /// a random key in each stale bucket's range. This populates stale buckets
-    /// with fresh peers.
+    /// [`BUCKET_REFRESH_INTERVAL_MAX`], selects the highest-debt buckets and
+    /// performs a FIND_NODE lookup for a random key in each selected bucket's
+    /// range. This keeps bucket refresh continuous while the per-pass budget
+    /// limits background lookup volume.
     async fn spawn_bucket_refresh_task(self: &Arc<Self>) {
         let this = Arc::clone(self);
         let shutdown = self.shutdown.clone();
@@ -1530,23 +1529,23 @@ impl DhtNetworkManager {
                 tokio::select! {
                     () = shutdown.cancelled() => break,
                     _ = async {
-                        let stale_candidates = this
+                        let refresh_candidates = this
                             .dht
                             .read()
                             .await
-                            .stale_bucket_refresh_candidates(STALE_BUCKET_THRESHOLD)
+                            .bucket_refresh_candidates()
                             .await;
 
-                        if stale_candidates.is_empty() {
-                            trace!("Bucket refresh: no stale buckets");
+                        if refresh_candidates.is_empty() {
+                            trace!("Bucket refresh: no refresh candidates");
                             return;
                         }
 
-                        let stale_count = stale_candidates.len();
-                        let refresh_indices = Self::select_bucket_refresh_indices(stale_candidates);
+                        let candidate_count = refresh_candidates.len();
+                        let refresh_indices = Self::select_bucket_refresh_indices(refresh_candidates);
                         let refresh_count = refresh_indices.len();
                         debug!(
-                            "Bucket refresh: {stale_count} stale buckets, refreshing {refresh_count}"
+                            "Bucket refresh: {candidate_count} candidate buckets, refreshing {refresh_count}"
                         );
 
                         let Ok(_maintenance_lookup_permit) = Arc::clone(
@@ -1645,7 +1644,10 @@ impl DhtNetworkManager {
     /// [`AUTO_REBOOTSTRAP_THRESHOLD`] and the cooldown has elapsed.
     ///
     /// Uses currently connected peers as bootstrap seeds. The cooldown prevents
-    /// hammering bootstrap nodes during transient network partitions.
+    /// hammering bootstrap nodes during transient network partitions. This is
+    /// deliberately not guarded by `maintenance_lookup_semaphore`: once the
+    /// routing table is below the recovery threshold, bootstrap repair should
+    /// not be skipped just because a best-effort maintenance lookup is running.
     async fn maybe_rebootstrap(&self) {
         let rt_size = self.get_routing_table_size().await;
         if rt_size >= AUTO_REBOOTSTRAP_THRESHOLD {
@@ -4866,7 +4868,7 @@ mod tests {
         BucketRefreshCandidate {
             index,
             refresh_debt,
-            live_peer_age: refresh_debt + STALE_BUCKET_THRESHOLD,
+            live_peer_age: refresh_debt,
             probe_age: refresh_debt,
         }
     }
@@ -4894,7 +4896,7 @@ mod tests {
         selected.sort_unstable();
 
         assert_eq!(selected.len(), MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS);
-        assert_eq!(selected, vec![8, 9, 10, 11]);
+        assert_eq!(selected, vec![4, 5]);
     }
 
     #[test]

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -23,7 +23,7 @@ use crate::{
     adaptive::TrustEngine,
     adaptive::trust::DEFAULT_NEUTRAL_TRUST,
     address::{MultiAddr, is_lan_ip},
-    dht::core_engine::{AddressType, AtomicInstant, NodeInfo},
+    dht::core_engine::{AddressType, AtomicInstant, BucketRefreshCandidate, NodeInfo},
     dht::{AdmissionResult, DhtCoreEngine, DhtKey, Key, RoutingTableEvent},
     error::{DhtError, IdentityError, NetworkError},
     network::{NodeConfig, NodeMode},
@@ -34,6 +34,7 @@ use anyhow::Context as _;
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry as DashEntry;
 use futures::stream::{FuturesUnordered, StreamExt};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::{IpAddr, SocketAddr};
@@ -167,6 +168,26 @@ const BUCKET_REFRESH_INTERVAL_MIN: Duration = Duration::from_secs(450); // 7.5 m
 
 /// Maximum periodic refresh cadence for stale k-buckets.
 const BUCKET_REFRESH_INTERVAL_MAX: Duration = Duration::from_secs(750); // 12.5 minutes
+
+/// Maximum stale k-buckets refreshed during a single bucket-refresh pass.
+///
+/// A large production routing table can have many stale buckets at once. Without
+/// a per-pass budget, the refresh task can spend the whole interval running
+/// iterative network lookups back-to-back.
+const MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS: usize = 4;
+
+/// Maximum concurrent maintenance lookups.
+///
+/// This is intentionally scoped to background maintenance so foreground/user
+/// lookup behaviour remains unchanged.
+const MAX_CONCURRENT_MAINTENANCE_LOOKUPS: usize = 1;
+
+/// Random jitter applied to bucket-refresh debt ordering.
+///
+/// Kept small relative to the one-hour stale threshold so the oldest/debtiest
+/// buckets still dominate, while same-age buckets do not refresh in lockstep
+/// across nodes.
+const BUCKET_REFRESH_SELECTION_JITTER: Duration = Duration::from_secs(60);
 
 /// Routing table size below which automatic re-bootstrap is triggered.
 const AUTO_REBOOTSTRAP_THRESHOLD: usize = 3;
@@ -657,6 +678,10 @@ pub struct DhtNetworkManager {
     /// Uses `parking_lot::Mutex` (not tokio) because it is never held across
     /// `.await` and its `Drop`-based guard cleanup requires synchronous locking.
     bucket_revalidation_active: Arc<parking_lot::Mutex<HashSet<usize>>>,
+    /// Semaphore for limiting concurrent background maintenance lookups.
+    ///
+    /// Foreground/payment/user lookup calls do not use this semaphore.
+    maintenance_lookup_semaphore: Arc<Semaphore>,
     /// Shutdown token for background tasks
     shutdown: CancellationToken,
     /// Handle for the network event handler task
@@ -1321,6 +1346,9 @@ impl DhtNetworkManager {
             message_handler_semaphore,
             revalidation_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_REVALIDATIONS)),
             bucket_revalidation_active: Arc::new(parking_lot::Mutex::new(HashSet::new())),
+            maintenance_lookup_semaphore: Arc::new(Semaphore::new(
+                MAX_CONCURRENT_MAINTENANCE_LOOKUPS,
+            )),
             shutdown: CancellationToken::new(),
             event_handler_handle: Arc::new(RwLock::new(None)),
             self_lookup_handle: Arc::new(RwLock::new(None)),
@@ -1451,8 +1479,17 @@ impl DhtNetworkManager {
                 tokio::select! {
                     () = shutdown.cancelled() => break,
                     _ = async {
-                        if let Err(e) = this.trigger_self_lookup().await {
-                            warn!("Periodic self-lookup failed: {e}");
+                        match Arc::clone(&this.maintenance_lookup_semaphore).try_acquire_owned() {
+                            Ok(_maintenance_lookup_permit) => {
+                                if let Err(e) = this.trigger_self_lookup().await {
+                                    warn!("Periodic self-lookup failed: {e}");
+                                }
+                            }
+                            Err(_) => {
+                                debug!(
+                                    "Periodic self-lookup skipped: maintenance lookup already running"
+                                );
+                            }
                         }
                         this.revalidate_stale_k_closest().await;
                         this.maybe_rebootstrap().await;
@@ -1493,22 +1530,39 @@ impl DhtNetworkManager {
                 tokio::select! {
                     () = shutdown.cancelled() => break,
                     _ = async {
-                        let stale_indices = this
+                        let stale_candidates = this
                             .dht
                             .read()
                             .await
-                            .stale_bucket_indices(STALE_BUCKET_THRESHOLD)
+                            .stale_bucket_refresh_candidates(STALE_BUCKET_THRESHOLD)
                             .await;
 
-                        if stale_indices.is_empty() {
+                        if stale_candidates.is_empty() {
                             trace!("Bucket refresh: no stale buckets");
                             return;
                         }
 
-                        debug!("Bucket refresh: {} stale buckets", stale_indices.len());
+                        let stale_count = stale_candidates.len();
+                        let refresh_indices = Self::select_bucket_refresh_indices(stale_candidates);
+                        let refresh_count = refresh_indices.len();
+                        debug!(
+                            "Bucket refresh: {stale_count} stale buckets, refreshing {refresh_count}"
+                        );
+
+                        let Ok(_maintenance_lookup_permit) = Arc::clone(
+                            &this.maintenance_lookup_semaphore,
+                        )
+                        .try_acquire_owned()
+                        else {
+                            debug!(
+                                "Bucket refresh skipped: maintenance lookup already running"
+                            );
+                            return;
+                        };
+
                         let k = this.k_value();
 
-                        for bucket_idx in stale_indices {
+                        for bucket_idx in refresh_indices {
                             if shutdown_ref.is_cancelled() {
                                 break;
                             }
@@ -1517,11 +1571,18 @@ impl DhtNetworkManager {
                                 dht.generate_random_key_for_bucket(bucket_idx)
                             };
                             let Some(key) = random_key else {
+                                let dht = this.dht.read().await;
+                                dht.mark_bucket_probe_finished(bucket_idx).await;
                                 continue;
                             };
 
                             let key_bytes: Key = *key.as_bytes();
-                            match this.find_closest_nodes_network(&key_bytes, k).await {
+                            let lookup_result = this.find_closest_nodes_network(&key_bytes, k).await;
+                            {
+                                let dht = this.dht.read().await;
+                                dht.mark_bucket_probe_finished(bucket_idx).await;
+                            }
+                            match lookup_result {
                                 Ok(nodes) => {
                                     trace!(
                                         "Bucket refresh[{bucket_idx}]: discovered {} peers",
@@ -1645,6 +1706,35 @@ impl DhtNetworkManager {
         ]);
         let jitter = Duration::from_secs(random_value % (range_secs + 1));
         min + jitter
+    }
+
+    fn select_bucket_refresh_indices(candidates: Vec<BucketRefreshCandidate>) -> Vec<usize> {
+        let jitter_bound_millis = BUCKET_REFRESH_SELECTION_JITTER.as_millis() as u64;
+        let mut rng = rand::thread_rng();
+        let mut scored: Vec<(u128, u128, u128, usize)> = candidates
+            .into_iter()
+            .map(|candidate| {
+                let jitter = if jitter_bound_millis == 0 {
+                    0
+                } else {
+                    rng.gen_range(0..=jitter_bound_millis) as u128
+                };
+                (
+                    candidate.refresh_debt.as_millis().saturating_add(jitter),
+                    candidate.live_peer_age.as_millis(),
+                    candidate.probe_age.as_millis(),
+                    candidate.index,
+                )
+            })
+            .collect();
+        scored.sort_by(|a, b| {
+            b.0.cmp(&a.0)
+                .then_with(|| b.1.cmp(&a.1))
+                .then_with(|| b.2.cmp(&a.2))
+                .then_with(|| a.3.cmp(&b.3))
+        });
+        scored.truncate(MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS);
+        scored.into_iter().map(|(_, _, _, index)| index).collect()
     }
 
     /// Perform DHT peer discovery from already-connected bootstrap peers.
@@ -4769,6 +4859,42 @@ mod tests {
             STALE_REVALIDATION_BUDGET,
             IDENTITY_EXCHANGE_TIMEOUT + STALE_REVALIDATION_PING_RTT,
         );
+    }
+
+    fn bucket_refresh_candidate(index: usize, refresh_debt_secs: u64) -> BucketRefreshCandidate {
+        let refresh_debt = Duration::from_secs(refresh_debt_secs);
+        BucketRefreshCandidate {
+            index,
+            refresh_debt,
+            live_peer_age: refresh_debt + STALE_BUCKET_THRESHOLD,
+            probe_age: refresh_debt,
+        }
+    }
+
+    #[test]
+    fn bucket_refresh_selection_keeps_all_stale_buckets_within_budget() {
+        let candidates: Vec<_> = (0..MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS - 1)
+            .map(|idx| bucket_refresh_candidate(idx, 3_600 + idx as u64))
+            .collect();
+        let mut selected = DhtNetworkManager::select_bucket_refresh_indices(candidates);
+        selected.sort_unstable();
+
+        assert_eq!(
+            selected,
+            (0..MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS - 1).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn bucket_refresh_selection_caps_large_stale_sets_by_debt() {
+        let candidates: Vec<_> = (0..MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS * 3)
+            .map(|idx| bucket_refresh_candidate(idx, (idx as u64) * 3_600))
+            .collect();
+        let mut selected = DhtNetworkManager::select_bucket_refresh_indices(candidates);
+        selected.sort_unstable();
+
+        assert_eq!(selected.len(), MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS);
+        assert_eq!(selected, vec![8, 9, 10, 11]);
     }
 
     #[test]

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -1529,75 +1529,69 @@ impl DhtNetworkManager {
                 tokio::select! {
                     () = shutdown.cancelled() => break,
                     _ = async {
-                        let refresh_candidates = this
-                            .dht
-                            .read()
-                            .await
-                            .bucket_refresh_candidates()
-                            .await;
+                        match Arc::clone(&this.maintenance_lookup_semaphore).try_acquire_owned() {
+                            Ok(_maintenance_lookup_permit) => {
+                                let refresh_candidates = this
+                                    .dht
+                                    .read()
+                                    .await
+                                    .bucket_refresh_candidates()
+                                    .await;
 
-                        if refresh_candidates.is_empty() {
-                            trace!("Bucket refresh: no refresh candidates");
-                            return;
-                        }
+                                let candidate_count = refresh_candidates.len();
+                                let refresh_indices =
+                                    Self::select_bucket_refresh_indices(refresh_candidates);
+                                let refresh_count = refresh_indices.len();
+                                debug!(
+                                    "Bucket refresh: {candidate_count} candidate buckets, refreshing {refresh_count}"
+                                );
 
-                        let candidate_count = refresh_candidates.len();
-                        let refresh_indices = Self::select_bucket_refresh_indices(refresh_candidates);
-                        let refresh_count = refresh_indices.len();
-                        debug!(
-                            "Bucket refresh: {candidate_count} candidate buckets, refreshing {refresh_count}"
-                        );
+                                let k = this.k_value();
 
-                        let Ok(_maintenance_lookup_permit) = Arc::clone(
-                            &this.maintenance_lookup_semaphore,
-                        )
-                        .try_acquire_owned()
-                        else {
-                            debug!(
-                                "Bucket refresh skipped: maintenance lookup already running"
-                            );
-                            return;
-                        };
+                                for bucket_idx in refresh_indices {
+                                    if shutdown_ref.is_cancelled() {
+                                        break;
+                                    }
+                                    let random_key = {
+                                        let dht = this.dht.read().await;
+                                        dht.generate_random_key_for_bucket(bucket_idx)
+                                    };
+                                    let Some(key) = random_key else {
+                                        this.mark_bucket_probe_finished(bucket_idx).await;
+                                        continue;
+                                    };
 
-                        let k = this.k_value();
-
-                        for bucket_idx in refresh_indices {
-                            if shutdown_ref.is_cancelled() {
-                                break;
-                            }
-                            let random_key = {
-                                let dht = this.dht.read().await;
-                                dht.generate_random_key_for_bucket(bucket_idx)
-                            };
-                            let Some(key) = random_key else {
-                                let dht = this.dht.read().await;
-                                dht.mark_bucket_probe_finished(bucket_idx).await;
-                                continue;
-                            };
-
-                            let key_bytes: Key = *key.as_bytes();
-                            let lookup_result = this.find_closest_nodes_network(&key_bytes, k).await;
-                            {
-                                let dht = this.dht.read().await;
-                                dht.mark_bucket_probe_finished(bucket_idx).await;
-                            }
-                            match lookup_result {
-                                Ok(nodes) => {
-                                    trace!(
-                                        "Bucket refresh[{bucket_idx}]: discovered {} peers",
-                                        nodes.len()
-                                    );
-                                    for dht_node in nodes {
-                                        if dht_node.peer_id == this.config.peer_id {
-                                            continue;
+                                    let key_bytes: Key = *key.as_bytes();
+                                    let lookup_result =
+                                        this.find_closest_nodes_network(&key_bytes, k).await;
+                                    this.mark_bucket_probe_finished(bucket_idx).await;
+                                    match lookup_result {
+                                        Ok(nodes) => {
+                                            trace!(
+                                                "Bucket refresh[{bucket_idx}]: discovered {} peers",
+                                                nodes.len()
+                                            );
+                                            for dht_node in nodes {
+                                                if dht_node.peer_id == this.config.peer_id {
+                                                    continue;
+                                                }
+                                                this.dial_addresses(
+                                                    &dht_node.peer_id,
+                                                    &dht_node.typed_addresses(),
+                                                )
+                                                .await;
+                                            }
                                         }
-                                        this.dial_addresses(&dht_node.peer_id, &dht_node.typed_addresses())
-                                            .await;
+                                        Err(e) => {
+                                            debug!("Bucket refresh[{bucket_idx}] lookup failed: {e}");
+                                        }
                                     }
                                 }
-                                Err(e) => {
-                                    debug!("Bucket refresh[{bucket_idx}] lookup failed: {e}");
-                                }
+                            }
+                            Err(_) => {
+                                debug!(
+                                    "Bucket refresh skipped: maintenance lookup already running"
+                                );
                             }
                         }
 
@@ -1607,6 +1601,18 @@ impl DhtNetworkManager {
             }
         });
         *handle_slot.write().await = Some(handle);
+    }
+
+    async fn mark_bucket_probe_finished(&self, bucket_idx: usize) {
+        let marked = {
+            let dht = self.dht.read().await;
+            dht.mark_bucket_probe_finished(bucket_idx).await
+        };
+        if !marked {
+            warn!(
+                "Bucket refresh[{bucket_idx}]: probe-finished mark skipped for out-of-range bucket"
+            );
+        }
     }
 
     /// Trigger an immediate self-lookup to refresh the close neighborhood.
@@ -4875,7 +4881,12 @@ mod tests {
 
     #[test]
     fn bucket_refresh_selection_keeps_all_stale_buckets_within_budget() {
-        let candidates: Vec<_> = (0..MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS - 1)
+        assert!(
+            MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS > 0,
+            "bucket refresh budget must allow at least one lookup"
+        );
+
+        let candidates: Vec<_> = (0..MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS)
             .map(|idx| bucket_refresh_candidate(idx, 3_600 + idx as u64))
             .collect();
         let mut selected = DhtNetworkManager::select_bucket_refresh_indices(candidates);
@@ -4883,20 +4894,29 @@ mod tests {
 
         assert_eq!(
             selected,
-            (0..MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS - 1).collect::<Vec<_>>()
+            (0..MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS).collect::<Vec<_>>()
         );
     }
 
     #[test]
     fn bucket_refresh_selection_caps_large_stale_sets_by_debt() {
-        let candidates: Vec<_> = (0..MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS * 3)
+        assert!(
+            MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS > 0,
+            "bucket refresh budget must allow at least one lookup"
+        );
+
+        let candidate_count = MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS * 3;
+        let candidates: Vec<_> = (0..candidate_count)
             .map(|idx| bucket_refresh_candidate(idx, (idx as u64) * 3_600))
             .collect();
         let mut selected = DhtNetworkManager::select_bucket_refresh_indices(candidates);
         selected.sort_unstable();
 
+        let expected_start = candidate_count - MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS;
+        let expected: Vec<_> = (expected_start..candidate_count).collect();
+
         assert_eq!(selected.len(), MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS);
-        assert_eq!(selected, vec![4, 5]);
+        assert_eq!(selected, expected);
     }
 
     #[test]

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -174,13 +174,14 @@ const BUCKET_REFRESH_INTERVAL_MAX: Duration = Duration::from_secs(750); // 12.5 
 /// full-table maintenance cadence while keeping background lookup pressure low.
 const MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS: usize = 2;
 
-/// Maximum concurrent maintenance lookups.
+/// Maximum concurrent bucket-refresh lookups.
 ///
-/// This is intentionally scoped to background maintenance so foreground/user
-/// lookup behaviour remains unchanged. Automatic re-bootstrap is intentionally
-/// exempt: it is gated separately by [`REBOOTSTRAP_COOLDOWN`] and only runs
-/// when the routing table has fallen below [`AUTO_REBOOTSTRAP_THRESHOLD`].
-const MAX_CONCURRENT_MAINTENANCE_LOOKUPS: usize = 1;
+/// This is intentionally scoped to bucket refresh so periodic self-lookup and
+/// foreground/user lookup behaviour remain unchanged. Automatic re-bootstrap is
+/// intentionally exempt: it is gated separately by [`REBOOTSTRAP_COOLDOWN`] and
+/// only runs when the routing table has fallen below
+/// [`AUTO_REBOOTSTRAP_THRESHOLD`].
+const MAX_CONCURRENT_BUCKET_REFRESH_LOOKUPS: usize = 1;
 
 /// Random jitter applied to bucket-refresh debt ordering.
 ///
@@ -677,10 +678,11 @@ pub struct DhtNetworkManager {
     /// Uses `parking_lot::Mutex` (not tokio) because it is never held across
     /// `.await` and its `Drop`-based guard cleanup requires synchronous locking.
     bucket_revalidation_active: Arc<parking_lot::Mutex<HashSet<usize>>>,
-    /// Semaphore for limiting concurrent background maintenance lookups.
+    /// Semaphore for limiting concurrent bucket-refresh lookups.
     ///
-    /// Foreground/payment/user lookup calls do not use this semaphore.
-    maintenance_lookup_semaphore: Arc<Semaphore>,
+    /// Self-lookups and foreground/payment/user lookup calls do not use this
+    /// semaphore.
+    bucket_refresh_lookup_semaphore: Arc<Semaphore>,
     /// Shutdown token for background tasks
     shutdown: CancellationToken,
     /// Handle for the network event handler task
@@ -1345,8 +1347,8 @@ impl DhtNetworkManager {
             message_handler_semaphore,
             revalidation_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_REVALIDATIONS)),
             bucket_revalidation_active: Arc::new(parking_lot::Mutex::new(HashSet::new())),
-            maintenance_lookup_semaphore: Arc::new(Semaphore::new(
-                MAX_CONCURRENT_MAINTENANCE_LOOKUPS,
+            bucket_refresh_lookup_semaphore: Arc::new(Semaphore::new(
+                MAX_CONCURRENT_BUCKET_REFRESH_LOOKUPS,
             )),
             shutdown: CancellationToken::new(),
             event_handler_handle: Arc::new(RwLock::new(None)),
@@ -1478,17 +1480,8 @@ impl DhtNetworkManager {
                 tokio::select! {
                     () = shutdown.cancelled() => break,
                     _ = async {
-                        match Arc::clone(&this.maintenance_lookup_semaphore).try_acquire_owned() {
-                            Ok(_maintenance_lookup_permit) => {
-                                if let Err(e) = this.trigger_self_lookup().await {
-                                    warn!("Periodic self-lookup failed: {e}");
-                                }
-                            }
-                            Err(_) => {
-                                debug!(
-                                    "Periodic self-lookup skipped: maintenance lookup already running"
-                                );
-                            }
+                        if let Err(e) = this.trigger_self_lookup().await {
+                            warn!("Periodic self-lookup failed: {e}");
                         }
                         this.revalidate_stale_k_closest().await;
                         this.maybe_rebootstrap().await;
@@ -1529,7 +1522,8 @@ impl DhtNetworkManager {
                 tokio::select! {
                     () = shutdown.cancelled() => break,
                     _ = async {
-                        match Arc::clone(&this.maintenance_lookup_semaphore).try_acquire_owned() {
+                        match Arc::clone(&this.bucket_refresh_lookup_semaphore).try_acquire_owned()
+                        {
                             Ok(_maintenance_lookup_permit) => {
                                 let refresh_candidates = this
                                     .dht
@@ -1590,7 +1584,7 @@ impl DhtNetworkManager {
                             }
                             Err(_) => {
                                 debug!(
-                                    "Bucket refresh skipped: maintenance lookup already running"
+                                    "Bucket refresh skipped: bucket refresh lookup already running"
                                 );
                             }
                         }
@@ -1651,9 +1645,9 @@ impl DhtNetworkManager {
     ///
     /// Uses currently connected peers as bootstrap seeds. The cooldown prevents
     /// hammering bootstrap nodes during transient network partitions. This is
-    /// deliberately not guarded by `maintenance_lookup_semaphore`: once the
+    /// deliberately not guarded by `bucket_refresh_lookup_semaphore`: once the
     /// routing table is below the recovery threshold, bootstrap repair should
-    /// not be skipped just because a best-effort maintenance lookup is running.
+    /// not be skipped just because a best-effort bucket refresh is running.
     async fn maybe_rebootstrap(&self) {
         let rt_size = self.get_routing_table_size().await;
         if rt_size >= AUTO_REBOOTSTRAP_THRESHOLD {


### PR DESCRIPTION
## Summary
- serialize maintenance lookups with a maintenance-only semaphore
- cap stale bucket refresh work per pass
- track live-peer freshness separately from probe completion
- select stale bucket refreshes by refresh debt with bounded jitter

## Tests
- cargo fmt
- cargo test bucket_refresh_selection
- cargo test stale_bucket_refresh_candidates
- cargo test marking_bucket_probe_finished
- cargo check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the old single-threshold stale-bucket refresh with a continuous debt-based selection strategy: each bucket now tracks `last_refreshed_by_live_peer` and `last_probe_finished` independently, and a per-pass budget (`MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS = 2`) combined with a new `maintenance_lookup_semaphore` prevents unbounded background lookup bursts.

- **Dual-clock freshness tracking**: splitting the former `last_refreshed` into two timestamps lets the scheduler distinguish live-peer evidence from deliberate probe activity, so a failed/empty probe no longer masks a genuinely stale bucket.
- **Debt-scored selection with jitter**: `select_bucket_refresh_indices` ranks all 256 buckets by `min(live_peer_age, probe_age) + rand(0..60s)`, picks the top 2, and serialises them behind the new `maintenance_lookup_semaphore`, keeping background network pressure predictable.
- **Probe completion stamping**: `mark_bucket_probe_finished` is called after every lookup attempt (including key-generation failures), ensuring debt accounting stays consistent regardless of outcome.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the logic and semaphore wiring are correct and well-tested.

The dual-clock debt model is sound, the semaphore correctly serialises background lookups, and `mark_bucket_probe_finished` is called on all code paths (including key-generation failures). The one flaw is an unreachable `is_empty()` early-return in the refresh task — a leftover from the old threshold-based guard — which has no runtime impact but could mislead future readers.

The dead early-return in `spawn_bucket_refresh_task` in `src/dht_network_manager.rs` is the only thing worth a second look.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dht/core_engine.rs | Splits the single `last_refreshed` timestamp into `last_refreshed_by_live_peer` and `last_probe_finished`, adds `BucketRefreshCandidate` with debt scoring, replaces threshold-based `stale_bucket_indices` with continuous `bucket_refresh_candidates`, and adds `mark_bucket_probe_finished`. All existing tests are updated; four new tests cover the new semantics with robust helpers. |
| src/dht_network_manager.rs | Adds `maintenance_lookup_semaphore` to serialize background lookups, replaces `STALE_BUCKET_THRESHOLD`-based selection with `select_bucket_refresh_indices` (debt + jitter sort, capped at `MAX_BUCKET_REFRESH_LOOKUPS_PER_PASS`), and calls `mark_bucket_probe_finished` after each lookup. Contains one dead-code early-return (`refresh_candidates.is_empty()`) left from the old threshold path. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/dht_network_manager.rs:1539-1544
The `refresh_candidates.is_empty()` guard is now unreachable. `bucket_refresh_candidates()` maps over every bucket in the routing table (always `KADEMLIA_BUCKET_COUNT` = 256 entries) and returns them all unconditionally — the existing test `test_bucket_refresh_candidates_returns_all_buckets_when_fresh` explicitly asserts this invariant. The early-return was meaningful with the old `stale_bucket_indices` path but has no effect here and could mislead future readers about when refresh is actually skipped.

```suggestion
                        let candidate_count = refresh_candidates.len();
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dht): keep bucket refresh tests port..."](https://github.com/saorsa-labs/saorsa-core/commit/851f9a6b0740e9ae75b0d2c6eab192b4e978439b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32679354)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->