### PR TITLE
feat(observability): log trust and K-closest swaps

### DIFF
--- a/src/adaptive/dht.rs
+++ b/src/adaptive/dht.rs
@@ -110,6 +110,16 @@ impl TrustEvent {
             | TrustEvent::ApplicationFailure(_) => NodeStatisticsUpdate::FailedResponse,
         }
     }
+
+    /// Stable reason label used in trust-score change logs.
+    const fn reason_label(self) -> &'static str {
+        match self {
+            TrustEvent::ConnectionFailed => "connection_failed",
+            TrustEvent::ConnectionTimeout => "connection_timeout",
+            TrustEvent::ApplicationSuccess(_) => "application_success",
+            TrustEvent::ApplicationFailure(_) => "application_failure",
+        }
+    }
 }
 
 /// AdaptiveDHT — the trust boundary for all DHT operations.
@@ -182,17 +192,21 @@ impl AdaptiveDHT {
             TrustEvent::ApplicationSuccess(weight) | TrustEvent::ApplicationFailure(weight) => {
                 if weight > 0.0 {
                     let clamped_weight = weight.min(MAX_CONSUMER_WEIGHT);
-                    self.trust_engine.update_node_stats_weighted(
+                    self.trust_engine.update_node_stats_weighted_with_reason(
                         peer_id,
                         event.to_stats_update(),
                         clamped_weight,
+                        event.reason_label(),
                     );
                 }
             }
             _ => {
                 // Internal events: unit weight
-                self.trust_engine
-                    .update_node_stats(peer_id, event.to_stats_update());
+                self.trust_engine.update_node_stats_with_reason(
+                    peer_id,
+                    event.to_stats_update(),
+                    event.reason_label(),
+                );
             }
         }
     }

--- a/src/adaptive/trust.rs
+++ b/src/adaptive/trust.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use tracing::info;
 
 /// Default trust score for unknown peers
 pub const DEFAULT_NEUTRAL_TRUST: f64 = 0.5;
@@ -99,21 +100,27 @@ impl PeerTrust {
     /// `(1-α)^W * score + (1-(1-α)^W) * observation` generalizes the unit-weight
     /// formula and is equivalent to applying `W` consecutive unit-weight updates
     /// for integer W.
-    fn record_weighted(&mut self, observation: f64, weight: f64) {
+    fn record_weighted(&mut self, observation: f64, weight: f64) -> Option<(f64, f64)> {
         if !weight.is_finite() || weight <= 0.0 {
-            return;
+            return None;
         }
         self.apply_decay();
+        let previous_score = self.score;
         let alpha_w = 1.0 - (1.0 - EMA_WEIGHT).powf(weight);
         self.score = (1.0 - alpha_w) * self.score + alpha_w * observation;
         self.score = self.score.clamp(MIN_TRUST_SCORE, MAX_TRUST_SCORE);
         self.last_updated = Instant::now();
+        if (self.score - previous_score).abs() > f64::EPSILON {
+            Some((previous_score, self.score))
+        } else {
+            None
+        }
     }
 
     /// Apply a new observation via EMA with unit weight, after first applying decay.
     #[allow(dead_code)] // design API: retained as convenience wrapper for record_weighted
     fn record(&mut self, observation: f64) {
-        self.record_weighted(observation, 1.0);
+        let _ = self.record_weighted(observation, 1.0);
     }
 
     /// Get the current score with decay applied (does not mutate).
@@ -140,12 +147,28 @@ const SUCCESS_OBSERVATION: f64 = 1.0;
 const FAILURE_OBSERVATION: f64 = 0.0;
 
 /// Statistics update type for recording peer interaction outcomes
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum NodeStatisticsUpdate {
     /// Peer provided a correct response
     CorrectResponse,
     /// Peer failed to provide a response
     FailedResponse,
+}
+
+impl NodeStatisticsUpdate {
+    const fn observation(self) -> f64 {
+        match self {
+            Self::CorrectResponse => SUCCESS_OBSERVATION,
+            Self::FailedResponse => FAILURE_OBSERVATION,
+        }
+    }
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::CorrectResponse => "correct_response",
+            Self::FailedResponse => "failed_response",
+        }
+    }
 }
 
 /// Serializable trust snapshot for persistence across restarts.
@@ -191,6 +214,16 @@ impl TrustEngine {
         self.update_node_stats_weighted(node_id, update, 1.0);
     }
 
