### PR TITLE
Revert PR #129 (relay-IP-level dial-failure inference)

### DIFF
--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -210,24 +210,6 @@ const REBOOTSTRAP_COOLDOWN: Duration = Duration::from_secs(300); // 5 minutes
 /// Unverified/Direct entries published by NATed peers.
 const DIAL_FAILURE_CACHE_TTL: Duration = Duration::from_secs(30 * 60);
 
-/// Number of *distinct* failed relay-session `SocketAddr`s at a single
-/// relay-server IP (with no intervening success at that IP, within the
-/// [`DIAL_FAILURE_CACHE_TTL`] window) that trips IP-level suppression in
-/// [`DialFailureCache`].
-///
-/// When a relay server goes down it orphans every MASQUE session address
-/// it ever allocated; those records keep circulating in FIND_NODE
-/// responses, each a distinct `ip:port` the per-`SocketAddr` tier can only
-/// suppress after it fails its own dial. Once this many distinct sessions
-/// at one IP have failed, every *remaining* session at that IP is
-/// suppressed without an individual dial. A success at the IP clears the
-/// suppression immediately, so a recovered relay is re-admitted promptly.
-///
-/// Conservative on purpose: a threshold (not a single failure) plus
-/// success-clears-immediately guards against suppressing a live IP because
-/// one peer behind a shared NAT IP churned.
-const DIAL_FAILURE_IP_SUPPRESS_THRESHOLD: usize = 4;
-
 /// Worst-case number of addresses
 /// [`DhtNetworkManager::select_dial_candidates_with_context`] returns for a
 /// single peer: one Relay plus at most one best WAN and one best LAN address
