### PR TITLE
fix(bootstrap): age-bound and refresh close-group cache

### DIFF
--- a/docs/adr/ADR-016-close-group-cache-validity.md
+++ b/docs/adr/ADR-016-close-group-cache-validity.md
@@ -1,0 +1,91 @@
+# ADR-016: Age-Bounded, Periodically Refreshed Close-Group Cache
+
+## Status
+
+Proposed
+
+## Context
+
+`saorsa-core` already persists `close_group_cache.json` when a cache directory is configured. On startup, cached peers are assigned bootstrap Priority 0 and their trust scores are imported before configured bootstrap peers are tried.
+
+The live implementation saves this snapshot after initial bootstrap and during graceful shutdown. It does not refresh the cache periodically during normal operation and does not enforce a maximum snapshot age when loading it. A node that runs for a long time and then exits ungracefully can therefore restart with an old, but structurally valid, view of peers and trust.
+
+This does not make a stale cached peer permanently authoritative: bootstrap already falls through to configured peers when cached peers fail. It can nevertheless delay or bias restart bootstrap, and it makes stale-cache behaviour difficult to distinguish from a live bootstrap or partition problem.
+
+ADR-008 records an older direction in which `saorsa-core` did not retain peer contact state. It is already marked Superseded. The close-group cache on current `main` is a narrower mechanism: it snapshots the node's current XOR-close peers and trust, rather than maintaining a general history of peer contact outcomes. This ADR documents and bounds that current mechanism.
+
+## Decision
+
+When `close_group_cache_dir` is configured:
+
+1. Cache validity is determined from the snapshot's persisted `saved_at_epoch_secs`, not filesystem modification time.
+2. `NodeConfig::close_group_cache_max_age` controls the maximum age of a snapshot used at startup.
+   - The backwards-compatible default is one hour.
+   - `None` explicitly disables age enforcement.
+   - A snapshot exactly at the limit remains valid; one older than the limit is stale.
+   - Future timestamps are treated as age zero using saturating subtraction to tolerate local clock correction.
+3. A stale snapshot is skipped as a whole:
+   - its trust scores are not imported;
+   - its peers are not inserted as Priority-0 bootstrap candidates;
+   - configured bootstrap peers remain available through the existing fallback path;
+   - the skip is logged with observed and configured age.
+4. The node refreshes the snapshot during normal running at the configured DHT refresh cadence, with a one-minute lower bound to prevent a hot write loop from unusually short refresh settings.
+5. The first periodic tick occurs after one full interval. The existing post-bootstrap save remains the initial snapshot.
+6. Periodic persistence has a dedicated cancellation token and tracked task handle. Shutdown cancels and joins that task before performing the final authoritative snapshot, preventing a late periodic write from racing the shutdown save.
+7. Existing atomic temp-file persistence and fail-soft startup behaviour remain unchanged. A load or save error is logged and does not stop node startup or shutdown.
+
+The cache remains local advisory bootstrap material. This ADR does not make cached records signed, encrypted, remotely supplied, or a substitute for configured bootstrap peers and live DHT discovery.
+
+## Consequences
+
+### Positive
+
+- Restart does not prioritise indefinitely old peer and trust state by default.
+- Long-running nodes refresh the cache without relying on graceful shutdown.
+- The final shutdown snapshot cannot be replaced by a concurrent periodic write.
+- Operators can identify stale-cache rejection directly in logs.
+- Existing configurations that omit the new field receive a safe one-hour default.
+- Operators can explicitly retain legacy no-TTL behaviour when required.
+
+### Negative
+
+- Enabling a cache directory now creates one additional lightweight Tokio task.
+- Normal operation performs one small atomic JSON write per DHT refresh interval.
+- The one-hour default is an operational policy rather than a proof that every cached peer remains reachable.
+- Wall-clock correction can temporarily affect age classification.
+
+### Neutral
+
+- A fresh cached peer can still be offline. Existing bootstrap fallback handles failed cache dials.
+- Stale cache files are retained on disk and may be replaced by later successful periodic or shutdown saves; they are not deleted merely because they are stale.
+- Cache confidentiality and tamper resistance remain out of scope because the file contains peer addresses and advisory trust state, not node secret keys.
+
+## Alternatives Considered
+
+### Keep save-on-bootstrap and save-on-shutdown only
+
+Rejected because ungraceful exit after a long-running session can retain an old snapshot indefinitely.
+
+### Check filesystem modification time
+
+Rejected because the persisted timestamp travels with the snapshot semantics and is deterministic in tests; file metadata can change during copy or restore.
+
+### Validate every cached peer before admitting it
+
+Rejected as unnecessary duplication. Existing bootstrap dial and identity validation already verify reachability and identity, then fall through to configured peers.
+
+### Import stale trust but skip stale peers
+
+Rejected because one snapshot should have one validity decision. Importing stale trust can influence routing and swap decisions even when the same peer set is considered too old for bootstrap.
+
+### Abort periodic writes without joining
+
+Rejected because an in-flight periodic save could complete after the final shutdown save and replace it with an older snapshot.
+
+## References
+
+- [V2-884: Age-bound and refresh the saorsa-core close-group bootstrap cache](https://linear.app/autonominetwork/issue/V2-884/age-bound-and-refresh-the-saorsa-core-close-group-bootstrap-cache)
+- [V2-864: Production pruning/bootstrap investigation](https://linear.app/autonominetwork/issue/V2-864/pruning-defers-100-of-candidates-in-production-no-disk-space-is-ever-reclaimed)
+- [ADR-008: Bootstrap Peer Discovery Scope](./ADR-008-bootstrap-delegation.md)
+- `src/bootstrap/cache.rs`
+- `src/network.rs`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,6 +42,7 @@ An Architecture Decision Record (ADR) is a document that captures an important a
 |-----|-------|--------|---------|
 | [ADR-007](./ADR-007-adaptive-networking.md) | Adaptive Networking with ML | Accepted | Machine learning for dynamic routing optimization |
 | [ADR-008](./ADR-008-bootstrap-delegation.md) | Bootstrap Peer Discovery Scope | Superseded | Historical peer discovery design replaced by configured peers plus DHT discovery |
+| [ADR-016](./ADR-016-close-group-cache-validity.md) | Age-Bounded, Periodically Refreshed Close-Group Cache | Proposed | Bound persisted close-group age and refresh it safely during normal running |
 
 ### Messaging
 

--- a/src/bootstrap/cache.rs
+++ b/src/bootstrap/cache.rs
@@ -23,6 +23,7 @@ use crate::address::MultiAddr;
 use serde::{Deserialize, Serialize};
 use std::io::Write as _;
 use std::path::Path;
+use std::time::Duration;
 
 /// Filename used for the close group cache inside the configured directory.
 const CACHE_FILENAME: &str = "close_group_cache.json";
@@ -40,9 +41,11 @@ pub struct CachedCloseGroupPeer {
 
 /// Persisted close group snapshot with trust scores.
 ///
-/// Saved periodically and on shutdown. Loaded on startup to reconnect
-/// to the same trusted close group peers, preserving close group
-/// consistency across restarts.
+/// Saved periodically during normal operation, after initial bootstrap,
+/// and on shutdown. Loaded on startup to reconnect to the same trusted
+/// close group peers, preserving close group consistency across restarts.
+/// Stale snapshots are skipped as Priority-0 bootstrap material according
+/// to the node's configured maximum cache age.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CloseGroupCache {
     /// Close group peers with their trust scores
@@ -52,6 +55,19 @@ pub struct CloseGroupCache {
 }
 
 impl CloseGroupCache {
+    /// Return whether this snapshot is older than `max_age` relative to
+    /// `now_epoch_secs`.
+    ///
+    /// `None` disables age enforcement. A snapshot timestamp in the future is
+    /// treated as age zero through saturating subtraction rather than being
+    /// rejected because of local clock skew.
+    #[must_use]
+    pub fn is_stale(&self, now_epoch_secs: u64, max_age: Option<Duration>) -> bool {
+        max_age.is_some_and(|max_age| {
+            now_epoch_secs.saturating_sub(self.saved_at_epoch_secs) > max_age.as_secs()
+        })
+    }
+
     /// Save the cache to `{dir}/close_group_cache.json`.
     ///
     /// Uses [`tempfile::NamedTempFile::persist`] for atomicity: the temp file
@@ -175,5 +191,43 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(loaded.peers.is_empty());
+    }
+
+    #[test]
+    fn cache_staleness_respects_age_limit_and_clock_skew() {
+        let now = 10_000;
+        let max_age = Duration::from_secs(3_600);
+        let mut cache = CloseGroupCache {
+            peers: vec![],
+            saved_at_epoch_secs: now,
+        };
+
+        assert!(!cache.is_stale(now, Some(max_age)));
+        cache.saved_at_epoch_secs = now - 3_600;
+        assert!(!cache.is_stale(now, Some(max_age)));
+        cache.saved_at_epoch_secs = now - 3_601;
+        assert!(cache.is_stale(now, Some(max_age)));
+        assert!(!cache.is_stale(now, None));
+
+        cache.saved_at_epoch_secs = now + 60;
+        assert!(!cache.is_stale(now, Some(max_age)));
+    }
+
+    #[tokio::test]
+    async fn stale_age_survives_save_load_roundtrip() {
+        let now = 10_000;
+        let cache = CloseGroupCache {
+            peers: vec![],
+            saved_at_epoch_secs: now - 7_200,
+        };
+        let dir = tempfile::tempdir().unwrap();
+
+        cache.save_to_dir(dir.path()).await.unwrap();
+        let loaded = CloseGroupCache::load_from_dir(dir.path())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(loaded.is_stale(now, Some(Duration::from_secs(3_600))));
     }
 }

--- a/src/bootstrap/cache.rs
+++ b/src/bootstrap/cache.rs
@@ -28,6 +28,11 @@ use std::time::Duration;
 /// Filename used for the close group cache inside the configured directory.
 const CACHE_FILENAME: &str = "close_group_cache.json";
 
+/// Maximum tolerated wall-clock skew for a cache timestamp in the future.
+/// Larger offsets are treated as invalid so a corrupt clock cannot make a
+/// cache appear fresh indefinitely.
+const MAX_FUTURE_TIMESTAMP_SKEW: Duration = Duration::from_secs(5 * 60);
+
 /// A peer in the persisted close group cache.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CachedCloseGroupPeer {
@@ -58,11 +63,15 @@ impl CloseGroupCache {
     /// Return whether this snapshot is older than `max_age` relative to
     /// `now_epoch_secs`.
     ///
-    /// `None` disables age enforcement. A snapshot timestamp in the future is
-    /// treated as age zero through saturating subtraction rather than being
-    /// rejected because of local clock skew.
+    /// `None` disables the maximum-age check, but timestamps materially in the
+    /// future are always rejected. Small offsets are tolerated for clock skew.
     #[must_use]
     pub fn is_stale(&self, now_epoch_secs: u64, max_age: Option<Duration>) -> bool {
+        let future_skew = self.saved_at_epoch_secs.saturating_sub(now_epoch_secs);
+        if future_skew > MAX_FUTURE_TIMESTAMP_SKEW.as_secs() {
+            return true;
+        }
+
         max_age.is_some_and(|max_age| {
             now_epoch_secs.saturating_sub(self.saved_at_epoch_secs) > max_age.as_secs()
         })
@@ -178,23 +187,36 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_cache() {
-        let cache = CloseGroupCache {
+        let populated = CloseGroupCache {
+            peers: vec![CachedCloseGroupPeer {
+                peer_id: PeerId::random(),
+                addresses: vec!["/ip4/10.0.1.1/udp/9000/quic".parse().unwrap()],
+                trust: TrustRecord {
+                    score: 0.8,
+                    last_updated_epoch_secs: 1,
+                },
+            }],
+            saved_at_epoch_secs: 1,
+        };
+        let empty = CloseGroupCache {
             peers: vec![],
-            saved_at_epoch_secs: 0,
+            saved_at_epoch_secs: 2,
         };
 
         let dir = tempfile::tempdir().unwrap();
 
-        cache.save_to_dir(dir.path()).await.unwrap();
+        populated.save_to_dir(dir.path()).await.unwrap();
+        empty.save_to_dir(dir.path()).await.unwrap();
         let loaded = CloseGroupCache::load_from_dir(dir.path())
             .await
             .unwrap()
             .unwrap();
         assert!(loaded.peers.is_empty());
+        assert_eq!(loaded.saved_at_epoch_secs, 2);
     }
 
     #[test]
-    fn cache_staleness_respects_age_limit_and_clock_skew() {
+    fn cache_staleness_respects_age_limit_and_rejects_future_timestamp() {
         let now = 10_000;
         let max_age = Duration::from_secs(3_600);
         let mut cache = CloseGroupCache {
@@ -211,6 +233,11 @@ mod tests {
 
         cache.saved_at_epoch_secs = now + 60;
         assert!(!cache.is_stale(now, Some(max_age)));
+        cache.saved_at_epoch_secs = now + MAX_FUTURE_TIMESTAMP_SKEW.as_secs();
+        assert!(!cache.is_stale(now, Some(max_age)));
+        cache.saved_at_epoch_secs = now + MAX_FUTURE_TIMESTAMP_SKEW.as_secs() + 1;
+        assert!(cache.is_stale(now, Some(max_age)));
+        assert!(cache.is_stale(now, None));
     }
 
     #[tokio::test]

--- a/src/network.rs
+++ b/src/network.rs
@@ -136,6 +136,14 @@ const DEFAULT_MAX_CONNECTIONS: usize = 10_000;
 /// the historical API default.
 const DEFAULT_CONNECTION_TIMEOUT_SECS: u64 = 25;
 
+/// Default maximum age of a close-group cache snapshot before it is skipped
+/// as Priority-0 bootstrap material.
+const DEFAULT_CLOSE_GROUP_CACHE_MAX_AGE_SECS: u64 = 60 * 60;
+
+/// Lower bound for periodic close-group-cache saves. Prevents a very short DHT
+/// refresh interval from turning cache persistence into a hot write loop.
+const MIN_CLOSE_GROUP_CACHE_SAVE_INTERVAL: Duration = Duration::from_secs(60);
+
 /// Timeout in seconds for waiting on a bootstrap peer's identity exchange.
 ///
 /// Tighter than the post-bootstrap budget (`IDENTITY_EXCHANGE_TIMEOUT`,
@@ -267,13 +275,24 @@ pub struct NodeConfig {
     /// Directory for persisting the close group cache.
     ///
     /// When set, the node saves its close group peers and their trust
-    /// scores to `{dir}/close_group_cache.json` on shutdown and after
-    /// bootstrap. On startup, cached peers are loaded and contacted
-    /// first, preserving close group consistency across restarts.
+    /// scores to `{dir}/close_group_cache.json` periodically, on shutdown,
+    /// and after bootstrap. On startup, fresh cached peers are loaded and
+    /// contacted first, preserving close group consistency across restarts.
     ///
     /// When `None`, no close group cache is used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub close_group_cache_dir: Option<PathBuf>,
+
+    /// Maximum age for using a close-group cache snapshot as Priority-0
+    /// bootstrap material. Older snapshots are logged and skipped so the node
+    /// falls through to configured bootstrap peers. `None` disables the age
+    /// check. Default: one hour.
+    #[serde(default = "default_close_group_cache_max_age")]
+    pub close_group_cache_max_age: Option<Duration>,
+}
+
+fn default_close_group_cache_max_age() -> Option<Duration> {
+    Some(Duration::from_secs(DEFAULT_CLOSE_GROUP_CACHE_MAX_AGE_SECS))
 }
 
 /// DHT-specific configuration
@@ -404,6 +423,9 @@ pub struct NodeConfigBuilder {
     allow_loopback: Option<bool>,
     adaptive_dht_config: Option<AdaptiveDhtConfig>,
     close_group_cache_dir: Option<PathBuf>,
+    /// Outer `None` means the builder setter was not called; inner `None`
+    /// explicitly disables age enforcement.
+    close_group_cache_max_age: Option<Option<Duration>>,
 }
 
 impl Default for NodeConfigBuilder {
@@ -422,6 +444,7 @@ impl Default for NodeConfigBuilder {
             allow_loopback: None,
             adaptive_dht_config: None,
             close_group_cache_dir: None,
+            close_group_cache_max_age: None,
         }
     }
 }
@@ -543,6 +566,13 @@ impl NodeConfigBuilder {
         self
     }
 
+    /// Set the maximum age for using a close-group cache as Priority-0
+    /// bootstrap material. `None` disables the age check.
+    pub fn close_group_cache_max_age(mut self, max_age: Option<Duration>) -> Self {
+        self.close_group_cache_max_age = Some(max_age);
+        self
+    }
+
     /// Build the [`NodeConfig`].
     ///
     /// # Errors
@@ -570,6 +600,9 @@ impl NodeConfigBuilder {
             allow_loopback,
             adaptive_dht_config: self.adaptive_dht_config.unwrap_or_default(),
             close_group_cache_dir: self.close_group_cache_dir,
+            close_group_cache_max_age: self
+                .close_group_cache_max_age
+                .unwrap_or_else(default_close_group_cache_max_age),
         })
     }
 }
@@ -592,6 +625,7 @@ impl Default for NodeConfig {
             allow_loopback: false,
             adaptive_dht_config: AdaptiveDhtConfig::default(),
             close_group_cache_dir: None,
+            close_group_cache_max_age: default_close_group_cache_max_age(),
         }
     }
 }
@@ -786,6 +820,14 @@ pub struct P2PNode {
     /// Shutdown token — cancelled when the node should stop
     shutdown: CancellationToken,
 
+    /// Dedicated cancellation token for periodic close-group-cache saves.
+    /// Cancelled and joined before the authoritative shutdown snapshot.
+    close_group_cache_save_shutdown: CancellationToken,
+
+    /// Periodic close-group-cache task, retained so shutdown can prevent a
+    /// late periodic write from replacing the final snapshot.
+    close_group_cache_save_handle: TokioMutex<Option<tokio::task::JoinHandle<()>>>,
+
     /// Adaptive DHT layer — owns both the DHT manager and the trust engine.
     /// All DHT operations and trust signals go through this component.
     adaptive_dht: AdaptiveDHT,
@@ -903,6 +945,8 @@ impl P2PNode {
             transport,
             start_time: Instant::now(),
             shutdown: CancellationToken::new(),
+            close_group_cache_save_shutdown: CancellationToken::new(),
+            close_group_cache_save_handle: TokioMutex::new(None),
             adaptive_dht,
             is_bootstrapped: Arc::new(AtomicBool::new(false)),
             is_started: Arc::new(AtomicBool::new(false)),
@@ -1212,39 +1256,56 @@ impl P2PNode {
         let close_group_cache = if let Some(ref dir) = self.config.close_group_cache_dir {
             match CloseGroupCache::load_from_dir(dir).await {
                 Ok(Some(cache)) => {
-                    // Filter out peers with non-finite trust scores (NaN/Inf)
-                    // that could corrupt trust engine state or sort ordering.
-                    let original_count = cache.peers.len();
-                    let cache = CloseGroupCache {
-                        peers: cache
-                            .peers
-                            .into_iter()
-                            .filter(|p| p.trust.score.is_finite())
-                            .collect(),
-                        ..cache
-                    };
-                    let filtered_count = original_count - cache.peers.len();
-                    if filtered_count > 0 {
+                    let now_epoch = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .map_or(0, |duration| duration.as_secs());
+                    if cache.is_stale(now_epoch, self.config.close_group_cache_max_age) {
                         warn!(
-                            "Filtered {filtered_count} peers with non-finite trust scores from close group cache"
+                            cache_age_secs = now_epoch.saturating_sub(cache.saved_at_epoch_secs),
+                            max_age_secs = self
+                                .config
+                                .close_group_cache_max_age
+                                .map(|age| age.as_secs()),
+                            "Close group cache is stale; skipping cached trust and Priority-0 peers"
                         );
-                    }
+                        None
+                    } else {
+                        // Filter out peers with non-finite trust scores (NaN/Inf)
+                        // that could corrupt trust engine state or sort ordering.
+                        let original_count = cache.peers.len();
+                        let cache = CloseGroupCache {
+                            peers: cache
+                                .peers
+                                .into_iter()
+                                .filter(|p| p.trust.score.is_finite())
+                                .collect(),
+                            ..cache
+                        };
+                        let filtered_count = original_count - cache.peers.len();
+                        if filtered_count > 0 {
+                            warn!(
+                                "Filtered {filtered_count} peers with non-finite trust scores from close group cache"
+                            );
+                        }
 
-                    let trust_snapshot = TrustSnapshot {
-                        peers: cache
-                            .peers
-                            .iter()
-                            .map(|p| (p.peer_id, p.trust.clone()))
-                            .collect(),
-                    };
-                    self.adaptive_dht
-                        .trust_engine()
-                        .import_snapshot(&trust_snapshot);
-                    info!(
-                        "Loaded {} peers from close group cache (trust scores imported)",
-                        cache.peers.len()
-                    );
-                    Some(cache)
+                        let trust_snapshot = TrustSnapshot {
+                            peers: cache
+                                .peers
+                                .iter()
+                                .map(|p| (p.peer_id, p.trust.clone()))
+                                .collect(),
+                        };
+                        self.adaptive_dht
+                            .trust_engine()
+                            .import_snapshot(&trust_snapshot);
+                        info!(
+                            cache_age_secs = now_epoch.saturating_sub(cache.saved_at_epoch_secs),
+                            saved_at_epoch_secs = cache.saved_at_epoch_secs,
+                            "Loaded {} peers from close group cache (trust scores imported)",
+                            cache.peers.len()
+                        );
+                        Some(cache)
+                    }
                 }
                 Ok(None) => {
                     debug!(
@@ -1404,6 +1465,35 @@ impl P2PNode {
             });
         }
 
+        if let Some(dir) = self.config.close_group_cache_dir.clone() {
+            let interval = self
+                .config
+                .dht_config
+                .refresh_interval
+                .max(MIN_CLOSE_GROUP_CACHE_SAVE_INTERVAL);
+            let mut task = self.close_group_cache_save_handle.lock().await;
+            if task.is_none() {
+                let dht_manager = Arc::clone(self.adaptive_dht.dht_manager());
+                let trust_engine = Arc::clone(self.adaptive_dht.trust_engine());
+                let peer_id = self.peer_id;
+                let k_value = self.config.dht_config.k_value;
+                let shutdown = self.close_group_cache_save_shutdown.clone();
+                *task = Some(tokio::spawn(periodic_close_group_cache_save(
+                    dht_manager,
+                    trust_engine,
+                    peer_id,
+                    k_value,
+                    dir,
+                    interval,
+                    shutdown,
+                )));
+                info!(
+                    interval_secs = interval.as_secs(),
+                    "Started periodic close group cache persistence"
+                );
+            }
+        }
+
         self.is_started
             .store(true, std::sync::atomic::Ordering::Release);
 
@@ -1432,6 +1522,16 @@ impl P2PNode {
     /// Stop the P2P node
     pub async fn stop(&self) -> Result<()> {
         info!("Stopping P2P node...");
+
+        // Stop periodic cache persistence and wait for any in-flight write.
+        // The final save below is then the authoritative shutdown snapshot.
+        self.close_group_cache_save_shutdown.cancel();
+        let cache_task = self.close_group_cache_save_handle.lock().await.take();
+        if let Some(cache_task) = cache_task
+            && let Err(error) = cache_task.await
+        {
+            warn!("Periodic close group cache task failed during shutdown: {error}");
+        }
 
         // Save close group cache before tearing down the DHT and transport layers.
         if let Some(ref dir) = self.config.close_group_cache_dir
@@ -2114,7 +2214,10 @@ impl P2PNode {
         // Phase A: serial close-group dials to preserve trust-priority ordering.
         let client_mode = matches!(self.config.mode, NodeMode::Client);
         for addrs in &serial_addr_sets {
-            if let Some(peer_id) = self.dial_bootstrap_addr_set(addrs, identity_timeout).await {
+            if let Some(peer_id) = self
+                .dial_bootstrap_addr_set(addrs, identity_timeout, "cache")
+                .await
+            {
                 successful_connections += 1;
                 connected_peer_ids.push(peer_id);
                 if client_mode && successful_connections >= CLIENT_BOOTSTRAP_TARGET {
@@ -2133,7 +2236,8 @@ impl P2PNode {
         if !client_mode || successful_connections < CLIENT_BOOTSTRAP_TARGET {
             let mut parallel_stream =
                 futures::stream::iter(parallel_addr_sets.into_iter().map(|addrs| async move {
-                    self.dial_bootstrap_addr_set(&addrs, identity_timeout).await
+                    self.dial_bootstrap_addr_set(&addrs, identity_timeout, "configured")
+                        .await
                 }))
                 .buffer_unordered(MAX_CONCURRENT_BOOTSTRAP_DIALS);
             while let Some(result) = parallel_stream.next().await {
@@ -2239,6 +2343,7 @@ impl P2PNode {
         &self,
         addrs: &[MultiAddr],
         identity_timeout: Duration,
+        source: &'static str,
     ) -> Option<PeerId> {
         for addr in addrs {
             // Bootstrap addresses come from operator-supplied seeds (CLI
@@ -2255,8 +2360,24 @@ impl P2PNode {
                     .wait_for_peer_identity(&channel_id, identity_timeout)
                     .await
                 {
-                    Ok(real_peer_id) => return Some(real_peer_id),
+                    Ok(real_peer_id) => {
+                        debug!(
+                            bootstrap_source = source,
+                            outcome = "ok",
+                            address = %addr,
+                            peer_id = %real_peer_id,
+                            "Bootstrap dial completed"
+                        );
+                        return Some(real_peer_id);
+                    }
                     Err(e) => {
+                        debug!(
+                            bootstrap_source = source,
+                            outcome = "identity_timeout",
+                            address = %addr,
+                            error = %e,
+                            "Bootstrap dial failed"
+                        );
                         warn!(
                             "Timeout waiting for identity from bootstrap peer {}: {}, \
                              closing channel {}",
@@ -2266,6 +2387,13 @@ impl P2PNode {
                     }
                 },
                 Err(e) => {
+                    debug!(
+                        bootstrap_source = source,
+                        outcome = "connect_error",
+                        address = %addr,
+                        error = %e,
+                        "Bootstrap dial failed"
+                    );
                     warn!("Failed to connect to bootstrap peer {}: {}", addr, e);
                 }
             }
@@ -2275,60 +2403,107 @@ impl P2PNode {
 
     /// Persist the current close group peers and their trust scores to disk.
     async fn save_close_group_cache(&self, dir: &Path) -> anyhow::Result<()> {
-        let key: crate::dht::Key = *self.peer_id.as_bytes();
-        let k_value = self.config.dht_config.k_value;
-        let close_group = self
-            .dht_manager()
-            .find_closest_nodes_local(&key, k_value)
-            .await;
-
-        if close_group.is_empty() {
-            debug!("No close group peers to save");
-            return Ok(());
-        }
-
-        let trust_engine = self.adaptive_dht.trust_engine();
-        let now_epoch = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-
-        let peers: Vec<CachedCloseGroupPeer> = close_group
-            .into_iter()
-            .filter_map(|dht_node| {
-                let score = trust_engine.score(&dht_node.peer_id);
-                // Guard against NaN/Infinity — serde_json cannot round-trip
-                // non-finite f64 values, which would corrupt the cache file.
-                if !score.is_finite() {
-                    return None;
-                }
-                Some(CachedCloseGroupPeer {
-                    peer_id: dht_node.peer_id,
-                    addresses: dht_node.addresses,
-                    trust: TrustRecord {
-                        score,
-                        last_updated_epoch_secs: now_epoch,
-                    },
-                })
-            })
-            .collect();
-
-        let peer_count = peers.len();
-        let cache = CloseGroupCache {
-            peers,
-            saved_at_epoch_secs: now_epoch,
-        };
-
-        cache.save_to_dir(dir).await?;
-        info!(
-            "Saved {} close group peers to cache in {}",
-            peer_count,
-            dir.display()
-        );
-        Ok(())
+        save_close_group_cache_snapshot(
+            self.dht_manager(),
+            self.adaptive_dht.trust_engine(),
+            self.peer_id,
+            self.config.dht_config.k_value,
+            dir,
+        )
+        .await
     }
 
     // disconnect_all_peers and periodic_tasks are now in TransportHandle
+}
+
+/// Persist a close-group snapshot using owned subsystem handles.
+///
+/// Keeping this separate from `P2PNode` allows the periodic task to own every
+/// dependency it needs without borrowing the node across a spawned task.
+async fn save_close_group_cache_snapshot(
+    dht_manager: &DhtNetworkManager,
+    trust_engine: &TrustEngine,
+    peer_id: PeerId,
+    k_value: usize,
+    dir: &Path,
+) -> anyhow::Result<()> {
+    let key: crate::dht::Key = *peer_id.as_bytes();
+    let close_group = dht_manager.find_closest_nodes_local(&key, k_value).await;
+
+    if close_group.is_empty() {
+        debug!("No close group peers to save");
+        return Ok(());
+    }
+
+    let now_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs());
+    let peers: Vec<CachedCloseGroupPeer> = close_group
+        .into_iter()
+        .filter_map(|dht_node| {
+            let score = trust_engine.score(&dht_node.peer_id);
+            // Guard against NaN/Infinity — serde_json cannot round-trip
+            // non-finite f64 values, which would corrupt the cache file.
+            if !score.is_finite() {
+                return None;
+            }
+            Some(CachedCloseGroupPeer {
+                peer_id: dht_node.peer_id,
+                addresses: dht_node.addresses,
+                trust: TrustRecord {
+                    score,
+                    last_updated_epoch_secs: now_epoch,
+                },
+            })
+        })
+        .collect();
+
+    let peer_count = peers.len();
+    let cache = CloseGroupCache {
+        peers,
+        saved_at_epoch_secs: now_epoch,
+    };
+
+    cache.save_to_dir(dir).await?;
+    info!(
+        "Saved {} close group peers to cache in {}",
+        peer_count,
+        dir.display()
+    );
+    Ok(())
+}
+
+/// Periodically persist the close group until cancelled.
+async fn periodic_close_group_cache_save(
+    dht_manager: Arc<DhtNetworkManager>,
+    trust_engine: Arc<TrustEngine>,
+    peer_id: PeerId,
+    k_value: usize,
+    dir: PathBuf,
+    interval: Duration,
+    shutdown: CancellationToken,
+) {
+    let start = tokio::time::Instant::now() + interval;
+    let mut ticker = tokio::time::interval_at(start, interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            biased;
+            () = shutdown.cancelled() => break,
+            _ = ticker.tick() => {
+                if let Err(error) = save_close_group_cache_snapshot(
+                    &dht_manager,
+                    &trust_engine,
+                    peer_id,
+                    k_value,
+                    &dir,
+                ).await {
+                    warn!("Periodic close group cache save failed: {error}");
+                }
+            }
+        }
+    }
 }
 
 /// Network sender trait for sending messages
@@ -2400,6 +2575,7 @@ mod tests {
             allow_loopback: true,
             adaptive_dht_config: AdaptiveDhtConfig::default(),
             close_group_cache_dir: None,
+            close_group_cache_max_age: default_close_group_cache_max_age(),
         }
     }
 
@@ -2413,6 +2589,52 @@ mod tests {
         assert_eq!(config.listen_addrs().len(), 2); // IPv4 + IPv6
         assert_eq!(config.max_connections, 10000);
         assert_eq!(config.connection_timeout, Duration::from_secs(25));
+        assert_eq!(
+            config.close_group_cache_max_age,
+            Some(Duration::from_secs(DEFAULT_CLOSE_GROUP_CACHE_MAX_AGE_SECS))
+        );
+    }
+
+    #[test]
+    fn close_group_cache_builder_default_and_explicit_disable() {
+        let defaulted = NodeConfig::builder().build().unwrap();
+        assert_eq!(
+            defaulted.close_group_cache_max_age,
+            Some(Duration::from_secs(DEFAULT_CLOSE_GROUP_CACHE_MAX_AGE_SECS))
+        );
+
+        let disabled = NodeConfig::builder()
+            .close_group_cache_max_age(None)
+            .build()
+            .unwrap();
+        assert_eq!(disabled.close_group_cache_max_age, None);
+        let disabled_json = serde_json::to_string(&disabled).unwrap();
+        let disabled_roundtrip: NodeConfig = serde_json::from_str(&disabled_json).unwrap();
+        assert_eq!(disabled_roundtrip.close_group_cache_max_age, None);
+
+        let custom = NodeConfig::builder()
+            .close_group_cache_max_age(Some(Duration::from_secs(120)))
+            .build()
+            .unwrap();
+        assert_eq!(
+            custom.close_group_cache_max_age,
+            Some(Duration::from_secs(120))
+        );
+    }
+
+    #[test]
+    fn old_serialized_config_gets_default_cache_max_age() {
+        let mut value = serde_json::to_value(NodeConfig::default()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("close_group_cache_max_age");
+
+        let decoded: NodeConfig = serde_json::from_value(value).unwrap();
+        assert_eq!(
+            decoded.close_group_cache_max_age,
+            Some(Duration::from_secs(DEFAULT_CLOSE_GROUP_CACHE_MAX_AGE_SECS))
+        );
     }
 
     #[tokio::test]
@@ -2481,6 +2703,22 @@ mod tests {
         // Stop the node
         node.stop().await?;
         assert!(!node.is_running());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn close_group_cache_task_is_joined_on_stop() -> Result<()> {
+        let cache_dir = tempfile::tempdir().unwrap();
+        let mut config = create_test_node_config();
+        config.close_group_cache_dir = Some(cache_dir.path().to_path_buf());
+        let node = P2PNode::new(config).await?;
+
+        node.start().await?;
+        assert!(node.close_group_cache_save_handle.lock().await.is_some());
+
+        node.stop().await?;
+        assert!(node.close_group_cache_save_handle.lock().await.is_none());
 
         Ok(())
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -45,6 +45,10 @@ use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace, warn};
 
+fn bootstrap_peer_identity_matches(expected: Option<PeerId>, actual: PeerId) -> bool {
+    expected.is_none_or(|expected| expected == actual)
+}
+
 /// Wire protocol message format for P2P communication.
 ///
 /// Serialized with postcard for compact binary encoding.
@@ -2122,7 +2126,7 @@ impl P2PNode {
         // peers are dialed serially to preserve trust-priority ordering;
         // configured bootstrap peers are dialed concurrently to cut cold-start
         // latency when some peers are slow or dead.
-        let mut serial_addr_sets: Vec<Vec<MultiAddr>> = Vec::new();
+        let mut serial_addr_sets: Vec<(PeerId, Vec<MultiAddr>)> = Vec::new();
         let mut parallel_addr_sets: Vec<Vec<MultiAddr>> = Vec::new();
         let mut seen_addresses = std::collections::HashSet::new();
 
@@ -2172,7 +2176,7 @@ impl P2PNode {
                             seen_addresses.insert(sa);
                         }
                     }
-                    serial_addr_sets.push(new_addresses);
+                    serial_addr_sets.push((peer.peer_id, new_addresses));
                     added_from_close_group += 1;
                 }
             }
@@ -2217,9 +2221,9 @@ impl P2PNode {
 
         // Phase A: serial close-group dials to preserve trust-priority ordering.
         let client_mode = matches!(self.config.mode, NodeMode::Client);
-        for addrs in &serial_addr_sets {
+        for (expected_peer_id, addrs) in &serial_addr_sets {
             if let Some(peer_id) = self
-                .dial_bootstrap_addr_set(addrs, identity_timeout, "cache")
+                .dial_bootstrap_addr_set(addrs, identity_timeout, "cache", Some(*expected_peer_id))
                 .await
             {
                 successful_connections += 1;
@@ -2241,7 +2245,7 @@ impl P2PNode {
         if !client_mode || successful_connections < CLIENT_BOOTSTRAP_TARGET {
             let mut parallel_stream =
                 futures::stream::iter(parallel_addr_sets.into_iter().map(|addrs| async move {
-                    self.dial_bootstrap_addr_set(&addrs, identity_timeout, "configured")
+                    self.dial_bootstrap_addr_set(&addrs, identity_timeout, "configured", None)
                         .await
                 }))
                 .buffer_unordered(MAX_CONCURRENT_BOOTSTRAP_DIALS);
@@ -2360,6 +2364,7 @@ impl P2PNode {
         addrs: &[MultiAddr],
         identity_timeout: Duration,
         source: &'static str,
+        expected_peer_id: Option<PeerId>,
     ) -> Option<PeerId> {
         for addr in addrs {
             // Bootstrap addresses come from operator-supplied seeds (CLI
@@ -2377,6 +2382,17 @@ impl P2PNode {
                     .await
                 {
                     Ok(real_peer_id) => {
+                        if !bootstrap_peer_identity_matches(expected_peer_id, real_peer_id) {
+                            warn!(
+                                bootstrap_source = source,
+                                address = %addr,
+                                expected_peer_id = ?expected_peer_id,
+                                actual_peer_id = %real_peer_id,
+                                "Bootstrap cache identity mismatch; rejecting connection"
+                            );
+                            self.disconnect_channel(&channel_id).await;
+                            continue;
+                        }
                         info!(
                             bootstrap_source = source,
                             outcome = "ok",
@@ -2451,11 +2467,6 @@ async fn save_close_group_cache_snapshot(
 ) -> anyhow::Result<()> {
     let key: crate::dht::Key = *peer_id.as_bytes();
     let close_group = dht_manager.find_closest_nodes_local(&key, k_value).await;
-
-    if close_group.is_empty() {
-        debug!("No close group peers to save");
-        return Ok(());
-    }
 
     let now_epoch = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -2576,6 +2587,16 @@ mod tests {
 
     /// 2 MiB — used in builder tests to verify max_message_size configuration.
     const TEST_MAX_MESSAGE_SIZE: usize = 2 * 1024 * 1024;
+
+    #[test]
+    fn cached_bootstrap_identity_must_match_handshake_peer() {
+        let expected = PeerId::from_bytes([1; 32]);
+        let other = PeerId::from_bytes([2; 32]);
+
+        assert!(bootstrap_peer_identity_matches(Some(expected), expected));
+        assert!(!bootstrap_peer_identity_matches(Some(expected), other));
+        assert!(bootstrap_peer_identity_matches(None, other));
+    }
 
     // Test tool handler for network tests
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -1535,7 +1535,7 @@ impl P2PNode {
 
         // Save close group cache before tearing down the DHT and transport layers.
         if let Some(ref dir) = self.config.close_group_cache_dir
-            && let Err(e) = self.save_close_group_cache(dir).await
+            && let Err(e) = self.save_close_group_cache(dir, "shutdown").await
         {
             warn!("Failed to save close group cache on shutdown: {e}");
         }
@@ -2209,6 +2209,10 @@ impl P2PNode {
         // perform DHT peer discovery using the real cryptographic PeerIds.
         let identity_timeout = Duration::from_secs(BOOTSTRAP_IDENTITY_TIMEOUT_SECS);
         let mut successful_connections = 0;
+        let cache_dial_candidates = serial_addr_sets.len();
+        let configured_dial_candidates = parallel_addr_sets.len();
+        let mut cache_dial_successes = 0usize;
+        let mut configured_dial_successes = 0usize;
         let mut connected_peer_ids: Vec<PeerId> = Vec::new();
 
         // Phase A: serial close-group dials to preserve trust-priority ordering.
@@ -2219,6 +2223,7 @@ impl P2PNode {
                 .await
             {
                 successful_connections += 1;
+                cache_dial_successes += 1;
                 connected_peer_ids.push(peer_id);
                 if client_mode && successful_connections >= CLIENT_BOOTSTRAP_TARGET {
                     debug!(
@@ -2243,6 +2248,7 @@ impl P2PNode {
             while let Some(result) = parallel_stream.next().await {
                 if let Some(peer_id) = result {
                     successful_connections += 1;
+                    configured_dial_successes += 1;
                     connected_peer_ids.push(peer_id);
                     if client_mode && successful_connections >= CLIENT_BOOTSTRAP_TARGET {
                         debug!(
@@ -2256,6 +2262,16 @@ impl P2PNode {
             // cancelling any in-flight futures inside `buffer_unordered`
             // before we proceed to the DHT discovery phase below.
         }
+
+        info!(
+            cache_dial_candidates,
+            cache_dial_successes,
+            configured_dial_candidates,
+            configured_dial_successes,
+            outbound_bootstrap_successes = successful_connections,
+            outbound_reachable = successful_connections > 0,
+            "Bootstrap reachability summary"
+        );
 
         if successful_connections == 0 {
             // Outbound connections failed — but for nodes behind symmetric NAT,
@@ -2327,7 +2343,7 @@ impl P2PNode {
         // Save close group cache after initial bootstrap so a crash before
         // graceful shutdown still preserves the newly-discovered close group.
         if let Some(ref dir) = self.config.close_group_cache_dir
-            && let Err(e) = self.save_close_group_cache(dir).await
+            && let Err(e) = self.save_close_group_cache(dir, "post_bootstrap").await
         {
             warn!("Failed to save close group cache after bootstrap: {e}");
         }
@@ -2361,7 +2377,7 @@ impl P2PNode {
                     .await
                 {
                     Ok(real_peer_id) => {
-                        debug!(
+                        info!(
                             bootstrap_source = source,
                             outcome = "ok",
                             address = %addr,
@@ -2371,7 +2387,7 @@ impl P2PNode {
                         return Some(real_peer_id);
                     }
                     Err(e) => {
-                        debug!(
+                        info!(
                             bootstrap_source = source,
                             outcome = "identity_timeout",
                             address = %addr,
@@ -2387,7 +2403,7 @@ impl P2PNode {
                     }
                 },
                 Err(e) => {
-                    debug!(
+                    info!(
                         bootstrap_source = source,
                         outcome = "connect_error",
                         address = %addr,
@@ -2402,13 +2418,18 @@ impl P2PNode {
     }
 
     /// Persist the current close group peers and their trust scores to disk.
-    async fn save_close_group_cache(&self, dir: &Path) -> anyhow::Result<()> {
+    async fn save_close_group_cache(
+        &self,
+        dir: &Path,
+        save_reason: &'static str,
+    ) -> anyhow::Result<()> {
         save_close_group_cache_snapshot(
             self.dht_manager(),
             self.adaptive_dht.trust_engine(),
             self.peer_id,
             self.config.dht_config.k_value,
             dir,
+            save_reason,
         )
         .await
     }
@@ -2426,6 +2447,7 @@ async fn save_close_group_cache_snapshot(
     peer_id: PeerId,
     k_value: usize,
     dir: &Path,
+    save_reason: &'static str,
 ) -> anyhow::Result<()> {
     let key: crate::dht::Key = *peer_id.as_bytes();
     let close_group = dht_manager.find_closest_nodes_local(&key, k_value).await;
@@ -2466,6 +2488,7 @@ async fn save_close_group_cache_snapshot(
 
     cache.save_to_dir(dir).await?;
     info!(
+        save_reason,
         "Saved {} close group peers to cache in {}",
         peer_count,
         dir.display()
@@ -2498,6 +2521,7 @@ async fn periodic_close_group_cache_save(
                     peer_id,
                     k_value,
                     &dir,
+                    "periodic",
                 ).await {
                     warn!("Periodic close group cache save failed: {error}");
                 }


### PR DESCRIPTION
## Linear issue

[V2-884 — Age-bound and refresh the saorsa-core close-group bootstrap cache](https://linear.app/autonominetwork/issue/V2-884/age-bound-and-refresh-the-saorsa-core-close-group-bootstrap-cache)

## Risk tier

- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [x] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

## Compatibility

- Wire: none; no protocol messages or peer validation rules change.
- Storage: existing `close_group_cache.json` format is unchanged. Old cache files remain readable. Old serialized `NodeConfig` values that omit the new field receive the one-hour default; explicit `null` preserves disabled TTL.
- API: adds `NodeConfig::close_group_cache_max_age` and a builder setter. This is source-breaking for downstream code that constructs the public `NodeConfig` with a struct literal; builder and deserialization callers remain compatible.

## Semver impact

- [x] breaking
- [ ] feature
- [ ] fix

## Test evidence

- `cargo check --all-targets --all-features` — passed.
- `cargo test --lib` — 475 passed; unrelated floating-point tolerance test `adaptive::trust::tests::test_unit_weight_equivalence` failed once at a 1.78e-10 difference, then passed 5/5 isolated reruns.
- Earlier exact-head run before the diagnostics-only follow-up: 476 passed, 0 failed.
- Focused cache/config/task lifecycle tests — passed.
- `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.

The proposed T2 classification still requires dev-testnet evidence before release. Detailed matrix: [V2-894](https://linear.app/autonominetwork/issue/V2-894/testnet-run-bootstrap-cache-hygiene-and-drain-diagnostics-149198197).

## New dependency

none

## ADR

[ADR-016 — Age-Bounded, Periodically Refreshed Close-Group Cache](https://github.com/WithAutonomi/saorsa-core/blob/fix/close-group-cache-hygiene/docs/adr/ADR-016-close-group-cache-validity.md) — Proposed; human acceptance pending.

## Mitigation / rollback

Disable age enforcement with `close_group_cache_max_age: null`, disable cache persistence by omitting `close_group_cache_dir`, or revert this PR; configured bootstrap peers remain the fallback path.
