### PR TITLE
fix(p2p): remove wall-clock timestamp validation from WireMessage

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -1723,16 +1723,6 @@ impl P2PNode {
     }
 }
 
-/// Parse a postcard-encoded protocol message into a `P2PEvent::Message`.
-///
-/// Returns `None` if the bytes cannot be deserialized as a valid `WireMessage`.
-///
-/// The `from` field is a required part of the wire protocol but is **not**
-/// used as the event source. Instead, `source` — the transport-level peer ID
-/// derived from the authenticated QUIC connection — is used so that consumers
-/// can pass it directly to `send_message()`. This eliminates a spoofing
-/// vector where a peer could claim an arbitrary identity via the payload.
-///
 /// Convenience constructor for `P2PError::Network(NetworkError::ProtocolError(...))`.
 fn protocol_error(msg: impl std::fmt::Display) -> P2PError {
     P2PError::Network(NetworkError::ProtocolError(msg.to_string().into()))
@@ -1755,6 +1745,15 @@ pub(crate) struct ParsedMessage {
     pub(crate) user_agent: String,
 }
 
+/// Parse a postcard-encoded protocol message into a `P2PEvent::Message`.
+///
+/// Returns `None` if the bytes cannot be deserialized as a valid `WireMessage`.
+///
+/// The `from` field is a required part of the wire protocol but is **not**
+/// used as the event source. Instead, `source` — the transport-level peer ID
+/// derived from the authenticated QUIC connection — is used so that consumers
+/// can pass it directly to `send_message()`. This eliminates a spoofing
+/// vector where a peer could claim an arbitrary identity via the payload.
 pub(crate) fn parse_protocol_message(bytes: &[u8], source: &str) -> Option<ParsedMessage> {
     let message: WireMessage = postcard::from_bytes(bytes).ok()?;
     let transport_source = source.parse::<SocketAddr>().ok().map(MultiAddr::quic);
@@ -3258,7 +3257,7 @@ mod tests {
             .unwrap_or(0)
     }
 
-    /// Helper to create a postcard-serialized WireMessage for tests
+    /// Helper to create a postcard-serialized unsigned WireMessage for tests
     fn make_wire_bytes(protocol: &str, data: Vec<u8>, from: &str, timestamp: u64) -> Vec<u8> {
         let msg = WireMessage {
             protocol: protocol.to_string(),
@@ -3268,6 +3267,31 @@ mod tests {
             user_agent: String::new(),
             public_key: Vec::new(),
             signature: Vec::new(),
+        };
+        postcard::to_stdvec(&msg).unwrap()
+    }
+
+    /// Helper to create a postcard-serialized signed WireMessage for tests.
+    fn make_signed_wire_bytes(
+        identity: &NodeIdentity,
+        protocol: &str,
+        data: Vec<u8>,
+        timestamp: u64,
+    ) -> Vec<u8> {
+        let from = *identity.peer_id();
+        let user_agent = "test/1.0";
+        let signable =
+            postcard::to_stdvec(&(protocol, data.as_slice(), &from, timestamp, user_agent))
+                .unwrap();
+        let sig = identity.sign(&signable).expect("signing should succeed");
+        let msg = WireMessage {
+            protocol: protocol.to_string(),
+            data,
+            from,
+            timestamp,
+            user_agent: user_agent.to_string(),
+            public_key: identity.public_key().as_bytes().to_vec(),
+            signature: sig.as_bytes().to_vec(),
         };
         postcard::to_stdvec(&msg).unwrap()
     }
@@ -3498,15 +3522,32 @@ mod tests {
         let old_bytes = make_wire_bytes("test/old", payload.clone(), "sender", old_ts);
         assert!(
             parse_protocol_message(&old_bytes, "peer-id").is_some(),
-            "should accept message with timestamp 10h in the past"
+            "should accept unsigned message with timestamp 10h in the past"
         );
 
         // 10 hours in the future
         let future_ts = current_timestamp().saturating_add(36_000);
-        let future_bytes = make_wire_bytes("test/future", payload, "sender", future_ts);
+        let future_bytes = make_wire_bytes("test/future", payload.clone(), "sender", future_ts);
         assert!(
             parse_protocol_message(&future_bytes, "peer-id").is_some(),
-            "should accept message with timestamp 10h in the future"
+            "should accept unsigned message with timestamp 10h in the future"
+        );
+
+        // Signed messages must take the same path: timestamp remains part of the
+        // signed bytes for integrity, but is not used for wall-clock rejection.
+        let identity = NodeIdentity::generate().expect("should generate identity");
+        let signed_old =
+            make_signed_wire_bytes(&identity, "test/signed-old", payload.clone(), old_ts);
+        assert!(
+            parse_protocol_message(&signed_old, "transport-xyz").is_some(),
+            "should accept signed message with timestamp 10h in the past"
+        );
+
+        let signed_future =
+            make_signed_wire_bytes(&identity, "test/signed-future", payload, future_ts);
+        assert!(
+            parse_protocol_message(&signed_future, "transport-xyz").is_some(),
+            "should accept signed message with timestamp 10h in the future"
         );
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -1733,21 +1733,6 @@ impl P2PNode {
 /// can pass it directly to `send_message()`. This eliminates a spoofing
 /// vector where a peer could claim an arbitrary identity via the payload.
 ///
-/// Maximum allowed clock skew for message timestamps.
-///
-/// A decentralized network cannot assume participants have accurate clocks.
-/// Consumer devices commonly have clocks that drift by minutes (no NTP, wrong
-/// timezone offset applied to UTC, suspended laptops, VMs without guest
-/// additions, etc.). Both past and future windows must be symmetric and
-/// generous enough that normal clock drift does not partition the network.
-///
-/// 5 minutes in both directions provides replay protection while tolerating
-/// the clock skew observed in real-world deployments (31-42 seconds was
-/// measured between a macOS client and NTP-synced VPS nodes).
-const MAX_MESSAGE_AGE_SECS: u64 = 300;
-/// Maximum allowed future timestamp — symmetric with the past window.
-const MAX_FUTURE_SECS: u64 = 300;
-
 /// Convenience constructor for `P2PError::Network(NetworkError::ProtocolError(...))`.
 fn protocol_error(msg: impl std::fmt::Display) -> P2PError {
     P2PError::Network(NetworkError::ProtocolError(msg.to_string().into()))
@@ -1773,34 +1758,6 @@ pub(crate) struct ParsedMessage {
 pub(crate) fn parse_protocol_message(bytes: &[u8], source: &str) -> Option<ParsedMessage> {
     let message: WireMessage = postcard::from_bytes(bytes).ok()?;
     let transport_source = source.parse::<SocketAddr>().ok().map(MultiAddr::quic);
-
-    // Validate timestamp to prevent replay attacks
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-
-    // Reject messages that are too old (potential replay)
-    if message.timestamp < now.saturating_sub(MAX_MESSAGE_AGE_SECS) {
-        tracing::warn!(
-            "Rejecting stale message from {} (timestamp {} is {} seconds old)",
-            source,
-            message.timestamp,
-            now.saturating_sub(message.timestamp)
-        );
-        return None;
-    }
-
-    // Reject messages too far in the future (clock manipulation)
-    if message.timestamp > now + MAX_FUTURE_SECS {
-        tracing::warn!(
-            "Rejecting future-dated message from {} (timestamp {} is {} seconds ahead)",
-            source,
-            message.timestamp,
-            message.timestamp.saturating_sub(now)
-        );
-        return None;
-    }
 
     // Verify app-level signature if present
     let authenticated_node_id = if !message.signature.is_empty() {
@@ -3526,6 +3483,30 @@ mod tests {
         assert!(
             parse_protocol_message(&bytes, "transport-xyz").is_none(),
             "message with mismatched from field should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_parse_protocol_message_accepts_arbitrary_timestamps() {
+        // Clock skew between peers must not drop messages.
+        // Regression: previously ±5 min tolerance silently rejected all
+        // traffic when client and node clocks differed.
+        let payload = vec![1, 2, 3];
+
+        // 10 hours in the past
+        let old_ts = current_timestamp().saturating_sub(36_000);
+        let old_bytes = make_wire_bytes("test/old", payload.clone(), "sender", old_ts);
+        assert!(
+            parse_protocol_message(&old_bytes, "peer-id").is_some(),
+            "should accept message with timestamp 10h in the past"
+        );
+
+        // 10 hours in the future
+        let future_ts = current_timestamp().saturating_add(36_000);
+        let future_bytes = make_wire_bytes("test/future", payload, "sender", future_ts);
+        assert!(
+            parse_protocol_message(&future_bytes, "peer-id").is_some(),
+            "should accept message with timestamp 10h in the future"
         );
     }
 }


### PR DESCRIPTION
## Problem

Clock skew between peers (>5 min) was silently dropping P2P traffic. Consumer devices commonly drift by minutes or hours (wrong timezone, suspended laptops, VMs), and testnets are likely mostly UTC so this was masked.

This is part of the Autonomi 2.0 issue where clients on non-UTC machines could not reliably download/upload.

## Change

- Remove timestamp-based acceptance/rejection from `parse_protocol_message()` in `src/network.rs`.
- Keep timestamp in `WireMessage` and in the signed payload for integrity.
- Remove `MAX_MESSAGE_AGE_SECS` and `MAX_FUTURE_SECS` constants.
- Keep the transport/authenticated peer as the message source; the payload `from` remains protected by signature verification for signed messages.
- Add regression coverage for arbitrary old/future timestamps on both unsigned and signed messages.
- Fix the displaced doc comment so it documents `parse_protocol_message`, not `protocol_error`.

## Security note

This deliberately removes wall-clock replay gating at the generic wire-message parser. That is the point of the fix: message acceptance must not depend on local wall-clock alignment between peers. Signature verification still covers the timestamp, payload, protocol, sender, and user agent for integrity/authenticity. Replay-sensitive semantics should be handled at the relevant protocol/application layer rather than by rejecting all skewed P2P messages globally.

## Verification

- `cargo test test_parse_protocol_message_accepts_arbitrary_timestamps --all-features` — passed.
- `cargo test --all-features --no-fail-fast` — 482 unit tests passed; integration/doc tests passed; known ignored tests remained ignored.
- `cargo clippy --all-features -- -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used` — passed.

## Related

- Autonomi 2.0 client upload/download failures on machines not set to UTC.
- Paired with WithAutonomi/ant-node#120, which removes payment quote wall-clock freshness and replaces it with storage-delta validation.