@@ -837,34 +819,9 @@ impl PendingDialOutcome {
 /// rather than by a background sweeper. A 30-minute TTL keeps the
 /// hot-set small enough that lazy eviction is sufficient, even on
 /// long-lived nodes.
-///
-/// # IP-level tier
-///
-/// Alongside the per-`SocketAddr` tier above, a second index keyed by
-/// relay-server [`IpAddr`] collapses the dead-orphaned-session pattern: a
-/// downed relay server orphans *every* MASQUE session address it ever
-/// allocated, and each is a distinct `ip:port` that the per-`SocketAddr`
-/// tier can only suppress after it fails its own dial. The IP tier records
-/// the set of *distinct* failed relay sessions per IP and, once that set
-/// reaches [`DIAL_FAILURE_IP_SUPPRESS_THRESHOLD`] within the TTL,
-/// suppresses *all* remaining sessions at that IP without dialing them.
-///
-/// The IP tier is fed only by `AddressType::Relay` failures and only
-/// suppresses relay-kind dials, so a genuinely-distinct Direct peer behind
-/// a shared NAT IP is never suppressed by relay churn at that IP. Any
-/// successful dial at an IP clears its IP-level suppression immediately
-/// (see [`Self::clear`]) — the primary guard against a transient
-/// false-positive on a shared or recovered IP.
 #[derive(Debug, Default)]
 struct DialFailureCache {
-    /// Per-`SocketAddr` failure timestamps (the original tier).
     entries: DashMap<SocketAddr, Instant>,
-    /// Per relay-server `IpAddr`: the distinct relay-session `SocketAddr`s
-    /// that have failed, each with its own record time for lazy TTL
-    /// expiry. Keyed on `SocketAddr` so re-dialing the *same* dead session
-    /// cannot inflate the distinct count. Only `AddressType::Relay`
-    /// failures populate this map.
-    ip_failures: DashMap<IpAddr, HashMap<SocketAddr, Instant>>,
 }
 
 impl DialFailureCache {
@@ -872,30 +829,17 @@ impl DialFailureCache {
         Self::default()
     }
 
-    /// Canonicalize a cache key so an IPv4-mapped IPv6 socket
-    /// (`[::ffff:a.b.c.d]:p`) and its bare IPv4 form (`a.b.c.d:p`) resolve to
-    /// the **same** entry — matching how the rest of the dial path
-    /// canonicalizes endpoint identity (see [`canonicalize_ip`]). Without
-    /// this, a failure recorded under one form would neither suppress nor be
-    /// cleared by the other for the same physical endpoint.
-    fn canon_key(addr: SocketAddr) -> SocketAddr {
-        SocketAddr::new(canonicalize_ip(addr.ip()), addr.port())
-    }
-
-    /// Returns true if `addr` should be skipped because it failed a dial
-    /// within the last [`DIAL_FAILURE_CACHE_TTL`] (per-`SocketAddr` tier),
-    /// or — for `AddressType::Relay` dials only — because its relay-server
-    /// IP is currently suppressed by the IP tier. Expired entries in both
-    /// tiers are removed as a side effect of the lookup so the cache stays
-    /// bounded without a dedicated sweeper.
+    /// Returns true if `addr` failed a dial within the last
+    /// [`DIAL_FAILURE_CACHE_TTL`]. Expired entries are removed as a
+    /// side effect of the lookup so the cache stays bounded without a
+    /// dedicated sweeper.
     ///
     /// The `DashMap::entry` API holds a single shard write lock across
     /// the elapsed-check and the `remove`, so a concurrent
     /// [`Self::record_failure`] cannot slip a fresh entry in between
     /// the check and the eviction.
-    fn is_failed(&self, addr: &SocketAddr, ty: AddressType) -> bool {
-        let addr = Self::canon_key(*addr);
-        let per_addr_failed = match self.entries.entry(addr) {
+    fn is_failed(&self, addr: &SocketAddr) -> bool {
+        match self.entries.entry(*addr) {
             DashEntry::Occupied(entry) => {
                 if entry.get().elapsed() < DIAL_FAILURE_CACHE_TTL {
                     true
@@ -905,82 +849,18 @@ impl DialFailureCache {
                 }
             }
             DashEntry::Vacant(_) => false,
-        };
-        if per_addr_failed {
-            return true;
-        }
-        ty == AddressType::Relay && self.ip_is_suppressed(&addr.ip())
-    }
-
-    /// Returns true if `ip` has at least
-    /// [`DIAL_FAILURE_IP_SUPPRESS_THRESHOLD`] distinct relay sessions that
-    /// failed within the TTL. Expired sessions are pruned on access, and
-    /// an IP whose set empties is removed entirely, so the IP tier stays
-    /// bounded by the same lazy-expiry discipline as the per-addr tier.
-    ///
-    /// Holds the shard write lock across the prune and the count, so a
-    /// concurrent [`Self::record_failure`] or [`Self::clear`] cannot race
-    /// the threshold decision.
-    fn ip_is_suppressed(&self, ip: &IpAddr) -> bool {
-        match self.ip_failures.entry(*ip) {
-            DashEntry::Occupied(mut entry) => {
-                let sessions = entry.get_mut();
-                sessions.retain(|_, recorded| recorded.elapsed() < DIAL_FAILURE_CACHE_TTL);
-                if sessions.is_empty() {
-                    entry.remove();
-                    false
-                } else {
-                    sessions.len() >= DIAL_FAILURE_IP_SUPPRESS_THRESHOLD
-                }
-            }
-            DashEntry::Vacant(_) => false,
         }
     }
 
-    /// Record a failed dial of `addr`. Always updates the per-`SocketAddr`
-    /// tier; additionally registers the session against its relay-server IP
-    /// when `ty` is [`AddressType::Relay`], so enough distinct dead
-    /// sessions at one IP trip IP-level suppression.
-    fn record_failure(&self, addr: SocketAddr, ty: AddressType) {
-        let addr = Self::canon_key(addr);
-        let now = Instant::now();
-        self.entries.insert(addr, now);
-        if ty == AddressType::Relay {
-            let mut sessions = self.ip_failures.entry(addr.ip()).or_default();
-            let newly_distinct = sessions.insert(addr, now).is_none();
-            let count = sessions.len();
-            drop(sessions);
-            // Log once — when a newly-distinct failed session first brings the
-            // IP to the suppression threshold — so traces can tell a single
-            // skipped address apart from a fully suppressed relay IP. (The
-            // count may include not-yet-expired entries; `ip_is_suppressed`
-            // prunes on read, so this is best-effort observability.)
-            if newly_distinct && count == DIAL_FAILURE_IP_SUPPRESS_THRESHOLD {
-                debug!(
-                    "DialFailureCache: relay IP {} reached the suppression threshold \
-                     ({} distinct failed sessions, no intervening success); suppressing \
-                     all further relay dials to this IP for up to {:?}",
-                    addr.ip(),
-                    DIAL_FAILURE_IP_SUPPRESS_THRESHOLD,
-                    DIAL_FAILURE_CACHE_TTL
-                );
-            }
-        }
+    fn record_failure(&self, addr: SocketAddr) {
+        self.entries.insert(addr, Instant::now());
     }
 
     /// Clear the cached failure for `addr` after a successful dial so
     /// the next retry is not suppressed by a stale entry. Cheap when
     /// the address is absent (typical success path).
-    ///
-    /// Also drops the entire IP-level failure set for `addr.ip()`: a
-    /// success at an IP proves the relay server (or a live peer behind a
-    /// shared IP) is reachable, so any IP-level suppression must lift
-    /// immediately. Type-agnostic on purpose — a Direct success behind a
-    /// shared NAT IP re-admits relay sessions there too.
     fn clear(&self, addr: &SocketAddr) {
-        let addr = Self::canon_key(*addr);
-        self.entries.remove(&addr);
-        self.ip_failures.remove(&addr.ip());
+        self.entries.remove(addr);
     }
 }
 
@@ -2513,10 +2393,7 @@ impl DhtNetworkManager {
         for node in initial {
             if peer_states.is_contactable(&node.peer_id) {
                 if self.lookup_candidate_dial_plan_is_exhausted(&node).await {
-                    // Cache exhaustion is a transient, address-view-local
-                    // decision — not a terminal peer failure. Skip this view
-                    // but leave the peer contactable so a later responder can
-                    // still revive it with a usable (e.g. Direct) address.
+                    peer_states.mark_failed(node.peer_id);
                     continue;
                 }
                 let dist = node.peer_id.distance(&target_key);
@@ -2551,12 +2428,9 @@ impl DhtNetworkManager {
                     continue;
                 }
                 if self.lookup_candidate_dial_plan_is_exhausted(&node).await {
-                    // Transient skip, not a terminal failure: keep the peer
-                    // contactable so a better address from a later responder
-                    // can re-admit it (it may have become exhausted only
-                    // because of a coarse relay-IP suppression).
+                    peer_states.mark_failed(node.peer_id);
                     trace!(
-                        "[NETWORK] Skipping {} this round: all dial candidates currently in the failure cache (peer left contactable)",
+                        "[NETWORK] Skipping {}: all FIND_NODE dial candidates are in the failure cache",
                         node.peer_id.to_hex()
                     );
                     continue;
@@ -2654,14 +2528,9 @@ impl DhtNetworkManager {
                                 continue;
                             }
                             if self.lookup_candidate_dial_plan_is_exhausted(&node).await {
-                                // Transient skip, not a terminal failure: a
-                                // single responder's stale/suppressed (e.g.
-                                // relay-only) view of this peer must not poison
-                                // it for the rest of the lookup. Leave it
-                                // contactable so another responder's usable
-                                // (e.g. Direct) address can still win.
+                                peer_states.mark_failed(node.peer_id);
                                 trace!(
-                                    "[NETWORK] Skipping gossiped {} this round: all dial candidates currently in the failure cache (peer left contactable)",
+                                    "[NETWORK] Skipping gossiped {}: all FIND_NODE dial candidates are in the failure cache",
                                     node.peer_id.to_hex()
                                 );
                                 continue;
@@ -3184,7 +3053,7 @@ impl DhtNetworkManager {
             let Some(socket_addr) = addr.dialable_socket_addr() else {
                 continue;
             };
-            if self.dial_failure_cache.is_failed(&socket_addr, *ty) {
+            if self.dial_failure_cache.is_failed(&socket_addr) {
                 skipped_cached += 1;
                 trace!(
                     "dial_addresses: skipping recently failed address {} ({:?}) for {}",
@@ -3200,7 +3069,7 @@ impl DhtNetworkManager {
                     return Some(channel_id);
                 }
                 None => {
-                    self.dial_failure_cache.record_failure(socket_addr, *ty);
+                    self.dial_failure_cache.record_failure(socket_addr);
                 }
             }
         }
@@ -3236,9 +3105,9 @@ impl DhtNetworkManager {
     ) -> bool {
         let plan = Self::select_dial_candidates(typed_addresses);
         !plan.is_empty()
-            && plan.iter().all(|(addr, ty)| {
+            && plan.iter().all(|(addr, _)| {
                 addr.dialable_socket_addr()
-                    .is_some_and(|socket_addr| cache.is_failed(&socket_addr, *ty))
+                    .is_some_and(|socket_addr| cache.is_failed(&socket_addr))
             })
     }
 
@@ -3301,9 +3170,9 @@ impl DhtNetworkManager {
     ) -> bool {
         let plan = self.contextual_dial_plan(typed_addresses).await;
         !plan.is_empty()
-            && plan.iter().all(|(addr, ty)| {
+            && plan.iter().all(|(addr, _)| {
                 addr.dialable_socket_addr()
-                    .is_some_and(|socket_addr| self.dial_failure_cache.is_failed(&socket_addr, *ty))
+                    .is_some_and(|socket_addr| self.dial_failure_cache.is_failed(&socket_addr))
             })
     }
 
@@ -6683,13 +6552,13 @@ mod tests {
             &cache, &addrs
         ));
 
-        cache.record_failure(plan[0].0.dialable_socket_addr().unwrap(), plan[0].1);
+        cache.record_failure(plan[0].0.dialable_socket_addr().unwrap());
         assert!(
             !DhtNetworkManager::dial_plan_fully_failed_in_cache(&cache, &addrs),
             "one available planned address should keep the candidate queryable"
         );
 
-        cache.record_failure(plan[1].0.dialable_socket_addr().unwrap(), plan[1].1);
+        cache.record_failure(plan[1].0.dialable_socket_addr().unwrap());
         assert!(
             DhtNetworkManager::dial_plan_fully_failed_in_cache(&cache, &addrs),
             "all planned dial addresses in the failure cache should suppress the candidate"
@@ -6714,13 +6583,10 @@ mod tests {
     fn dial_failure_cache_records_and_checks() {
         let cache = DialFailureCache::new();
         let addr = sock("203.0.113.7:9001");
+        assert!(!cache.is_failed(&addr), "empty cache never reports failed");
+        cache.record_failure(addr);
         assert!(
-            !cache.is_failed(&addr, AddressType::Direct),
-            "empty cache never reports failed"
-        );
-        cache.record_failure(addr, AddressType::Direct);
-        assert!(
-            cache.is_failed(&addr, AddressType::Direct),
+            cache.is_failed(&addr),
             "recorded address must be treated as failed within the TTL"
         );
     }
@@ -6729,10 +6595,10 @@ mod tests {
     fn dial_failure_cache_clear_removes_entry() {
         let cache = DialFailureCache::new();
         let addr = sock("203.0.113.7:9001");
-        cache.record_failure(addr, AddressType::Direct);
+        cache.record_failure(addr);
         cache.clear(&addr);
         assert!(
-            !cache.is_failed(&addr, AddressType::Direct),
+            !cache.is_failed(&addr),
             "clear() must drop the entry so a subsequent dial is allowed"
         );
     }
@@ -6756,7 +6622,7 @@ mod tests {
         };
         cache.entries.insert(addr, stale);
         assert!(
-            !cache.is_failed(&addr, AddressType::Direct),
+            !cache.is_failed(&addr),
             "stale entry must not suppress a fresh dial"
         );
         assert!(
@@ -6770,204 +6636,9 @@ mod tests {
         let cache = DialFailureCache::new();
         let a = sock("203.0.113.7:9001");
         let b = sock("203.0.113.8:9001");
-        cache.record_failure(a, AddressType::Direct);
-        assert!(cache.is_failed(&a, AddressType::Direct));
-        assert!(
-            !cache.is_failed(&b, AddressType::Direct),
-            "different SocketAddr must not hit"
-        );
-    }
-
-    /// Helper: a distinct relay-session [`SocketAddr`] at relay-server IP
-    /// `203.0.113.50`, varying only the port. Models the many orphaned
-    /// MASQUE session addresses a single downed relay leaves circulating.
-    fn relay_session(port: u16) -> SocketAddr {
-        SocketAddr::new("203.0.113.50".parse().unwrap(), port)
-    }
-
-    const TEST_RELAY_IP: &str = "203.0.113.50";
-
-    #[test]
-    fn dial_failure_ip_tier_suppresses_unseen_session_after_threshold() {
-        let cache = DialFailureCache::new();
-
-        // One short of the threshold: no IP-level suppression yet, so a
-        // never-seen session at that IP is still dialable.
-        for port in 0..(DIAL_FAILURE_IP_SUPPRESS_THRESHOLD - 1) as u16 {
-            cache.record_failure(relay_session(9001 + port), AddressType::Relay);
-        }
-        let unseen = relay_session(9500);
-        assert!(
-            !cache.is_failed(&unseen, AddressType::Relay),
-            "below the threshold the IP tier must not suppress a fresh session"
-        );
-
-        // Cross the threshold with one more distinct dead session.
-        cache.record_failure(
-            relay_session(9001 + (DIAL_FAILURE_IP_SUPPRESS_THRESHOLD - 1) as u16),
-            AddressType::Relay,
-        );
-        assert!(
-            cache.is_failed(&unseen, AddressType::Relay),
-            "at the threshold every remaining session at the dead relay IP is suppressed"
-        );
-        assert!(
-            cache.entries.get(&unseen).is_none(),
-            "IP-level suppression must not require dialing or recording the unseen session"
-        );
-    }
-
-    #[test]
-    fn dial_failure_ip_tier_redialing_same_session_does_not_inflate_count() {
-        let cache = DialFailureCache::new();
-        // The same dead session failing repeatedly is one *distinct* address
-        // and must not on its own reach the distinct-session threshold.
-        for _ in 0..(DIAL_FAILURE_IP_SUPPRESS_THRESHOLD + 2) {
-            cache.record_failure(relay_session(9001), AddressType::Relay);
-        }
-        let unseen = relay_session(9500);
-        assert!(
-            !cache.is_failed(&unseen, AddressType::Relay),
-            "re-dialing a single dead session must not trip IP-level suppression"
-        );
-    }
-
-    #[test]
-    fn dial_failure_ip_tier_success_clears_suppression() {
-        let cache = DialFailureCache::new();
-        for port in 0..DIAL_FAILURE_IP_SUPPRESS_THRESHOLD as u16 {
-            cache.record_failure(relay_session(9001 + port), AddressType::Relay);
-        }
-        let unseen = relay_session(9500);
-        assert!(cache.is_failed(&unseen, AddressType::Relay));
-
-        // A success at any address at that IP proves the relay recovered.
-        cache.clear(&relay_session(9001));
-        assert!(
-            !cache.is_failed(&unseen, AddressType::Relay),
-            "a success at the IP must lift IP-level suppression immediately"
-        );
-    }
-
-    #[test]
-    fn dial_failure_ip_tier_shared_ip_success_keeps_live_peer() {
-        // A shared NAT IP hosts several churning relay sessions plus one
-        // genuinely-live peer. Once the dead sessions trip suppression, a
-        // success from the live peer at the same IP must re-admit it.
-        let cache = DialFailureCache::new();
-        for port in 0..DIAL_FAILURE_IP_SUPPRESS_THRESHOLD as u16 {
-            cache.record_failure(relay_session(9001 + port), AddressType::Relay);
-        }
-        let live_peer = relay_session(7000);
-        assert!(
-            cache.is_failed(&live_peer, AddressType::Relay),
-            "precondition: the live peer's session is initially caught by IP suppression"
-        );
-
-        // The live peer answers — record the success.
-        cache.clear(&live_peer);
-        assert!(
-            !cache.is_failed(&live_peer, AddressType::Relay),
-            "a live peer that succeeds at a shared IP must not stay suppressed"
-        );
-    }
-
-    #[test]
-    fn dial_failure_ip_tier_ignores_non_relay_failures() {
-        // Many distinct Direct failures at one IP must never build IP-level
-        // suppression: distinct Direct peers legitimately share a NAT IP.
-        let cache = DialFailureCache::new();
-        for port in 0..(DIAL_FAILURE_IP_SUPPRESS_THRESHOLD + 2) as u16 {
-            cache.record_failure(relay_session(9001 + port), AddressType::Direct);
-        }
-        let unseen_relay = relay_session(9500);
-        assert!(
-            !cache.is_failed(&unseen_relay, AddressType::Relay),
-            "non-relay failures must not populate the relay-IP suppression tier"
-        );
-    }
-
-    #[test]
-    fn dial_failure_ip_tier_relay_failures_do_not_suppress_direct_dials() {
-        // Even at a suppressed relay IP, a Direct dial to the same IP is a
-        // distinct peer kind and must not be skipped by the relay tier.
-        let cache = DialFailureCache::new();
-        for port in 0..DIAL_FAILURE_IP_SUPPRESS_THRESHOLD as u16 {
-            cache.record_failure(relay_session(9001 + port), AddressType::Relay);
-        }
-        let direct = relay_session(9500);
-        assert!(
-            !cache.is_failed(&direct, AddressType::Direct),
-            "IP-level suppression is scoped to relay-kind dials only"
-        );
-    }
-
-    #[test]
-    fn dial_failure_ip_tier_expires_stale_sessions_on_read() {
-        let cache = DialFailureCache::new();
-        let ip: IpAddr = TEST_RELAY_IP.parse().unwrap();
-        let Some(stale) =
-            Instant::now().checked_sub(DIAL_FAILURE_CACHE_TTL + Duration::from_secs(1))
-        else {
-            eprintln!(
-                "skipping: runner Instant is fresher than DIAL_FAILURE_CACHE_TTL ({DIAL_FAILURE_CACHE_TTL:?})"
-            );
-            return;
-        };
-        let mut sessions = HashMap::new();
-        for port in 0..DIAL_FAILURE_IP_SUPPRESS_THRESHOLD as u16 {
-            sessions.insert(relay_session(9001 + port), stale);
-        }
-        cache.ip_failures.insert(ip, sessions);
-
-        assert!(
-            !cache.ip_is_suppressed(&ip),
-            "all sessions stale: the IP must not suppress a fresh dial"
-        );
-        assert!(
-            cache.ip_failures.get(&ip).is_none(),
-            "an IP whose session set empties on expiry must be evicted"
-        );
-    }
-
-    #[test]
-    fn dial_failure_cache_canonicalizes_v4_mapped_v6_key() {
-        // A failure recorded under the IPv4-mapped IPv6 form must suppress —
-        // and be cleared by — the bare IPv4 form of the same endpoint, so the
-        // cache matches the transport's canonicalized endpoint identity.
-        let cache = DialFailureCache::new();
-        let mapped: SocketAddr = "[::ffff:203.0.113.7]:9001".parse().unwrap();
-        let bare: SocketAddr = "203.0.113.7:9001".parse().unwrap();
-
-        cache.record_failure(mapped, AddressType::Direct);
-        assert!(
-            cache.is_failed(&bare, AddressType::Direct),
-            "failure recorded under v4-mapped-v6 must suppress the bare IPv4 form"
-        );
-        cache.clear(&mapped);
-        assert!(
-            !cache.is_failed(&bare, AddressType::Direct),
-            "clear under v4-mapped-v6 must clear the bare IPv4 form"
-        );
-    }
-
-    #[test]
-    fn dial_failure_ip_tier_canonicalizes_v4_mapped_v6() {
-        // IP-tier suppression must collapse v4-mapped-v6 and bare IPv4 to the
-        // same relay-server IP: threshold sessions recorded under the mapped
-        // form must suppress an unseen bare-IPv4 session at the same endpoint.
-        let cache = DialFailureCache::new();
-        for port in 0..DIAL_FAILURE_IP_SUPPRESS_THRESHOLD as u16 {
-            let mapped: SocketAddr = format!("[::ffff:203.0.113.50]:{}", 9001 + port)
-                .parse()
-                .unwrap();
-            cache.record_failure(mapped, AddressType::Relay);
-        }
-        let bare_unseen: SocketAddr = "203.0.113.50:9500".parse().unwrap();
-        assert!(
-            cache.is_failed(&bare_unseen, AddressType::Relay),
-            "IP-tier suppression must apply across v4-mapped-v6 / bare IPv4 forms of one IP"
-        );
+        cache.record_failure(a);
+        assert!(cache.is_failed(&a));
+        assert!(!cache.is_failed(&b), "different SocketAddr must not hit");
     }
 
     /// Helper: deterministic [`PeerId`] from a single byte. Mirrors


### PR DESCRIPTION
Reverts #129 (`feat(dht): relay-IP-level dial-failure inference in DialFailureCache`, merged `0a02a83`) on the `rc-2026.6.2` branch.

**Purpose:** testnet experiment — building new `ant-node` / `ant` binaries from the rc branches to test network behaviour without #129's dial-failure inference.

- Clean revert of merge `0a02a83` (`-m 1`); only touches `src/dht_network_manager.rs` (+31 / -360).
- Verified: `cargo check --all-targets --all-features` passes with the revert applied — nothing downstream (incl. the witnessed close-group work) depends on #129's additions.
- No version bump and no dependent-crate changes; this is a targeted revert onto the existing rc branch only.