### PR TITLE
chore(release): promote rc-2026.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.24.4-rc.1"
+version = "0.24.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1779,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.24.3"
+version = "0.24.4-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3194,9 +3194,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "saorsa-core"
 # 0.22.0: MASQUE relay data plane, upgrade saorsa-transport to 0.31.0
 # 0.24.0: upgrade saorsa-transport to 0.33.0
 # 0.24.1: release candidate fixes
-version = "0.24.4-rc.1"
+version = "0.24.4"
 edition = "2024"
 authors = ["Saorsa Labs Limited <david@saorsalabs.com>"]
 license = "AGPL-3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "saorsa-core"
 # 0.22.0: MASQUE relay data plane, upgrade saorsa-transport to 0.31.0
 # 0.24.0: upgrade saorsa-transport to 0.33.0
 # 0.24.1: release candidate fixes
-version = "0.24.3"
+version = "0.24.4-rc.1"
 edition = "2024"
 authors = ["Saorsa Labs Limited <david@saorsalabs.com>"]
 license = "AGPL-3.0"


### PR DESCRIPTION
Promotes `rc-2026.5.3` to release version(s): 0.24.4.

- strips `-rc.*` from `[package].version`
- rewrites internal git+branch deps to crates.io version pins
- regenerates `Cargo.lock`

Once merged, the release tag will be pushed to fire the publish workflow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release PR promotes the `rc-2026.5.3` release candidate to the stable `0.24.4` version by bumping the crate version in `Cargo.toml` and regenerating `Cargo.lock`.

- `Cargo.toml`: version advanced from `0.24.3` → `0.24.4`; all dependencies remain as crates.io version pins with no structural changes.
- `Cargo.lock`: updated checksums for `saorsa-core` itself plus five transitive/direct-dependency patch upgrades (`asn1-rs` 0.7.2, `dashmap` 6.2.1, `either` 1.16.0, `num-conv` 0.2.2, `tower-http` 0.6.11).

<h3>Confidence Score: 5/5</h3>

This is a straightforward release promotion — the only change is a version bump from 0.24.3 to 0.24.4 and a regenerated lock file; no logic was modified.

The diff touches only the crate version string and the auto-generated lock file. All transitive dependency bumps are minor patch releases. No source code was changed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Version bumped from 0.24.3 to 0.24.4; all dependencies remain version-pinned to crates.io; no structural changes. |
| Cargo.lock | Lock file regenerated: saorsa-core 0.24.3→0.24.4, plus transitive bumps for asn1-rs, dashmap, either, num-conv, and tower-http — all minor patch releases with updated checksums. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): promote rc-2026.5.3 to 0..."](https://github.com/saorsa-labs/saorsa-core/commit/b0e7f48a868ad5dba6c04c921853444c1d996003) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33116453)</sub>

<!-- /greptile_comment -->