### PR TITLE
feat: add XOR-only self-inclusive local lookup for closeness verification

### DIFF
--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -5772,6 +5772,39 @@ mod tests {
     }
 
     #[test]
+    fn by_distance_comparator_keeps_xor_closer_relay_only_ahead_of_direct() {
+        // Complement of `reachability_rerank_prefers_direct_over_xor_closer_relay_only`,
+        // and the property the closeness-verification path relies on: the XOR-only
+        // `compare_node_distance` (used by `find_closest_nodes_local_by_distance`
+        // and `find_closest_nodes_local_by_distance_with_self`) must NOT apply the
+        // reachability re-rank. With key = [0; 32], xor_distance == peer_id, so the
+        // lower seed is XOR-closer. The relay-only peer (seed 1) is XOR-closer and
+        // must therefore rank first even though it is relay-only — mirroring the
+        // uploader's pure-XOR view so an honest payment quoting that peer is not
+        // falsely rejected. (The reranked comparator would put the direct peer first.)
+        let key: Key = [0u8; 32];
+        let relay_closer = dht_node(1, vec![("/ip4/10.0.0.1/udp/9000/quic", AddressType::Relay)]);
+        let direct_farther = dht_node(
+            2,
+            vec![("/ip4/203.0.113.7/udp/9001/quic", AddressType::Direct)],
+        );
+
+        // Start in the opposite order so a passing assertion proves the sort
+        // actually reordered (rather than leaving an already-correct input).
+        let mut nodes = [direct_farther, relay_closer];
+        nodes.sort_by(|a, b| DhtNetworkManager::compare_node_distance(a, b, &key));
+
+        assert_eq!(nodes.len(), 2, "distance sort must never drop peers");
+        assert_eq!(
+            nodes[0].peer_id,
+            PeerId::from_bytes([1u8; 32]),
+            "XOR-only ordering must keep the XOR-closer relay-only peer first, \
+             unlike compare_node_reachability_then_distance"
+        );
+        assert_eq!(nodes[1].peer_id, PeerId::from_bytes([2u8; 32]));
+    }
+
+    #[test]
     fn reachability_rerank_sparse_all_relay_only_keeps_count_in_xor_order() {
         // Sparse-network safety: when every candidate is relay-only they all
         // share tier 1, so ordering falls back to XOR distance and truncation

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -2121,6 +2121,46 @@ impl DhtNetworkManager {
         nodes
     }
 
+    /// XOR-only, self-inclusive variant of
+    /// [`find_closest_nodes_local_by_distance`].
+    ///
+    /// Mirrors [`find_closest_nodes_local_with_self`] — it includes the local
+    /// node in the candidate set so a caller can compute `IsResponsible(self,
+    /// K)` — but orders purely by XOR distance and does **not** prefer
+    /// directly-reachable peers.
+    ///
+    /// Use this for closeness *verification* (the single-node payment
+    /// close-group check, the Merkle candidate-pool check), which must mirror
+    /// the uploader's pure XOR-distance peer selection rather than the
+    /// reachability re-rank used for storage *selection*. The reachability
+    /// re-rank in [`find_closest_nodes_local_with_self`] can demote an
+    /// XOR-close relay-only peer out of the compared window and falsely reject
+    /// an honest payment that legitimately quoted that peer — see
+    /// saorsa-labs/saorsa-core#121, which added the XOR-only
+    /// [`find_closest_nodes_local_by_distance`] for exactly this purpose.
+    ///
+    /// Like the other `_local` lookups this is a pure in-memory routing-table
+    /// read (no network I/O). Self competes on XOR distance and may displace
+    /// the farthest peer.
+    pub async fn find_closest_nodes_local_by_distance_with_self(
+        &self,
+        key: &Key,
+        count: usize,
+    ) -> Vec<DHTNode> {
+        // Fetch the XOR-closest `count` peers (self is excluded by the
+        // underlying lookup), append self, re-sort by pure XOR distance, and
+        // truncate back to `count`. Any peer beyond the closest `count` is
+        // farther than all of them, so adding only self cannot pull it into
+        // the top-`count` — fetching `count` is sufficient.
+        let mut nodes = self.find_closest_nodes_local_by_distance(key, count).await;
+
+        nodes.push(self.local_dht_node().await);
+
+        nodes.sort_by(|a, b| Self::compare_node_distance(a, b, key));
+        nodes.truncate(count);
+        nodes
+    }
+
     /// Find closest nodes to a key using iterative network lookup.
     ///
     /// This implements Kademlia-style iterative lookup:

--- a/tests/two_node_messaging.rs
+++ b/tests/two_node_messaging.rs
@@ -382,3 +382,61 @@ async fn local_by_distance_returns_peer_and_stamps_neutral_trust() {
     node_a.stop().await.unwrap();
     node_b.stop().await.unwrap();
 }
+
+/// `find_closest_nodes_local_by_distance_with_self` is the self-inclusive
+/// counterpart of `find_closest_nodes_local_by_distance`, used by the
+/// single-node payment close-group verification so the storer's view mirrors
+/// the uploader's pure-XOR selection rather than the reachability re-rank.
+///
+/// Wiring/contract smoke test. The distinguishing contract vs `_by_distance` is
+/// that the local node MUST be included (so the storer can satisfy
+/// `IsResponsible(self, K)`); it also returns the connected peer and stamps the
+/// real (neutral) trust score. The XOR-vs-reachability *ordering* divergence is
+/// covered by the `by_distance_comparator_keeps_xor_closer_relay_only_ahead_of_direct`
+/// unit test — this function deliberately sorts with `compare_node_distance`,
+/// never `compare_node_reachability_then_distance`.
+#[tokio::test]
+async fn local_by_distance_with_self_includes_self_and_connected_peer() {
+    const NEUTRAL_TRUST: f64 = 0.5;
+
+    let (node_a, node_b, peer_b) = connected_pair().await;
+
+    // Query closest to node_b's own ID, mirroring the sibling tests above.
+    let key: Key = *peer_b.as_bytes();
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let nodes = loop {
+        let nodes = node_a
+            .dht_manager()
+            .find_closest_nodes_local_by_distance_with_self(&key, 8)
+            .await;
+        if nodes.iter().any(|n| n.peer_id == peer_b) {
+            break nodes;
+        }
+        if std::time::Instant::now() >= deadline {
+            break nodes;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+
+    // The self-inclusive variant MUST include the local peer — this is the
+    // distinguishing contract vs `find_closest_nodes_local_by_distance`, which
+    // excludes self.
+    assert!(
+        nodes.iter().any(|n| &n.peer_id == node_a.peer_id()),
+        "self-inclusive XOR-only lookup must include the local peer"
+    );
+
+    let node_b_entry = nodes
+        .into_iter()
+        .find(|n| n.peer_id == peer_b)
+        .expect("node_b should appear in node_a's self-inclusive XOR-only selection");
+
+    assert!(
+        (node_b_entry.reliability - NEUTRAL_TRUST).abs() < 1e-9,
+        "expected neutral trust {NEUTRAL_TRUST}, got {}",
+        node_b_entry.reliability
+    );
+
+    node_a.stop().await.unwrap();
+    node_b.stop().await.unwrap();
+}


### PR DESCRIPTION
## Summary

`find_closest_nodes_local_with_self` orders by `(reachability_tier, xor_distance)` — directly-reachable peers first. That's the right ranking for storage **selection** (prefer a reachable peer over an XOR-equal unreachable one, per #121), but it's wrong for closeness **verification**.

A verifier that reuses `_with_self` compares the uploader's pure-XOR-distance peer set against a reachability-reranked local view. On a network with a meaningful NAT fraction, the re-rank demotes XOR-close relay-only / NAT'd peers out of the compared window, so honest payments that legitimately quoted those peers get falsely rejected. #121 already shipped the XOR-only `find_closest_nodes_local_by_distance` for exactly this reason — but only the non-self-inclusive variant.

This adds the missing self-inclusive counterpart:

- **`find_closest_nodes_local_by_distance_with_self`** — same pure in-memory routing-table read as `find_closest_nodes_local_with_self`, still appends the local node so callers can compute `IsResponsible(self, K)`, but sorts purely by XOR distance (`compare_node_distance`) with no reachability re-rank.

Fetching the XOR-closest `count` peers and adding only self is sufficient: any peer beyond the closest `count` is farther than all of them, so self cannot pull it into the top-`count`.

## Consumer

ant-node's single-node payment close-group verification switches onto this method (companion PR against `ant-node` `rc-2026.5.4`), mirroring the Merkle closeness path that already uses the XOR-only lookup.

## Test plan

- [x] `cargo check --lib` — clean
- [x] Verified downstream `ant-node` compiles against this method via a local path patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `find_closest_nodes_local_by_distance_with_self`, the self-inclusive, XOR-only counterpart to the existing `find_closest_nodes_local_by_distance`. It fixes a correctness gap in closeness verification: the previous self-inclusive variant (`find_closest_nodes_local_with_self`) applies a reachability re-rank that can demote NAT'd peers out of the comparison window, causing honest payments to be falsely rejected.

- **New method** (`find_closest_nodes_local_by_distance_with_self`): fetches the `count` XOR-closest remote peers, appends the local node, re-sorts by pure XOR distance (`compare_node_distance`), and truncates to `count` — matching the pattern of the existing `_with_self` method but without reachability re-ranking.
- **No new tests**: both sibling methods have dedicated integration tests; the new method has none, leaving the self-inclusion contract and XOR-only ordering unverified at the integration level.

<h3>Confidence Score: 4/5</h3>

The change is a clean, minimal addition that correctly mirrors an already-reviewed pattern; the only gap is missing integration test coverage for the new public method.

The implementation faithfully follows the established _with_self pattern, the count-sufficiency argument holds under all routing-table configurations, and the XOR-only sort comparator is the correct choice for closeness verification. The sole concern is the absence of an integration test: every sibling method has a dedicated test asserting its self-inclusion and ordering contracts, but this new method ships without one.

src/dht_network_manager.rs — specifically the new find_closest_nodes_local_by_distance_with_self method, which lacks a companion integration test in tests/.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dht_network_manager.rs | Adds find_closest_nodes_local_by_distance_with_self: a XOR-only, self-inclusive local lookup that mirrors the existing find_closest_nodes_local_with_self pattern but uses pure XOR ordering instead of reachability re-ranking. Logic and argument for count-sufficiency are sound; no integration test covers the new method. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["find_closest_nodes_local_by_distance_with_self(key, count)"] --> B["find_closest_nodes_local_by_distance(key, count)\n(XOR-only, excludes self)"]
    B --> C["Routing table\nfind_nodes_with_publish_seq(key, count)\n→ XOR-sorted, self filtered"]
    C --> D["Vec≤ count remote peers"]
    D --> E["push(local_dht_node())"]
    E --> F["sort_by compare_node_distance\n(pure XOR, no reachability tier)"]
    F --> G["truncate(count)"]
    G --> H["Vec — XOR-closest count nodes\n(including self if competitive)"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/dht_network_manager.rs:2145-2162
**Missing integration test for the new public API**

Both of the method's siblings have dedicated integration tests: `find_closest_nodes_local_with_self` is covered by `dht_self_advertisement.rs`, and `find_closest_nodes_local_by_distance` is covered by `two_node_messaging.rs::local_by_distance_returns_peer_and_stamps_neutral_trust`. The new `find_closest_nodes_local_by_distance_with_self` has no test at all. At minimum, a two-node smoke test should assert that: (a) the local node IS included in the result, and (b) `Self::compare_node_distance` is used rather than `compare_node_reachability_then_distance` — the whole correctness argument for closeness verification rests on that distinction.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add XOR-only self-inclusive local ..."](https://github.com/saorsa-labs/saorsa-core/commit/346c7073dc6ee84ffb106f6226ee3cad1d8163c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34030895)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->