### PR TITLE
chore(release): promote rc-2026.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.27.0-rc.1"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2584,8 +2584,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.36.0-rc.1"
-source = "git+https://github.com/WithAutonomi/saorsa-transport?branch=rc-2026.8.2#f7bb6e9e94c264123b9a9d35855b890a8b3e4f07"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8dbc21ea8af08c30a0d7d66289b987f14eb22e9ff1ed32e12c4e0a07c6d49d8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.26.4"
+version = "0.27.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2584,8 +2584,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.35.2"
-source = "git+https://github.com/WithAutonomi/saorsa-transport.git?branch=fix%2Fpr136-provisional-relay#4b1ed67973763e4636694a9d9c0601ff41b9e933"
+version = "0.36.0-rc.1"
+source = "git+https://github.com/WithAutonomi/saorsa-transport?branch=rc-2026.8.2#f7bb6e9e94c264123b9a9d35855b890a8b3e4f07"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "saorsa-core"
 # 0.22.0: MASQUE relay data plane, upgrade saorsa-transport to 0.31.0
 # 0.24.0: upgrade saorsa-transport to 0.33.0
 # 0.24.1: release candidate fixes
-version = "0.26.4"
+version = "0.27.0-rc.1"
 edition = "2024"
 authors = ["Saorsa Labs Limited <david@saorsalabs.com>"]
 license = "MIT OR Apache-2.0"
@@ -64,7 +64,7 @@ once_cell = "1.21"
 dashmap = "6"
 
 # Networking
-saorsa-transport = { git = "https://github.com/WithAutonomi/saorsa-transport.git", branch = "fix/pr136-provisional-relay" }
+saorsa-transport = { git = "https://github.com/WithAutonomi/saorsa-transport", branch = "rc-2026.8.2" }
 
 # Core-specific dependencies
 dirs = "6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "saorsa-core"
 # 0.22.0: MASQUE relay data plane, upgrade saorsa-transport to 0.31.0
 # 0.24.0: upgrade saorsa-transport to 0.33.0
 # 0.24.1: release candidate fixes
-version = "0.27.0-rc.1"
+version = "0.27.0"
 edition = "2024"
 authors = ["Saorsa Labs Limited <david@saorsalabs.com>"]
 license = "MIT OR Apache-2.0"
@@ -64,7 +64,7 @@ once_cell = "1.21"
 dashmap = "6"
 
 # Networking
-saorsa-transport = { git = "https://github.com/WithAutonomi/saorsa-transport", branch = "rc-2026.8.2" }
+saorsa-transport = "0.36.0"
 
 # Core-specific dependencies
 dirs = "6.0"


### PR DESCRIPTION
Promotes `rc-2026.8.2` to release version(s): 0.27.0.

- strips `-rc.*` from `[package].version`
- rewrites internal git+branch deps to crates.io version pins
- regenerates `Cargo.lock`

Once merged, the release tag will be pushed to fire the publish workflow.