### PR TITLE
feat(network): reconnect-on-demand for P2PNode::send_request

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -1036,22 +1036,128 @@ impl P2PNode {
         data: Vec<u8>,
         timeout: Duration,
     ) -> Result<PeerResponse> {
+        let result = self
+            .send_request_reconnecting(peer_id, protocol, data, timeout)
+            .await;
+        if let Err(ref e) = result {
+            let event = if matches!(e, P2PError::Timeout(_)) {
+                TrustEvent::ConnectionTimeout
+            } else {
+                TrustEvent::ConnectionFailed
+            };
+            self.report_trust_event(peer_id, event).await;
+        }
+        result
+    }
+
+    /// Request/response send with reconnect-on-demand.
+    ///
+    /// Mirrors [`Self::send_message`]: when there is no live channel to
+    /// `peer_id` it dials one (serialised per peer via
+    /// [`Self::reconnect_lock_for`]) before sending, and when an existing
+    /// channel turns out to be stale it tears it down, reconnects, and retries
+    /// the request exactly once. The plain transport `send_request` only sends
+    /// over a pre-existing channel and fails fast with `PeerNotFound`
+    /// otherwise; routing request/response through this reconnecting path means
+    /// a request to a peer whose QUIC connection has dropped (e.g. a periodic
+    /// audit of a close peer that idled out) re-establishes the connection
+    /// instead of surfacing as a spurious timeout.
+    ///
+    /// `timeout` bounds only the response wait inside the transport; the dial
+    /// is independently bounded by `connect_peer_typed` plus
+    /// [`IDENTITY_EXCHANGE_TIMEOUT`].
+    async fn send_request_reconnecting(
+        &self,
+        peer_id: &PeerId,
+        protocol: &str,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<PeerResponse> {
+        // Snapshot channel IDs before the send attempt — transport.send_request
+        // prunes dead channels from bookkeeping but does NOT close the
+        // underlying QUIC connection. We need the original IDs for
+        // disconnect_channel later.
+        let existing_channels = self.transport.channels_for_peer(peer_id).await;
+
+        // No live channel — serialise dials so concurrent requests to the same
+        // unconnected peer don't each open their own QUIC connection.
+        if existing_channels.is_empty() {
+            // Hold the per-peer reconnect lock only across the dial so
+            // concurrent requests to the same cold peer collapse onto one dial —
+            // not across the response wait, which would serialise every such
+            // request for the full `timeout`.
+            {
+                let lock = self.reconnect_lock_for(peer_id);
+                let _guard = lock.lock().await;
+                // Another caller may have connected while we waited for the lock.
+                if !self.transport.is_peer_connected(peer_id).await {
+                    self.ensure_channel(peer_id, &[], &[], &[]).await?;
+                }
+            }
+            return self
+                .transport
+                .send_request(peer_id, protocol, data, timeout)
+                .await;
+        }
+
+        // Snapshot addresses before the attempt — transport.send_request prunes
+        // stale channels, which removes peer_info.
+        let saved_addrs: Vec<MultiAddr> = self
+            .transport
+            .peer_info(peer_id)
+            .await
+            .map(|info| info.addresses)
+            .unwrap_or_default();
+
+        // Clone the payload for a possible retry — transport.send_request
+        // consumes the Vec, and only stale-channel failures are retried.
+        let retry_data = data.clone();
+
+        // Fast path: try the existing connection.
         match self
             .transport
             .send_request(peer_id, protocol, data, timeout)
             .await
         {
-            Ok(resp) => Ok(resp),
+            Ok(resp) => return Ok(resp),
             Err(e) => {
-                let event = if matches!(&e, P2PError::Timeout(_)) {
-                    TrustEvent::ConnectionTimeout
-                } else {
-                    TrustEvent::ConnectionFailed
-                };
-                self.report_trust_event(peer_id, event).await;
-                Err(e)
+                // A response-deadline timeout means the request WAS delivered
+                // but went unanswered — reconnecting would not help, so do not
+                // retry. Only a stale-channel send failure warrants a redial.
+                if !e.is_stale_channel_send_failure() {
+                    return Err(e);
+                }
+                debug!(
+                    peer = %peer_id.to_hex(),
+                    error = %e,
+                    "stale channel request failed, attempting reconnect",
+                );
             }
         }
+
+        // Serialise the reconnect (stale-channel teardown + dial) so concurrent
+        // requests to the same stale peer don't race to dial, but release the
+        // lock before the response wait so they don't serialise for the full
+        // `timeout`.
+        {
+            let lock = self.reconnect_lock_for(peer_id);
+            let _guard = lock.lock().await;
+
+            // Another caller may have reconnected while we waited for the lock.
+            if self.transport.is_peer_connected(peer_id).await {
+                // Close stale QUIC connections that transport.send_request's
+                // bookkeeping cleanup didn't tear down (it only drops the mapping).
+                for channel_id in &existing_channels {
+                    self.transport.disconnect_channel(channel_id).await;
+                }
+            } else {
+                self.ensure_channel(peer_id, &[], &saved_addrs, &existing_channels)
+                    .await?;
+            }
+        }
+        self.transport
+            .send_request(peer_id, protocol, retry_data, timeout)
+            .await
     }
 
     pub async fn send_response(
@@ -1573,12 +1679,23 @@ impl P2PNode {
         .await
     }
 
-    /// Tear down stale channels, reconnect to a peer, and send a message.
-    async fn reconnect_and_send(
+    /// Ensure an identity-authenticated channel to `peer_id` exists, dialing a
+    /// fresh connection when necessary.
+    ///
+    /// Resolves a dial address (caller-provided > saved > DHT routing table),
+    /// tears down any stale channels, dials, waits for the identity exchange,
+    /// and verifies the authenticated peer matches `peer_id`. On success the
+    /// transport's `peer_to_channel` map is populated, so a subsequent
+    /// `send_message` / `send_request` finds the channel instead of failing
+    /// with `PeerNotFound`. Returns `PeerNotFound` when no dialable address is
+    /// available.
+    ///
+    /// Shared by [`Self::reconnect_and_send`] and
+    /// [`Self::send_request_reconnecting`] so both gain identical dial
+    /// behaviour.
+    async fn ensure_channel(
         &self,
         peer_id: &PeerId,
-        protocol: &str,
-        data: Vec<u8>,
         addrs: &[MultiAddr],
         saved_addrs: &[MultiAddr],
         stale_channels: &[String],
@@ -1627,6 +1744,21 @@ impl P2PNode {
             }));
         }
 
+        Ok(())
+    }
+
+    /// Tear down stale channels, reconnect to a peer, and send a message.
+    async fn reconnect_and_send(
+        &self,
+        peer_id: &PeerId,
+        protocol: &str,
+        data: Vec<u8>,
+        addrs: &[MultiAddr],
+        saved_addrs: &[MultiAddr],
+        stale_channels: &[String],
+    ) -> Result<()> {
+        self.ensure_channel(peer_id, addrs, saved_addrs, stale_channels)
+            .await?;
         // Send on the fresh connection.
         self.transport.send_message(peer_id, protocol, data).await
     }