+    /// Record a peer interaction outcome with an internal reason label.
+    pub(crate) fn update_node_stats_with_reason(
+        &self,
+        node_id: &PeerId,
+        update: NodeStatisticsUpdate,
+        reason: &'static str,
+    ) {
+        self.update_node_stats_weighted_with_reason(node_id, update, 1.0, reason);
+    }
+
     /// Record a peer interaction outcome with an explicit weight.
     ///
     /// Weight `1.0` is equivalent to a single internal event. Higher weights
@@ -202,15 +235,36 @@ impl TrustEngine {
         update: NodeStatisticsUpdate,
         weight: f64,
     ) {
-        let mut peers = self.peers.write();
-        let entry = peers.entry(*node_id).or_insert_with(PeerTrust::new);
+        self.update_node_stats_weighted_with_reason(node_id, update, weight, update.as_str());
+    }
 
-        let observation = match update {
-            NodeStatisticsUpdate::CorrectResponse => SUCCESS_OBSERVATION,
-            NodeStatisticsUpdate::FailedResponse => FAILURE_OBSERVATION,
+    /// Record a weighted peer interaction outcome with an internal reason label.
+    pub(crate) fn update_node_stats_weighted_with_reason(
+        &self,
+        node_id: &PeerId,
+        update: NodeStatisticsUpdate,
+        weight: f64,
+        reason: &'static str,
+    ) {
+        let score_change = {
+            let mut peers = self.peers.write();
+            let entry = peers.entry(*node_id).or_insert_with(PeerTrust::new);
+
+            entry.record_weighted(update.observation(), weight)
         };
 
-        entry.record_weighted(observation, weight);
+        if let Some((previous_score, current_score)) = score_change {
+            info!(
+                peer_id = %node_id.to_hex(),
+                reason = %reason,
+                update = %update.as_str(),
+                previous_score,
+                current_score,
+                delta = current_score - previous_score,
+                weight,
+                "peer trust score changed"
+            );
+        }
     }
 
     /// Get current trust score for a peer (synchronous).

--- a/src/dht/core_engine.rs
+++ b/src/dht/core_engine.rs
@@ -1352,6 +1352,94 @@ pub enum AdmissionResult {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PeerSwapReason {
+    BucketIpDiversity,
+    CloseGroupIpDiversity,
+    LowTrust,
+}
+
+impl PeerSwapReason {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::BucketIpDiversity => "bucket_ip_diversity",
+            Self::CloseGroupIpDiversity => "close_group_ip_diversity",
+            Self::LowTrust => "trust_below_swap_threshold",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PlannedPeerSwap {
+    peer_id: PeerId,
+    reason: PeerSwapReason,
+    evicted_trust_score: Option<f64>,
+    swap_threshold: Option<f64>,
+}
+
+impl PlannedPeerSwap {
+    const fn new(peer_id: PeerId, reason: PeerSwapReason) -> Self {
+        Self {
+            peer_id,
+            reason,
+            evicted_trust_score: None,
+            swap_threshold: None,
+        }
+    }
+
+    const fn trust_based(peer_id: PeerId, evicted_trust_score: f64, swap_threshold: f64) -> Self {
+        Self {
+            peer_id,
+            reason: PeerSwapReason::LowTrust,
+            evicted_trust_score: Some(evicted_trust_score),
+            swap_threshold: Some(swap_threshold),
+        }
+    }
+}
+
+fn planned_swaps_contain(swaps: &[PlannedPeerSwap], peer_id: &PeerId) -> bool {
+    swaps.iter().any(|swap| swap.peer_id == *peer_id)
+}
+
+fn peer_ids_to_hex(peer_ids: &[PeerId]) -> Vec<String> {
+    peer_ids.iter().map(PeerId::to_hex).collect()
+}
+
+fn log_k_closest_peer_swap(
+    added_peer_id: &PeerId,
+    executed_swaps: &[PlannedPeerSwap],
+    k_before: &[PeerId],
+    k_after: &[PeerId],
+) {
+    if executed_swaps.is_empty() || k_before == k_after {
+        return;
+    }
+
+    let old_k_closest_peer_ids = peer_ids_to_hex(k_before);
+    let new_k_closest_peer_ids = peer_ids_to_hex(k_after);
+    let added_to_k_closest = k_after.contains(added_peer_id) && !k_before.contains(added_peer_id);
+
+    for swap in executed_swaps {
+        let removed_from_k_closest = k_before.contains(&swap.peer_id);
+        if !removed_from_k_closest && !added_to_k_closest {
+            continue;
+        }
+
+        tracing::info!(
+            added_peer_id = %added_peer_id.to_hex(),
+            removed_peer_id = %swap.peer_id.to_hex(),
+            reason = %swap.reason.as_str(),
+            removed_from_k_closest,
+            added_to_k_closest,
+            evicted_trust_score = ?swap.evicted_trust_score,
+            swap_threshold = ?swap.swap_threshold,
+            old_k_closest_peer_ids = ?old_k_closest_peer_ids,
+            new_k_closest_peer_ids = ?new_k_closest_peer_ids,
+            "K-closest peer swap completed"
+        );
+    }
+}
+
 /// Main DHT Core Engine
 pub struct DhtCoreEngine {
     node_id: PeerId,
@@ -2325,7 +2413,7 @@ impl DhtCoreEngine {
         // After identifying a swap for one IP, exclude that peer from subsequent
         // checks so that each IP sees the state after prior swaps — preventing
         // over-eviction when a candidate has multiple IPs.
-        let mut all_bucket_swaps: Vec<PeerId> = Vec::new();
+        let mut all_bucket_swaps: Vec<PlannedPeerSwap> = Vec::new();
         for &candidate_ip in candidate_ips {
             if candidate_ip.is_loopback() {
                 continue;
@@ -2333,7 +2421,7 @@ impl DhtCoreEngine {
             let bucket_view: Vec<NodeInfo> = routing.buckets[bucket_idx]
                 .nodes
                 .iter()
-                .filter(|n| !all_bucket_swaps.contains(&n.id))
+                .filter(|n| !planned_swaps_contain(&all_bucket_swaps, &n.id))
                 .cloned()
                 .collect();
             let swap = self.find_ip_swap_in_scope(
@@ -2345,9 +2433,9 @@ impl DhtCoreEngine {
                 trust_score,
             )?;
             if let Some(id) = swap
-                && !all_bucket_swaps.contains(&id)
+                && !planned_swaps_contain(&all_bucket_swaps, &id)
             {
-                all_bucket_swaps.push(id);
+                all_bucket_swaps.push(PlannedPeerSwap::new(id, PeerSwapReason::BucketIpDiversity));
             }
         }
 
@@ -2356,26 +2444,26 @@ impl DhtCoreEngine {
 
         let effective_close_len = close_group
             .iter()
-            .filter(|n| !all_bucket_swaps.contains(&n.id))
+            .filter(|n| !planned_swaps_contain(&all_bucket_swaps, &n.id))
             .count();
 
         let candidate_in_close = effective_close_len < self.k_value
             || close_group
                 .iter()
-                .rfind(|n| !all_bucket_swaps.contains(&n.id))
+                .rfind(|n| !planned_swaps_contain(&all_bucket_swaps, &n.id))
                 .map(|n| {
                     candidate_distance
                         < xor_distance_bytes(self.node_id.to_bytes(), n.id.to_bytes())
                 })
                 .unwrap_or(true);
 
-        let mut all_close_swaps: Vec<PeerId> = Vec::new();
+        let mut all_close_swaps: Vec<PlannedPeerSwap> = Vec::new();
 
         if candidate_in_close {
             // Build hypothetical close group as Vec<NodeInfo>
             let mut hyp_close: Vec<NodeInfo> = close_group
                 .iter()
-                .filter(|n| !all_bucket_swaps.contains(&n.id) && n.id != node.id)
+                .filter(|n| !planned_swaps_contain(&all_bucket_swaps, &n.id) && n.id != node.id)
                 .cloned()
                 .collect();
             hyp_close.push(node.clone());
@@ -2395,7 +2483,7 @@ impl DhtCoreEngine {
                 }
                 let close_view: Vec<NodeInfo> = hyp_close
                     .iter()
-                    .filter(|n| !all_close_swaps.contains(&n.id))
+                    .filter(|n| !planned_swaps_contain(&all_close_swaps, &n.id))
                     .cloned()
                     .collect();
                 let swap = self.find_ip_swap_in_scope(
@@ -2408,8 +2496,13 @@ impl DhtCoreEngine {
                 )?;
                 if let Some(id) = swap {
                     // Deduplicate: don't plan a close swap that's already a bucket swap
-                    if !all_bucket_swaps.contains(&id) && !all_close_swaps.contains(&id) {
-                        all_close_swaps.push(id);
+                    if !planned_swaps_contain(&all_bucket_swaps, &id)
+                        && !planned_swaps_contain(&all_close_swaps, &id)
+                    {
+                        all_close_swaps.push(PlannedPeerSwap::new(
+                            id,
+                            PeerSwapReason::CloseGroupIpDiversity,
+                        ));
                     }
                 }
             }
@@ -2424,7 +2517,7 @@ impl DhtCoreEngine {
             let swap_frees_slot = !all_bucket_swaps.is_empty()
                 || all_close_swaps
                     .iter()
-                    .any(|id| routing.get_bucket_index(id) == Some(bucket_idx));
+                    .any(|swap| routing.get_bucket_index(&swap.peer_id) == Some(bucket_idx));
             if !already_exists && !has_room && !swap_frees_slot {
                 // --- Trust-based swap-out (lazy eviction) ---
                 // When a bucket is full and no IP-diversity swap is available,
@@ -2442,8 +2535,12 @@ impl DhtCoreEngine {
                             a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
                         });
 
-                    if let Some((swap_id, _)) = lowest {
-                        all_bucket_swaps.push(swap_id);
+                    if let Some((swap_id, score)) = lowest {
+                        all_bucket_swaps.push(PlannedPeerSwap::trust_based(
+                            swap_id,
+                            score,
+                            self.swap_threshold,
+                        ));
                     }
                 }
 
@@ -2451,7 +2548,7 @@ impl DhtCoreEngine {
                 let swap_frees_slot_now = !all_bucket_swaps.is_empty()
                     || all_close_swaps
                         .iter()
-                        .any(|id| routing.get_bucket_index(id) == Some(bucket_idx));
+                        .any(|swap| routing.get_bucket_index(&swap.peer_id) == Some(bucket_idx));
 
                 if !swap_frees_slot_now {
                     if allow_stale_revalidation {
@@ -2466,15 +2563,17 @@ impl DhtCoreEngine {
                         // bucket-level set. Evicting these may resolve the close-group
                         // diversity violation and (if they happen to reside in the same
                         // bucket) free capacity for the candidate.
-                        for close_swap_id in &all_close_swaps {
-                            if stale_peers.iter().any(|(id, _)| id == close_swap_id) {
+                        for close_swap in &all_close_swaps {
+                            if stale_peers.iter().any(|(id, _)| id == &close_swap.peer_id) {
                                 continue;
                             }
-                            if let Some(swap_bucket_idx) = routing.get_bucket_index(close_swap_id)
-                                && let Some(swap_node) = routing.find_node_by_id(close_swap_id)
+                            if let Some(swap_bucket_idx) =
+                                routing.get_bucket_index(&close_swap.peer_id)
+                                && let Some(swap_node) =
+                                    routing.find_node_by_id(&close_swap.peer_id)
                                 && swap_node.last_seen.elapsed() > self.live_threshold
                             {
-                                stale_peers.push((*close_swap_id, swap_bucket_idx));
+                                stale_peers.push((close_swap.peer_id, swap_bucket_idx));
                             }
                         }
 
@@ -2500,15 +2599,15 @@ impl DhtCoreEngine {
         let k_before = routing.k_closest_ids(self.k_value);
 
         // === Execute all swaps (deduplicated) ===
-        let mut executed: Vec<PeerId> = Vec::with_capacity(2);
-        for swap_id in all_bucket_swaps
+        let mut executed: Vec<PlannedPeerSwap> = Vec::with_capacity(2);
+        for swap in all_bucket_swaps
             .iter()
             .chain(all_close_swaps.iter())
             .copied()
         {
-            if !executed.contains(&swap_id) {
-                routing.remove_node(&swap_id);
-                executed.push(swap_id);
+            if !planned_swaps_contain(&executed, &swap.peer_id) {
+                routing.remove_node(&swap.peer_id);
+                executed.push(swap);
             }
         }
 
@@ -2516,14 +2615,15 @@ impl DhtCoreEngine {
 
         // === Build events ===
         let mut events: Vec<RoutingTableEvent> = Vec::with_capacity(executed.len() + 2);
-        for removed_id in &executed {
-            events.push(RoutingTableEvent::PeerRemoved(*removed_id));
+        for removed in &executed {
+            events.push(RoutingTableEvent::PeerRemoved(removed.peer_id));
         }
         events.push(RoutingTableEvent::PeerAdded(peer_id));
 
         // === Snapshot K-closest AFTER mutation ===
         let k_after = routing.k_closest_ids(self.k_value);
         if k_before != k_after {
+            log_k_closest_peer_swap(&peer_id, &executed, &k_before, &k_after);
             events.push(RoutingTableEvent::KClosestPeersChanged {
                 old: k_before,
                 new: k_after,

--- a/src/dht_network_manager.rs
+++ b/src/dht_network_manager.rs
@@ -20,8 +20,8 @@
 
 use crate::{
     P2PError, PeerId, Result,
-    adaptive::TrustEngine,
     adaptive::trust::DEFAULT_NEUTRAL_TRUST,
+    adaptive::{NodeStatisticsUpdate, TrustEngine},
     address::{MultiAddr, is_lan_ip},
     dht::core_engine::{AddressType, AtomicInstant, BucketRefreshCandidate, NodeInfo},
     dht::{AdmissionResult, DhtCoreEngine, DhtKey, Key, RoutingTableEvent},
@@ -227,6 +227,15 @@ const DIAL_FAILURE_CACHE_TTL: Duration = Duration::from_secs(30 * 60);
 /// success-clears-immediately guards against suppressing a live IP because
 /// one peer behind a shared NAT IP churned.
 const DIAL_FAILURE_IP_SUPPRESS_THRESHOLD: usize = 4;
+
+/// Trust-score log reason for a failed pre-request dial.
+const TRUST_REASON_DHT_DIAL_FAILED: &str = "dht_dial_failed";
+
+/// Trust-score log reason for a failed post-dial identity exchange.
+const TRUST_REASON_DHT_IDENTITY_EXCHANGE_FAILED: &str = "dht_identity_exchange_failed";
+
+/// Trust-score log reason for a sent DHT request that failed or timed out.
+const TRUST_REASON_DHT_REQUEST_FAILED: &str = "dht_request_failed";
 
 /// Worst-case number of addresses
 /// [`DhtNetworkManager::select_dial_candidates_with_context`] returns for a
@@ -3335,11 +3344,12 @@ impl DhtNetworkManager {
             })
     }
 
-    async fn record_peer_failure(&self, peer_id: &PeerId) {
+    async fn record_peer_failure(&self, peer_id: &PeerId, reason: &'static str) {
         if let Some(ref engine) = self.trust_engine {
-            engine.update_node_stats(
+            engine.update_node_stats_with_reason(
                 peer_id,
-                crate::adaptive::NodeStatisticsUpdate::FailedResponse,
+                NodeStatisticsUpdate::FailedResponse,
+                reason,
             );
         }
     }
@@ -3517,7 +3527,8 @@ impl DhtNetworkManager {
                 peer_hex,
                 candidates.len()
             );
-            self.record_peer_failure(peer_id).await;
+            self.record_peer_failure(peer_id, TRUST_REASON_DHT_DIAL_FAILED)
+                .await;
             return PendingDialOutcome::DialFailed {
                 candidates_count: candidates.len(),
             };
@@ -3574,7 +3585,8 @@ impl DhtNetworkManager {
                     local_hex, peer_hex, e
                 );
                 self.transport.disconnect_channel(&channel_id).await;
-                self.record_peer_failure(peer_id).await;
+                self.record_peer_failure(peer_id, TRUST_REASON_DHT_IDENTITY_EXCHANGE_FAILED)
+                    .await;
                 // Suppress further dials to this peer for
                 // [`IDENTITY_FAILURE_CACHE_TTL`] so that the next
                 // iterative DHT lookup (or chunk-fetch close-group
@@ -3791,7 +3803,8 @@ impl DhtNetworkManager {
         // Record trust failure at the RPC level so every failed request
         // (send error, response timeout, etc.) is counted exactly once.
         if result.is_err() {
-            self.record_peer_failure(peer_id).await;
+            self.record_peer_failure(peer_id, TRUST_REASON_DHT_REQUEST_FAILED)
+                .await;
         }
 
         result


### PR DESCRIPTION
## Summary
- add info-level trust score change logs with peer ID, reason, update type, previous/current score, delta, and weight
- propagate semantic trust reasons from adaptive trust events and DHT request failures
- log K-closest peer swaps with added/removed peer IDs, swap reason, trust threshold metadata, and old/new close-group sets

## Semver
- feat: semver-minor observability addition

## Tests
- cargo fmt --all -- --check
- cargo test --all-features trust_swap_out
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --all-features -- -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used