### PR TITLE
fix(p2p): expose signed timestamp on P2PEvent::Message (alt to #123)

### DIFF
--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -4165,6 +4165,7 @@ impl DhtNetworkManager {
                                     topic,
                                     source,
                                     transport_source,
+                                    timestamp: _,
                                     data,
                                 } => {
                                     trace!(

--- a/src/network.rs
+++ b/src/network.rs
@@ -1723,16 +1723,6 @@ impl P2PNode {
     }
 }
 
-/// Parse a postcard-encoded protocol message into a `P2PEvent::Message`.
-///
-/// Returns `None` if the bytes cannot be deserialized as a valid `WireMessage`.
-///
-/// The `from` field is a required part of the wire protocol but is **not**
-/// used as the event source. Instead, `source` — the transport-level peer ID
-/// derived from the authenticated QUIC connection — is used so that consumers
-/// can pass it directly to `send_message()`. This eliminates a spoofing
-/// vector where a peer could claim an arbitrary identity via the payload.
-///
 /// Convenience constructor for `P2PError::Network(NetworkError::ProtocolError(...))`.
 fn protocol_error(msg: impl std::fmt::Display) -> P2PError {
     P2PError::Network(NetworkError::ProtocolError(msg.to_string().into()))
@@ -1755,6 +1745,15 @@ pub(crate) struct ParsedMessage {
     pub(crate) user_agent: String,
 }
 
+/// Parse a postcard-encoded protocol message into a `P2PEvent::Message`.
+///
+/// Returns `None` if the bytes cannot be deserialized as a valid `WireMessage`.
+///
+/// The `from` field is a required part of the wire protocol but is **not**
+/// used as the event source. Instead, `source` — the transport-level peer ID
+/// derived from the authenticated QUIC connection — is used so that consumers
+/// can pass it directly to `send_message()`. This eliminates a spoofing
+/// vector where a peer could claim an arbitrary identity via the payload.
 pub(crate) fn parse_protocol_message(bytes: &[u8], source: &str) -> Option<ParsedMessage> {
     let message: WireMessage = postcard::from_bytes(bytes).ok()?;
     let transport_source = source.parse::<SocketAddr>().ok().map(MultiAddr::quic);
@@ -3258,7 +3257,7 @@ mod tests {
             .unwrap_or(0)
     }
 
-    /// Helper to create a postcard-serialized WireMessage for tests
+    /// Helper to create a postcard-serialized unsigned WireMessage for tests
     fn make_wire_bytes(protocol: &str, data: Vec<u8>, from: &str, timestamp: u64) -> Vec<u8> {
         let msg = WireMessage {
             protocol: protocol.to_string(),
@@ -3268,6 +3267,31 @@ mod tests {
             user_agent: String::new(),
             public_key: Vec::new(),
             signature: Vec::new(),
+        };
+        postcard::to_stdvec(&msg).unwrap()
+    }
+
+    /// Helper to create a postcard-serialized signed WireMessage for tests.
+    fn make_signed_wire_bytes(
+        identity: &NodeIdentity,
+        protocol: &str,
+        data: Vec<u8>,
+        timestamp: u64,
+    ) -> Vec<u8> {
+        let from = *identity.peer_id();
+        let user_agent = "test/1.0";
+        let signable =
+            postcard::to_stdvec(&(protocol, data.as_slice(), &from, timestamp, user_agent))
+                .unwrap();
+        let sig = identity.sign(&signable).expect("signing should succeed");
+        let msg = WireMessage {
+            protocol: protocol.to_string(),
+            data,
+            from,
+            timestamp,
+            user_agent: user_agent.to_string(),
+            public_key: identity.public_key().as_bytes().to_vec(),
+            signature: sig.as_bytes().to_vec(),
         };
         postcard::to_stdvec(&msg).unwrap()
     }
@@ -3498,15 +3522,32 @@ mod tests {
         let old_bytes = make_wire_bytes("test/old", payload.clone(), "sender", old_ts);
         assert!(
             parse_protocol_message(&old_bytes, "peer-id").is_some(),
-            "should accept message with timestamp 10h in the past"
+            "should accept unsigned message with timestamp 10h in the past"
         );
 
         // 10 hours in the future
         let future_ts = current_timestamp().saturating_add(36_000);
-        let future_bytes = make_wire_bytes("test/future", payload, "sender", future_ts);
+        let future_bytes = make_wire_bytes("test/future", payload.clone(), "sender", future_ts);
         assert!(
             parse_protocol_message(&future_bytes, "peer-id").is_some(),
-            "should accept message with timestamp 10h in the future"
+            "should accept unsigned message with timestamp 10h in the future"
+        );
+
+        // Signed messages must take the same path: timestamp remains part of the
+        // signed bytes for integrity, but is not used for wall-clock rejection.
+        let identity = NodeIdentity::generate().expect("should generate identity");
+        let signed_old =
+            make_signed_wire_bytes(&identity, "test/signed-old", payload.clone(), old_ts);
+        assert!(
+            parse_protocol_message(&signed_old, "transport-xyz").is_some(),
+            "should accept signed message with timestamp 10h in the past"
+        );
+
+        let signed_future =
+            make_signed_wire_bytes(&identity, "test/signed-future", payload, future_ts);
+        assert!(
+            parse_protocol_message(&signed_future, "transport-xyz").is_some(),
+            "should accept signed message with timestamp 10h in the future"
         );
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -709,6 +709,14 @@ pub enum P2PEvent {
         ///
         /// This is provenance metadata, not an identity signal.
         transport_source: Option<MultiAddr>,
+        /// Sender-supplied Unix timestamp in seconds.
+        ///
+        /// For signed messages this value is covered by the ML-DSA-65 signature
+        /// alongside the payload, so handlers can use it for application-level
+        /// freshness or replay defense. Wire-level acceptance no longer gates
+        /// on this value; subscribers MUST do their own age/dedup checks when
+        /// the protocol requires them.
+        timestamp: u64,
         /// Raw message data payload
         data: Vec<u8>,
     },
@@ -1736,6 +1744,10 @@ pub(crate) fn broadcast_event(tx: &broadcast::Sender<P2PEvent>, event: P2PEvent)
 }
 
 /// Result of parsing a protocol message, including optional authenticated identity.
+///
+/// The signed wire timestamp is carried on the inner [`P2PEvent::Message`]
+/// (see its `timestamp` field) so subscribers can apply their own freshness
+/// or replay policy now that the wire-level skew gate is gone.
 pub(crate) struct ParsedMessage {
     /// The P2P event to broadcast.
     pub(crate) event: P2PEvent,
@@ -1794,6 +1806,7 @@ pub(crate) fn parse_protocol_message(bytes: &[u8], source: &str) -> Option<Parse
             topic: message.protocol,
             source: authenticated_node_id,
             transport_source,
+            timestamp: message.timestamp,
             data: message.data,
         },
         authenticated_node_id,
@@ -3315,6 +3328,7 @@ mod tests {
                 topic,
                 source,
                 transport_source,
+                timestamp: _,
                 data,
             } => {
                 assert!(source.is_none(), "unsigned message source must be None");
@@ -3548,6 +3562,48 @@ mod tests {
         assert!(
             parse_protocol_message(&signed_future, "transport-xyz").is_some(),
             "should accept signed message with timestamp 10h in the future"
+        );
+    }
+
+    #[test]
+    fn test_parse_protocol_message_exposes_timestamp_on_event() {
+        // After removing the wall-clock skew gate, the signed timestamp must
+        // remain reachable on `P2PEvent::Message` so application-layer handlers
+        // can implement freshness / replay defense.
+        let ts: u64 = 1_234_567_890;
+        let bytes = make_wire_bytes("test/ts", vec![9, 9, 9], "sender", ts);
+        let parsed = parse_protocol_message(&bytes, "peer-id").expect("valid message should parse");
+        match parsed.event {
+            P2PEvent::Message { timestamp, .. } => {
+                assert_eq!(timestamp, ts, "P2PEvent::Message.timestamp must round-trip");
+            }
+            other => panic!("expected P2PEvent::Message, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_signed_message_timestamp_is_signature_covered() {
+        // Sign once, mutate only the timestamp, assert rejection. This is the
+        // only timestamp property still enforced by `parse_protocol_message`
+        // after the wall-clock gate was removed: signature integrity.
+        let identity = NodeIdentity::generate().expect("should generate identity");
+        let ts: u64 = 1_700_000_000;
+        let signed = make_signed_wire_bytes(&identity, "test/sig", vec![1, 2, 3], ts);
+
+        // Sanity: unmodified bytes parse and authenticate.
+        let parsed = parse_protocol_message(&signed, "transport-xyz")
+            .expect("unmodified signed message should parse");
+        assert!(parsed.authenticated_node_id.is_some());
+
+        // Now tamper with just the timestamp on the wire and re-serialize.
+        let mut tampered: WireMessage =
+            postcard::from_bytes(&signed).expect("signed bytes must deserialize");
+        tampered.timestamp = ts.wrapping_add(1);
+        let tampered_bytes = postcard::to_stdvec(&tampered).expect("re-serialize");
+
+        assert!(
+            parse_protocol_message(&tampered_bytes, "transport-xyz").is_none(),
+            "timestamp-only mutation on a signed message must fail signature verification"
         );
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -1733,21 +1733,6 @@ impl P2PNode {
 /// can pass it directly to `send_message()`. This eliminates a spoofing
 /// vector where a peer could claim an arbitrary identity via the payload.
 ///
-/// Maximum allowed clock skew for message timestamps.
-///
-/// A decentralized network cannot assume participants have accurate clocks.
-/// Consumer devices commonly have clocks that drift by minutes (no NTP, wrong
-/// timezone offset applied to UTC, suspended laptops, VMs without guest
-/// additions, etc.). Both past and future windows must be symmetric and
-/// generous enough that normal clock drift does not partition the network.
-///
-/// 5 minutes in both directions provides replay protection while tolerating
-/// the clock skew observed in real-world deployments (31-42 seconds was
-/// measured between a macOS client and NTP-synced VPS nodes).
-const MAX_MESSAGE_AGE_SECS: u64 = 300;
-/// Maximum allowed future timestamp — symmetric with the past window.
-const MAX_FUTURE_SECS: u64 = 300;
-
 /// Convenience constructor for `P2PError::Network(NetworkError::ProtocolError(...))`.
 fn protocol_error(msg: impl std::fmt::Display) -> P2PError {
     P2PError::Network(NetworkError::ProtocolError(msg.to_string().into()))
@@ -1773,34 +1758,6 @@ pub(crate) struct ParsedMessage {
 pub(crate) fn parse_protocol_message(bytes: &[u8], source: &str) -> Option<ParsedMessage> {
     let message: WireMessage = postcard::from_bytes(bytes).ok()?;
     let transport_source = source.parse::<SocketAddr>().ok().map(MultiAddr::quic);
-
-    // Validate timestamp to prevent replay attacks
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-
-    // Reject messages that are too old (potential replay)
-    if message.timestamp < now.saturating_sub(MAX_MESSAGE_AGE_SECS) {
-        tracing::warn!(
-            "Rejecting stale message from {} (timestamp {} is {} seconds old)",
-            source,
-            message.timestamp,
-            now.saturating_sub(message.timestamp)
-        );
-        return None;
-    }
-
-    // Reject messages too far in the future (clock manipulation)
-    if message.timestamp > now + MAX_FUTURE_SECS {
-        tracing::warn!(
-            "Rejecting future-dated message from {} (timestamp {} is {} seconds ahead)",
-            source,
-            message.timestamp,
-            message.timestamp.saturating_sub(now)
-        );
-        return None;
-    }
 
     // Verify app-level signature if present
     let authenticated_node_id = if !message.signature.is_empty() {
@@ -3526,6 +3483,30 @@ mod tests {
         assert!(
             parse_protocol_message(&bytes, "transport-xyz").is_none(),
             "message with mismatched from field should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_parse_protocol_message_accepts_arbitrary_timestamps() {
+        // Clock skew between peers must not drop messages.
+        // Regression: previously ±5 min tolerance silently rejected all
+        // traffic when client and node clocks differed.
+        let payload = vec![1, 2, 3];
+
+        // 10 hours in the past
+        let old_ts = current_timestamp().saturating_sub(36_000);
+        let old_bytes = make_wire_bytes("test/old", payload.clone(), "sender", old_ts);
+        assert!(
+            parse_protocol_message(&old_bytes, "peer-id").is_some(),
+            "should accept message with timestamp 10h in the past"
+        );
+
+        // 10 hours in the future
+        let future_ts = current_timestamp().saturating_add(36_000);
+        let future_bytes = make_wire_bytes("test/future", payload, "sender", future_ts);
+        assert!(
+            parse_protocol_message(&future_bytes, "peer-id").is_some(),
+            "should accept message with timestamp 10h in the future"
         );
     }
 }

--- a/src/transport_handle.rs
+++ b/src/transport_handle.rs
@@ -2125,10 +2125,16 @@ impl TransportHandle {
             );
         }
 
+        // Self-emit to local subscribers. The on-wire timestamp lives on each
+        // serialized WireMessage built by `send_on_channel`; this local copy
+        // just stamps "when the publisher sent it" so handlers see the same
+        // shape they would for a received signed message.
+        let timestamp = Self::current_timestamp_secs().unwrap_or(0);
         self.send_event(P2PEvent::Message {
             topic: topic.to_string(),
             source: Some(*self.node_identity.peer_id()),
             transport_source: None,
+            timestamp,
             data: data.to_vec(),
         });
 


### PR DESCRIPTION
## Summary

Alternative to #123 that addresses the blocker raised in review: `parse_protocol_message()` discarded `WireMessage.timestamp` before broadcasting `P2PEvent::Message`, so application-layer replay/freshness defense was impossible to add without another wire-format parse or API change.

This branch is built on top of #123 (same `fix/remove-p2p-timestamp-validation` HEAD) and adds a single commit that exposes the signed timestamp.

## Changes (on top of #123)

- Add `timestamp: u64` to `P2PEvent::Message`.
- Propagate `message.timestamp` from `parse_protocol_message()` into the event.
- Populate the self-publish path in `TransportHandle::publish` with `current_timestamp_secs()`, matching the convention used when `WireMessage` is built for the wire.
- Add a regression test that signing then mutating only the timestamp causes `parse_protocol_message` to reject the message (signature still covers the timestamp).
- Add a test that the timestamp round-trips through `parse_protocol_message` onto the event.

Wire-level acceptance is unchanged: the parser still does not reject on age or skew. The point is to make downstream replay/freshness defense actually implementable.

## Verification

- `cargo fmt --check` — clean.
- `cargo clippy --all-features -- -D warnings` — clean.
- `cargo test --lib network::` — 45 passed (incl. the two new regression tests).

## Related

- Supersedes the freshness blocker on #123. Replay protection for individual DHT RPCs (e.g. `FindNode`/`Ping`/`Join`) is a separate concern that's out of scope here; the change just unblocks adding it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes the signed wire timestamp on `P2PEvent::Message` so application-layer subscribers can implement freshness and replay-defense checks without re-parsing the wire format — a capability that was previously impossible because `parse_protocol_message` discarded the timestamp before broadcasting the event.

- Adds `timestamp: u64` to `P2PEvent::Message`, propagates it from `parse_protocol_message`, and stamps the self-publish path with `current_timestamp_secs().unwrap_or(0)` to maintain a consistent event shape.
- Removes the wall-clock skew gate (`MAX_MESSAGE_AGE_SECS` / `MAX_FUTURE_SECS`) and adds two regression tests: one confirming arbitrary timestamps are accepted, and one confirming that mutating only the timestamp on a signed message still fails signature verification.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is narrowly scoped to adding a field to an event enum and propagating it through two call sites, with no behavioural change on the wire-acceptance path.

The implementation is correct: the signing scheme in the new test helper exactly matches verify_message_signature, the dht_network_manager destructuring is updated properly, and the self-publish timestamp is consistent with received-message events. The only open item is a documentation gap on the timestamp field that could mislead consumers of unsigned messages into treating an unauthenticated value as trustworthy for security checks.

src/network.rs — the timestamp field doc comment should explicitly note that for unsigned messages the value is unauthenticated.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/network.rs | Adds `timestamp: u64` to `P2PEvent::Message`, propagates `message.timestamp` through `parse_protocol_message`, removes the wall-clock skew gate, and adds two well-targeted regression tests. Minor: the field doc could be more explicit that unsigned-message timestamps are unauthenticated. |
| src/transport_handle.rs | Populates the local self-publish event with `current_timestamp_secs().unwrap_or(0)`, consistent with the shape subscribers see for received messages. The fallback to 0 on system-time failure is a reasonable sentinel for this path. |
| src/dht_network_manager.rs | Adds `timestamp: _` to the `P2PEvent::Message` destructuring arm to accommodate the new field; DHT layer correctly discards it. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Sender as Remote Peer
    participant Wire as QUIC Wire
    participant Parser as parse_protocol_message()
    participant Broadcast as broadcast::Sender
    participant Subscriber as App Subscriber

    Sender->>Wire: "WireMessage { protocol, data, from, timestamp, signature }"
    Wire->>Parser: raw bytes
    Parser->>Parser: postcard::from_bytes()
    Parser->>Parser: verify ML-DSA-65 signature (covers protocol+data+from+timestamp+ua)
    Parser->>Broadcast: "P2PEvent::Message { topic, source, transport_source, timestamp, data }"
    Broadcast->>Subscriber: event
    Subscriber->>Subscriber: application-level freshness/replay check (timestamp trusted only when source.is_some())

    Note over Sender,Subscriber: Self-publish path
    participant Publisher as TransportHandle::publish()
    Publisher->>Broadcast: "P2PEvent::Message { ..., timestamp: current_timestamp_secs() }"
    Broadcast->>Subscriber: event
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/network.rs:712-719
The doc comment correctly scopes the freshness/replay-defense advice to signed messages, but doesn't explicitly warn that for unsigned messages (`source: None`) the timestamp is unauthenticated and trivially spoofable. Developers may overlook the "For signed messages…" qualifier and use the field for security-sensitive decisions on unsigned traffic. Adding one explicit sentence would close that gap.

```suggestion
        /// Sender-supplied Unix timestamp in seconds.
        ///
        /// For signed messages this value is covered by the ML-DSA-65 signature
        /// alongside the payload, so handlers can use it for application-level
        /// freshness or replay defense. Wire-level acceptance no longer gates
        /// on this value; subscribers MUST do their own age/dedup checks when
        /// the protocol requires them.
        ///
        /// **For unsigned messages** (`source` is `None`) this value is
        /// unauthenticated and trivially spoofable — do not rely on it for
        /// security decisions.
        timestamp: u64,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(p2p): expose signed timestamp on P2P..."](https://github.com/saorsa-labs/saorsa-core/commit/18316478df86300f359e2099a8d74e4c44b79441) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34526171)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->