--- a/tests/stale_session_reconnect.rs
+++ b/tests/stale_session_reconnect.rs
@@ -13,15 +13,15 @@
 
 //! Integration test: stale QUIC session recovery.
 //!
-//! Verifies that `send_message` transparently reconnects when the underlying
-//! QUIC connection is dead but the channel bookkeeping still considers it
-//! alive.  This exercises the reconnect-and-retry path in
-//! `P2PNode::send_message`.
+//! Verifies that `send_message` and `send_request` transparently reconnect when
+//! the underlying QUIC connection is dead but the channel bookkeeping still
+//! considers it alive.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use saorsa_core::{NodeConfig, P2PNode, PeerId};
+use saorsa_core::{NodeConfig, P2PEvent, P2PNode, PeerId};
 use std::time::Duration;
+use tokio::sync::broadcast;
 use tokio::time::timeout;
 
 /// Maximum time to wait for node_b to recognise node_a after initial dial.
@@ -32,6 +32,30 @@ const QUIC_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Polling interval when waiting for bilateral connection.
 const CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Time to wait for QUIC close propagation before sending on stale local state.
+const QUIC_CLOSE_PROPAGATION_GRACE: Duration = Duration::from_millis(200);
+
+/// Outer bound for reconnecting request/response operations in this test.
+const REQUEST_RECONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Response deadline passed into `send_request`.
+const REQUEST_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Maximum time for the responder to observe an incoming request event.
+const RESPONDER_EVENT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Request/response application protocol used by stale-session tests.
+const REQUEST_PROTOCOL: &str = "test_echo";
+
+/// Wire topic emitted for request/response messages on `REQUEST_PROTOCOL`.
+const REQUEST_TOPIC: &str = "/rr/test_echo";
+
+/// Payload sent after the stale channel is detected.
+const REQUEST_AFTER_DISCONNECT: &[u8] = b"request after disconnect";
+
+/// Response payload returned by the target after reconnect.
+const RESPONSE_AFTER_RECONNECT: &[u8] = b"response after reconnect";
 
 /// Helper: local loopback, ephemeral port, IPv4-only config.
 fn test_config() -> NodeConfig {
@@ -108,6 +132,57 @@ async fn connected_pair() -> (P2PNode, PeerId, P2PNode, PeerId) {
     (node_a, peer_a, node_b, peer_b)
 }
 
+async fn respond_to_next_request(
+    node: &P2PNode,
+    requester: PeerId,
+    expected_payload: &[u8],
+    response_payload: &[u8],
+    events_rx: &mut broadcast::Receiver<P2PEvent>,
+) {
+    let response_result = timeout(RESPONDER_EVENT_TIMEOUT, async {
+        loop {
+            let event = events_rx
+                .recv()
+                .await
+                .expect("event stream should stay open");
+            let P2PEvent::Message {
+                topic,
+                source,
+                data,
+                ..
+            } = event
+            else {
+                continue;
+            };
+
+            if topic != REQUEST_TOPIC || source != Some(requester) {
+                continue;
+            }
+
+            let (message_id, is_response, payload) = P2PNode::parse_request_envelope(&data)
+                .expect("request/response envelope should parse");
+            assert!(!is_response, "responder should receive a request envelope");
+            assert_eq!(payload, expected_payload);
+
+            node.send_response(
+                &requester,
+                REQUEST_PROTOCOL,
+                &message_id,
+                response_payload.to_vec(),
+            )
+            .await
+            .expect("send_response should succeed");
+            break;
+        }
+    })
+    .await;
+    assert!(
+        response_result.is_ok(),
+        "responder should receive request within {:?}",
+        RESPONDER_EVENT_TIMEOUT,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Target-side disconnect (the common real-world scenario)
 // ---------------------------------------------------------------------------
@@ -138,7 +213,7 @@ async fn send_recovers_when_target_drops_connection() {
     node_b.disconnect_peer(&peer_a).await.unwrap();
 
     // Brief pause so the QUIC close propagates at the transport level.
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    tokio::time::sleep(QUIC_CLOSE_PROPAGATION_GRACE).await;
 
     // node_a still thinks it's connected, but the next send should fail on
     // the dead QUIC session, trigger reconnect, and succeed on a fresh
@@ -154,6 +229,51 @@ async fn send_recovers_when_target_drops_connection() {
         "send_message should recover after target drops connection: {:?}",
         post_result.unwrap_err()
     );
+
+    node_a.stop().await.unwrap();
+    node_b.stop().await.unwrap();
+}
+
+/// `send_request` should also detect the stale channel, reconnect, deliver the
+/// request, and route the response back to the original caller.
+#[tokio::test]
+async fn send_request_recovers_when_target_drops_connection() {
+    let (node_a, peer_a, node_b, peer_b) = connected_pair().await;
+    let mut events_rx = node_b.subscribe_events();
+
+    node_b.disconnect_peer(&peer_a).await.unwrap();
+    tokio::time::sleep(QUIC_CLOSE_PROPAGATION_GRACE).await;
+
+    let request = timeout(
+        REQUEST_RECONNECT_TIMEOUT,
+        node_a.send_request(
+            &peer_b,
+            REQUEST_PROTOCOL,
+            REQUEST_AFTER_DISCONNECT.to_vec(),
+            REQUEST_RESPONSE_TIMEOUT,
+        ),
+    );
+    let responder = respond_to_next_request(
+        &node_b,
+        peer_a,
+        REQUEST_AFTER_DISCONNECT,
+        RESPONSE_AFTER_RECONNECT,
+        &mut events_rx,
+    );
+
+    tokio::pin!(request);
+    tokio::pin!(responder);
+
+    let request_result = tokio::select! {
+        result = &mut request => result,
+        () = &mut responder => request.await,
+    };
+    let response = request_result
+        .expect("send_request should not exceed outer reconnect timeout")
+        .expect("send_request should recover after target drops connection");
+
+    assert_eq!(response.peer_id, peer_b);
+    assert_eq!(response.data, RESPONSE_AFTER_RECONNECT);
 
     node_a.stop().await.unwrap();
     node_b.stop().await.unwrap();


### PR DESCRIPTION
## Problem

`P2PNode::send_request` (the request/response path) only sent over a
pre-existing channel: it delegated to `transport.send_request` →
`transport.send_message`, which returns `PeerNotFound` immediately when there
is no live channel to the peer, with **no dial attempt**. The one-way
`P2PNode::send_message` already reconnected on demand, and the DHT path dialed
via `ensure_peer_channel`, but generic request/response did not.

Consumers of request/response include the replication **responsible-chunk audit**,
prune-confirmation, fetch, verification, and neighbor sync. QUIC connection
liveness and DHT routing-table membership are decoupled (keep-alive maintains
*existing* connections but nothing re-dials a dropped one), so a request to a
close peer whose connection had idled out / dropped surfaced as an instant
failure — e.g. a periodic audit recording a spurious timeout against a peer that
was perfectly reachable.

## Change

- Extract the dial logic out of `reconnect_and_send` into a shared
  `ensure_channel` helper (resolve dial address → tear down stale channels →
  dial → wait for identity exchange → verify peer id). `reconnect_and_send` now
  calls it then sends, so **`send_message` behaviour is unchanged**.
- Route `send_request` through a new `send_request_reconnecting` that mirrors
  `send_message`:
  - dials when there is no live channel, serialised per peer via the existing
    reconnect lock so concurrent requests to one cold peer collapse onto a
    single dial;
  - on a **stale-channel** send failure, tears down and reconnects, retrying the
    request exactly once. A response-deadline **timeout** is *not* retried — the
    request was delivered but unanswered, so a redial would not help;
  - holds the reconnect lock only across the dial, not the response wait, so
    concurrent requests to the same peer don't serialise for the full `timeout`.

`timeout` still bounds only the response wait; the dial is independently bounded
by `connect_peer_typed` + `IDENTITY_EXCHANGE_TIMEOUT`.

## Compatibility

All public signatures are unchanged, so every existing caller is unaffected and
transparently gains reconnect-on-demand.

## Testing

- `cargo build --lib`, `cargo fmt --all -- --check`, `cargo clippy --lib -- -D warnings` — clean.
- `cargo test --lib network::` — 44 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)