### PR TITLE
fix: rank close-group/candidate selection by reachability

### DIFF
--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -1301,7 +1301,14 @@ fn apply_lookup_report_winners(
     }
 
     let mut refreshed: Vec<DHTNode> = by_peer.into_values().collect();
-    refreshed.sort_by(|a, b| DhtNetworkManager::compare_node_distance(a, b, key));
+    // Fix E: final re-rank of the converged candidate pool by
+    // (reachability_tier, xor_distance) so directly-reachable peers lead the
+    // result. This is the sole final-ordering chokepoint for the network path
+    // (the Merkle candidate pool and the client's find_closest_peers), so the
+    // re-rank applies to the returned order without touching the iterative
+    // convergence or the dial-failure skip. Re-rank only — truncation is
+    // unchanged, so the result can never drop below `count`.
+    refreshed.sort_by(|a, b| DhtNetworkManager::compare_node_reachability_then_distance(a, b, key));
     refreshed.truncate(count);
     refreshed
 }
@@ -1961,22 +1968,52 @@ impl DhtNetworkManager {
             hex::encode(key)
         );
 
+        // Over-fetch so the reachability re-rank below has material to demote
+        // with: an XOR-closer relay-only peer can be displaced by a slightly
+        // farther directly-reachable one only if the latter is in the fetched
+        // set. The routing table is scanned per bucket regardless, so a 2x
+        // over-fetch is cheap.
+        let overfetch = count.saturating_mul(2);
+
         let dht_guard = self.dht.read().await;
         match dht_guard
