### PR TITLE
chore(release): promote rc-2026.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.26.4-rc.1"
+version = "0.26.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2584,8 +2584,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.35.3-rc.1"
-source = "git+https://github.com/saorsa-labs/saorsa-transport?branch=rc-2026.7.4#613a55326d735632aa203d1438d84ed48e32e934"
+version = "0.35.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3284026c300f642077315b782462b22558e24d621265a8deeae23287b1c5542"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.26.3"
+version = "0.26.4-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2584,9 +2584,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.35.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbc31faa4bd1f51807dd3815950212005613e512f6b400715067b78c2fb9603"
+version = "0.35.3-rc.1"
+source = "git+https://github.com/saorsa-labs/saorsa-transport?branch=rc-2026.7.4#613a55326d735632aa203d1438d84ed48e32e934"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "saorsa-core"
 # 0.22.0: MASQUE relay data plane, upgrade saorsa-transport to 0.31.0
 # 0.24.0: upgrade saorsa-transport to 0.33.0
 # 0.24.1: release candidate fixes
-version = "0.26.3"
+version = "0.26.4-rc.1"
 edition = "2024"
 authors = ["Saorsa Labs Limited <david@saorsalabs.com>"]
 license = "AGPL-3.0"
@@ -64,7 +64,7 @@ once_cell = "1.21"
 dashmap = "6"
 
 # Networking
-saorsa-transport = "0.35.2"
+saorsa-transport = { git = "https://github.com/saorsa-labs/saorsa-transport", branch = "rc-2026.7.4" }
 
 # Core-specific dependencies
 dirs = "6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "saorsa-core"
 # 0.22.0: MASQUE relay data plane, upgrade saorsa-transport to 0.31.0
 # 0.24.0: upgrade saorsa-transport to 0.33.0
 # 0.24.1: release candidate fixes
-version = "0.26.4-rc.1"
+version = "0.26.4"
 edition = "2024"
 authors = ["Saorsa Labs Limited <david@saorsalabs.com>"]
 license = "AGPL-3.0"
@@ -64,7 +64,7 @@ once_cell = "1.21"
 dashmap = "6"
 
 # Networking
-saorsa-transport = { git = "https://github.com/saorsa-labs/saorsa-transport", branch = "rc-2026.7.4" }
+saorsa-transport = "0.35.3"
 
 # Core-specific dependencies
 dirs = "6.0"


### PR DESCRIPTION
Promotes `rc-2026.7.4` to release version(s): 0.26.4.

- strips `-rc.*` from `[package].version`
- rewrites internal git+branch deps to crates.io version pins
- regenerates `Cargo.lock`

Once merged, the release tag will be pushed to fire the publish workflow.