-            .find_nodes_with_publish_seq(&DhtKey::from_bytes(*key), count)
+            .find_nodes_with_publish_seq(&DhtKey::from_bytes(*key), overfetch)
             .await
         {
-            Ok(nodes) => nodes
-                .into_iter()
-                .filter(|(node, _)| !self.is_local_peer_id(&node.id))
-                .map(|(node, publish_seq)| DHTNode {
-                    peer_id: node.id,
-                    address_types: node.address_types,
-                    addresses: node.addresses,
-                    distance: encode_publish_seq_distance(publish_seq),
-                    reliability: SELF_RELIABILITY_SCORE,
-                })
-                .collect(),
+            Ok(nodes) => {
+                let mut nodes: Vec<DHTNode> = nodes
+                    .into_iter()
+                    .filter(|(node, _)| !self.is_local_peer_id(&node.id))
+                    .map(|(node, publish_seq)| {
+                        // Fix E: stamp the real trust score instead of a
+                        // hardcoded constant so downstream consumers (ant-node
+                        // replication/payment) see a meaningful reliability.
+                        // Never-failed peers sit at DEFAULT_NEUTRAL_TRUST, so
+                        // reachability tier (below) is the primary signal and
+                        // trust is only a future tiebreaker.
+                        let reliability = self
+                            .trust_engine
+                            .as_ref()
+                            .map(|engine| engine.score(&node.id))
+                            .unwrap_or(DEFAULT_NEUTRAL_TRUST);
+                        DHTNode {
+                            peer_id: node.id,
+                            address_types: node.address_types,
+                            addresses: node.addresses,
+                            distance: encode_publish_seq_distance(publish_seq),
+                            reliability,
+                        }
+                    })
+                    .collect();
+
+                // Re-rank by (reachability_tier, xor_distance) and truncate
+                // back to `count`. Re-rank only, never filter: this can never
+                // return fewer than `count` reachable-or-not peers, keeping the
+                // close-group selection sparse-network-safe.
+                nodes.sort_by(|a, b| Self::compare_node_reachability_then_distance(a, b, key));
+                nodes.truncate(count);
+                nodes
+            }
             Err(e) => {
                 warn!("find_nodes failed for key {}: {e}", hex::encode(key));
                 Vec::new()
@@ -1993,7 +2030,8 @@ impl DhtNetworkManager {
     /// `IsResponsible(self, K)` by checking whether self appears in the
     /// top-N results.
     ///
-    /// Results are sorted by XOR distance to the key and truncated to `count`.
+    /// Results are sorted by `(reachability_tier, XOR distance)` to the key —
+    /// directly-reachable peers first — and truncated to `count`.
     pub async fn find_closest_nodes_local_with_self(
         &self,
         key: &Key,
@@ -2005,12 +2043,10 @@ impl DhtNetworkManager {
 
         nodes.push(self.local_dht_node().await);
 
-        let key_peer = PeerId::from_bytes(*key);
-        nodes.sort_by(|a, b| {
-            let da = a.peer_id.xor_distance(&key_peer);
-            let db = b.peer_id.xor_distance(&key_peer);
-            da.cmp(&db)
-        });
+        // Same reachability-aware ordering as find_closest_nodes_local: prefer
+        // directly-reachable peers, XOR distance as tiebreaker. Self competes
+        // on the same terms and may displace the farthest peer.
+        nodes.sort_by(|a, b| Self::compare_node_reachability_then_distance(a, b, key));
         nodes.truncate(count);
         nodes
     }
@@ -2446,6 +2482,33 @@ impl DhtNetworkManager {
         a.peer_id
             .distance(&target_key)
             .cmp(&b.peer_id.distance(&target_key))
+    }
+
+    /// Reachability tier for selection ranking: `0` when the node exposes a
+    /// directly-dialable address, `1` when it is relay-only / NAT-stuck (no
+    /// `Direct` address). Used as the primary sort key so a directly-reachable
+    /// peer is preferred over an XOR-equal unreachable one (Fix E).
+    ///
+    /// Keyed on the *absence* of a `Direct` address, not on the presence of a
+    /// `Relay` address — a peer that advertises both stays tier `0`. This is a
+    /// re-ranking signal only; it is never used to filter peers out, so it can
+    /// never shrink a close group below the requested `count`.
+    fn reachability_tier(node: &DHTNode) -> u8 {
+        u8::from(Self::first_direct_dialable(node).is_none())
+    }
+
+    /// Order nodes by `(reachability_tier, xor_distance)`: directly-reachable
+    /// peers first, then by XOR distance to `key` within each tier. The XOR
+    /// tiebreaker reuses [`Self::compare_node_distance`], keeping ordering
+    /// deterministic for equal tiers (stable, no churn).
+    fn compare_node_reachability_then_distance(
+        a: &DHTNode,
+        b: &DHTNode,
+        key: &Key,
+    ) -> std::cmp::Ordering {
+        Self::reachability_tier(a)
+            .cmp(&Self::reachability_tier(b))
+            .then_with(|| Self::compare_node_distance(a, b, key))
     }
 
     /// Drain an iteration's α queries with a bounded wait after first response.
@@ -5533,6 +5596,91 @@ mod tests {
     fn first_direct_dialable_returns_none_when_only_relay() {
         let node = dht_node(1, vec![("/ip4/10.0.0.1/udp/9000/quic", AddressType::Relay)]);
         assert_eq!(DhtNetworkManager::first_direct_dialable(&node), None);
+    }
+
+    // ---- Fix E: reachability-aware selection re-rank ----
+
+    #[test]
+    fn reachability_tier_is_zero_for_direct_one_for_relay_only() {
+        let direct = dht_node(
+            1,
+            vec![("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct)],
+        );
+        let relay_only = dht_node(2, vec![("/ip4/10.0.0.1/udp/9000/quic", AddressType::Relay)]);
+        let empty = DHTNode {
+            peer_id: PeerId::from_bytes([3u8; 32]),
+            addresses: vec![],
+            address_types: vec![],
+            distance: None,
+            reliability: 1.0,
+        };
+
+        assert_eq!(DhtNetworkManager::reachability_tier(&direct), 0);
+        assert_eq!(DhtNetworkManager::reachability_tier(&relay_only), 1);
+        assert_eq!(DhtNetworkManager::reachability_tier(&empty), 1);
+    }
+
+    #[test]
+    fn reachability_tier_zero_when_node_has_both_relay_and_direct() {
+        // A peer advertising both a relay and a direct address is still
+        // directly reachable — tier keyed on absence of Direct, not presence
+        // of Relay.
+        let node = dht_node(
+            1,
+            vec![
+                ("/ip4/10.0.0.1/udp/9000/quic", AddressType::Relay),
+                ("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct),
+            ],
+        );
+        assert_eq!(DhtNetworkManager::reachability_tier(&node), 0);
+    }
+
+    #[test]
+    fn reachability_rerank_prefers_direct_over_xor_closer_relay_only() {
+        // With key = [0; 32], xor_distance == peer_id, so the lower seed is the
+        // XOR-closer peer. The relay-only peer (seed 1) is XOR-closer; the
+        // direct peer (seed 2) is farther. Reachability tier must win: the
+        // direct peer is ranked first despite the larger XOR distance.
+        let key: Key = [0u8; 32];
+        let relay_closer = dht_node(1, vec![("/ip4/10.0.0.1/udp/9000/quic", AddressType::Relay)]);
+        let direct_farther = dht_node(
+            2,
+            vec![("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct)],
+        );
+
+        let mut nodes = [relay_closer, direct_farther];
+        nodes
+            .sort_by(|a, b| DhtNetworkManager::compare_node_reachability_then_distance(a, b, &key));
+
+        assert_eq!(nodes.len(), 2, "re-rank must never drop peers");
+        assert_eq!(
+            nodes[0].peer_id,
+            PeerId::from_bytes([2u8; 32]),
+            "directly-reachable peer must rank first even though it is XOR-farther"
+        );
+        assert_eq!(nodes[1].peer_id, PeerId::from_bytes([1u8; 32]));
+    }
+
+    #[test]
+    fn reachability_rerank_sparse_all_relay_only_keeps_count_in_xor_order() {
+        // Sparse-network safety: when every candidate is relay-only they all
+        // share tier 1, so ordering falls back to XOR distance and truncation
+        // still yields `count` members — selection never shrinks below `count`.
+        let key: Key = [0u8; 32];
+        let mut nodes = vec![
+            dht_node(3, vec![("/ip4/10.0.0.3/udp/9000/quic", AddressType::Relay)]),
+            dht_node(1, vec![("/ip4/10.0.0.1/udp/9000/quic", AddressType::Relay)]),
+            dht_node(2, vec![("/ip4/10.0.0.2/udp/9000/quic", AddressType::Relay)]),
+        ];
+        nodes
+            .sort_by(|a, b| DhtNetworkManager::compare_node_reachability_then_distance(a, b, &key));
+
+        let count = 2;
+        nodes.truncate(count);
+
+        assert_eq!(nodes.len(), count, "sparse selection must still fill count");
+        assert_eq!(nodes[0].peer_id, PeerId::from_bytes([1u8; 32]));
+        assert_eq!(nodes[1].peer_id, PeerId::from_bytes([2u8; 32]));
     }
 
     #[test]

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -2021,6 +2021,76 @@ impl DhtNetworkManager {
         }
     }
 
+    /// Find closest nodes to a key using the local routing table, ordered by
+    /// **XOR distance only** (no reachability re-rank).
+    ///
+    /// This is the distance-pure counterpart to [`find_closest_nodes_local`].
+    /// The two exist because the routing table serves two consumers with
+    /// opposite ordering needs:
+    ///
+    /// - **Close-group / candidate *selection* for storage** (the majority of
+    ///   callers) benefits from the `(reachability_tier, xor_distance)`
+    ///   re-rank in [`find_closest_nodes_local`]: a directly-reachable peer is
+    ///   a better place to put data than an XOR-equal relay-only one.
+    /// - **Closeness *verification*** (ant-node's Merkle pay-yourself defence)
+    ///   must instead mirror the *uploader's* view, which is built from a
+    ///   pure XOR-distance network lookup. If the verifier re-ranked by
+    ///   reachability it could demote an XOR-close relay-only peer out of the
+    ///   compared window and falsely reject an honest candidate pool that
+    ///   legitimately contains that peer. Verification therefore needs the raw
+    ///   XOR ordering this method provides.
+    ///
+    /// Like [`find_closest_nodes_local`] this is a pure in-memory routing-table
+    /// read (no network I/O) and excludes the local peer. Reliability is still
+    /// stamped with the real trust score so consumers see a meaningful value;
+    /// only the *ordering* differs.
+    pub async fn find_closest_nodes_local_by_distance(
+        &self,
+        key: &Key,
+        count: usize,
+    ) -> Vec<DHTNode> {
+        debug!(
+            "[LOCAL] Finding {} closest nodes (XOR-only) to key: {}",
+            count,
+            hex::encode(key)
+        );
+
+        let dht_guard = self.dht.read().await;
+        match dht_guard
+            .find_nodes_with_publish_seq(&DhtKey::from_bytes(*key), count)
+            .await
+        {
+            // `find_nodes_with_publish_seq` already returns peers in ascending
+            // XOR-distance order; we keep that order intact — no re-rank, no
+            // truncation beyond what the routing table returned.
+            Ok(nodes) => nodes
+                .into_iter()
+                .filter(|(node, _)| !self.is_local_peer_id(&node.id))
+                .map(|(node, publish_seq)| {
+                    let reliability = self
+                        .trust_engine
+                        .as_ref()
+                        .map(|engine| engine.score(&node.id))
+                        .unwrap_or(DEFAULT_NEUTRAL_TRUST);
+                    DHTNode {
+                        peer_id: node.id,
+                        address_types: node.address_types,
+                        addresses: node.addresses,
+                        distance: encode_publish_seq_distance(publish_seq),
+                        reliability,
+                    }
+                })
+                .collect(),
+            Err(e) => {
+                warn!(
+                    "find_nodes (XOR-only) failed for key {}: {e}",
+                    hex::encode(key)
+                );
+                Vec::new()
+            }
+        }
+    }
+
     /// Find closest nodes to a key using the local routing table, including
     /// the local node itself in the candidate set.
     ///

--- a/tests/two_node_messaging.rs
+++ b/tests/two_node_messaging.rs
@@ -19,7 +19,7 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use saorsa_core::{NodeConfig, P2PEvent, P2PNode, PeerId, TrustEvent};
+use saorsa_core::{Key, NodeConfig, P2PEvent, P2PNode, PeerId, TrustEvent};
 use std::time::Duration;
 use tokio::time::timeout;
 
@@ -276,6 +276,50 @@ async fn peer_count_reflects_connections() {
     assert!(
         node_a.peer_count().await >= 1,
         "node_a should have at least 1 peer after connecting"
+    );
+
+    node_a.stop().await.unwrap();
+    node_b.stop().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Reliability stamping (Fix E.2)
+// ---------------------------------------------------------------------------
+
+/// `find_closest_nodes_local` stamps the real trust score, not the old
+/// hardcoded `1.0`. A freshly-discovered peer that has never failed sits at the
+/// trust engine's neutral default (`DEFAULT_NEUTRAL_TRUST = 0.5`).
+#[tokio::test]
+async fn local_selection_stamps_neutral_trust_not_hardcoded_one() {
+    // `DEFAULT_NEUTRAL_TRUST` lives in a pub(crate) module, so it cannot be
+    // imported here; mirror its value with a comment instead.
+    const NEUTRAL_TRUST: f64 = 0.5;
+
+    let (node_a, node_b, peer_b) = connected_pair().await;
+
+    // Query closest to node_b's own ID so node_b (XOR distance 0) is returned
+    // once it lands in node_a's routing table. Poll briefly: identity exchange
+    // completing does not instantly guarantee a routing-table entry.
+    let key: Key = *peer_b.as_bytes();
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let node_b_entry = loop {
+        let nodes = node_a.dht_manager().find_closest_nodes_local(&key, 8).await;
+        if let Some(entry) = nodes.into_iter().find(|n| n.peer_id == peer_b) {
+            break Some(entry);
+        }
+        if std::time::Instant::now() >= deadline {
+            break None;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+
+    let node_b_entry =
+        node_b_entry.expect("node_b should appear in node_a's local selection after connecting");
+
+    assert!(
+        (node_b_entry.reliability - NEUTRAL_TRUST).abs() < 1e-9,
+        "expected neutral trust {NEUTRAL_TRUST}, got {} (the old hardcoded path returned 1.0)",
+        node_b_entry.reliability
     );
 
     node_a.stop().await.unwrap();

--- a/tests/two_node_messaging.rs
+++ b/tests/two_node_messaging.rs
@@ -325,3 +325,60 @@ async fn local_selection_stamps_neutral_trust_not_hardcoded_one() {
     node_a.stop().await.unwrap();
     node_b.stop().await.unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// XOR-only local lookup (closeness-verification path)
+// ---------------------------------------------------------------------------
+
+/// `find_closest_nodes_local_by_distance` is the distance-pure counterpart to
+/// `find_closest_nodes_local`, used by the Merkle closeness-verification path so
+/// it mirrors the uploader's XOR-only view rather than the reachability re-rank.
+///
+/// This is a wiring/contract smoke test: it confirms the XOR-only path returns
+/// the connected peer, excludes self, and stamps the real (neutral) trust score
+/// like its reranked sibling. The XOR-vs-reachability *ordering* divergence is
+/// covered by the `compare_node_reachability_then_distance` unit tests — this
+/// function's whole point is that it never invokes that comparator.
+#[tokio::test]
+async fn local_by_distance_returns_peer_and_stamps_neutral_trust() {
+    const NEUTRAL_TRUST: f64 = 0.5;
+
+    let (node_a, node_b, peer_b) = connected_pair().await;
+
+    // Query closest to node_b's own ID, mirroring the reranked-path test above.
+    let key: Key = *peer_b.as_bytes();
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let nodes = loop {
+        let nodes = node_a
+            .dht_manager()
+            .find_closest_nodes_local_by_distance(&key, 8)
+            .await;
+        if nodes.iter().any(|n| n.peer_id == peer_b) {
+            break nodes;
+        }
+        if std::time::Instant::now() >= deadline {
+            break nodes;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+
+    // Self must never appear in the local selection.
+    assert!(
+        !nodes.iter().any(|n| &n.peer_id == node_a.peer_id()),
+        "XOR-only local lookup must exclude the local peer"
+    );
+
+    let node_b_entry = nodes
+        .into_iter()
+        .find(|n| n.peer_id == peer_b)
+        .expect("node_b should appear in node_a's XOR-only local selection after connecting");
+
+    assert!(
+        (node_b_entry.reliability - NEUTRAL_TRUST).abs() < 1e-9,
+        "expected neutral trust {NEUTRAL_TRUST}, got {}",
+        node_b_entry.reliability
+    );
+
+    node_a.stop().await.unwrap();
+    node_b.stop().await.unwrap();
+}


### PR DESCRIPTION
## Summary

Close-group (7 XOR-closest) and Merkle candidate-pool (16 XOR-closest) selection ranked purely by XOR distance, ignoring whether a peer is actually reachable. An unreachable / relay-only / NAT-stuck peer that happened to be XOR-close was picked, then failed — costing a store slot and skewing closeness lookups. This ranks by `(reachability_tier, xor_distance)` so a directly-reachable peer is preferred over an XOR-equal unreachable one.

**Re-rank only, never filter:** every path over-fetches, stable-sorts, then truncates, so a group can never shrink below `count` (sparse-network-safe). Tier keys on the *absence* of a `Direct` address, so a peer advertising both relay and direct stays tier 0. No wire-format or public-API change.

- **E.1** `find_closest_nodes_local`: over-fetch 2×, re-rank by `(reachability_tier, xor_distance)`, truncate; `find_closest_nodes_local_with_self` reuses the same comparator.
- **E.2** Stamp `DHTNode.reliability` from `trust_engine.score()` instead of the hardcoded `1.0` placeholder, so ant-node consumers (replication, payment) see a real signal. Mirrors the existing `routing_table_peers` pattern.
- **E.3** `apply_lookup_report_winners` (the sole final-ordering chokepoint for the network/candidate-pool path) re-ranks reachability-first; iterative convergence and the dial-failure skip are left intact.

Out of scope (per Fix E plan): saorsa-transport relay/holepunch work (E.4).

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --lib -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` clean
- [x] `cargo test --lib` — 485 passed, 0 failed
- [x] New unit tests: Direct outranks XOR-closer relay-only; sparse (all relay-only) keeps `count` in XOR order; `reachability_tier` 0/1
- [x] New 2-node integration test (`local_selection_stamps_neutral_trust_not_hardcoded_one`) — passed 3/3 runs; verifies a learned peer's reliability is the neutral trust default, not the old hardcoded 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Re-ranks close-group and Merkle candidate-pool selection by `(reachability_tier, xor_distance)` instead of pure XOR distance, so a directly-reachable peer beats an XOR-closer relay-only peer without ever filtering peers out. Also replaces the hardcoded `reliability: 1.0` placeholder in `find_closest_nodes_local` with the real trust-engine score.

- **E.1/E.3 re-rank**: `find_closest_nodes_local` over-fetches 2× from the routing table, re-ranks, and truncates; `find_closest_nodes_local_with_self` and `apply_lookup_report_winners` adopt the same comparator — all three selection chokepoints now consistently prefer reachable peers.
- **E.2 trust stamping**: `find_closest_nodes_local` now calls `trust_engine.score()` (falling back to `DEFAULT_NEUTRAL_TRUST`) instead of the constant `SELF_RELIABILITY_SCORE`, mirroring the existing `routing_table_peers` pattern; a new 2-node integration test verifies the `0.5` default for freshly-learned peers.

<h3>Confidence Score: 4/5</h3>

The change is a re-rank-only fix with no wire-format or API changes; sparse-network safety is preserved by the over-fetch+truncate pattern.

The logic is straightforward and well-tested: the new comparator is exercised by four targeted unit tests and an integration test. The only gap is a stale doc-comment on find_closest_nodes_local that still describes pure XOR ordering.

src/dht_network_manager.rs — doc-comment on find_closest_nodes_local (line 1963) still describes pure XOR sort order.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/dht_network_manager.rs | Adds reachability-aware (reachability_tier, xor_distance) comparator; applies it in find_closest_nodes_local (with 2× over-fetch), find_closest_nodes_local_with_self, and apply_lookup_report_winners; stamps real trust scores instead of hardcoded 1.0. One stale doc-comment in find_closest_nodes_local (still describes pure XOR sort). |
| tests/two_node_messaging.rs | Adds integration test verifying that a freshly-discovered peer's reliability is stamped as DEFAULT_NEUTRAL_TRUST (0.5) rather than the old hardcoded 1.0. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[find_closest_nodes_local\ncalled with count] --> B[Over-fetch 2×count\nfrom routing table]
    B --> C[Filter out local peer ID]
    C --> D[Stamp reliability:\ntrust_engine.score OR\nDEFAULT_NEUTRAL_TRUST]
    D --> E[sort_by reachability_tier\nthen xor_distance]
    E --> F[truncate to count]
    F --> G[Return ≤count DHTNodes]
    G --> H{find_closest_nodes_local_with_self?}
    H -- Yes --> I[Push local_dht_node\nreliability = 1.0]
    I --> J[sort_by reachability_tier\nthen xor_distance]
    J --> K[truncate to count]
    H -- No --> L[Done]
    K --> L
    M[apply_lookup_report_winners\nnetwork/converged path] --> N[Deduplicate by peer_id\nkeep prefer_lookup_record winner]
    N --> O[sort_by reachability_tier\nthen xor_distance]
    O --> P[truncate to count]
    P --> L
    subgraph reachability_tier
        Q[DHTNode has Direct address?] -- Yes --> R[tier = 0]
        Q -- No --> S[tier = 1]
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/dht_network_manager.rs`, line 1963-1964 ([link](https://github.com/saorsa-labs/saorsa-core/blob/b230e5c81086f1d7d08c84c65fe0044880259517/src/dht_network_manager.rs#L1963-L1964)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The doc-comment for `find_closest_nodes_local` still describes pure XOR-distance ordering, but the new implementation sorts by `(reachability_tier, xor_distance)`. The sibling function `find_closest_nodes_local_with_self` was correctly updated; this one was missed. A caller reading only the doc-comment would assume XOR order and could be surprised by the reachability-based ranking.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/dht_network_manager.rs
   Line: 1963-1964

   Comment:
   The doc-comment for `find_closest_nodes_local` still describes pure XOR-distance ordering, but the new implementation sorts by `(reachability_tier, xor_distance)`. The sibling function `find_closest_nodes_local_with_self` was correctly updated; this one was missed. A caller reading only the doc-comment would assume XOR order and could be surprised by the reachability-based ranking.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/dht_network_manager.rs:1963-1964
The doc-comment for `find_closest_nodes_local` still describes pure XOR-distance ordering, but the new implementation sorts by `(reachability_tier, xor_distance)`. The sibling function `find_closest_nodes_local_with_self` was correctly updated; this one was missed. A caller reading only the doc-comment would assume XOR order and could be surprised by the reachability-based ranking.

```suggestion
    /// Results are sorted by `(reachability_tier, XOR distance)` to the key —
    /// directly-reachable peers first — and truncated to `count`.
    pub async fn find_closest_nodes_local(&self, key: &Key, count: usize) -> Vec<DHTNode> {
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: rank close-group/candidate selectio..."](https://github.com/saorsa-labs/saorsa-core/commit/b230e5c81086f1d7d08c84c65fe0044880259517) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33664595)</sub>

<!-- /greptile_comment -->